### PR TITLE
Pkg dependencies

### DIFF
--- a/.github/workflows/build-galactic.yaml
+++ b/.github/workflows/build-galactic.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: build and test
         uses: ros-tooling/action-ros-ci@v0.2
         with:
-          package-name: as2_core as2_msgs as2_controller as2_tello_platform as2_motion_reference_handlers as2_behaviors as2_state_estimator
+          package-name: aerostack2
           target-ros2-distro: galactic 
           skip-tests: true 
           # colcon-defaults: |

--- a/.github/workflows/build-humble.yaml
+++ b/.github/workflows/build-humble.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: build and test
         uses: ros-tooling/action-ros-ci@v0.2
         with:
-          package-name: as2_core as2_msgs as2_controller as2_tello_platform as2_motion_reference_handlers as2_behaviors as2_state_estimator
+          package-name: aerostack2
           target-ros2-distro: humble
           skip-tests: true 
           # colcon-defaults: |

--- a/aerostack2/package.xml
+++ b/aerostack2/package.xml
@@ -14,13 +14,17 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>as2_msgs</exec_depend>
-  <exec_depend>as2_core</exec_depend>
+  <exec_depend>as2_aerial_platform</exec_depend>
+  <exec_depend>behaviour_trees</exec_depend>
+  <exec_depend>as2_behaviors</exec_depend>
   <exec_depend>as2_cli</exec_depend>
   <exec_depend>as2_controller</exec_depend>
+  <exec_depend>as2_core</exec_depend>
+  <exec_depend>as2_hardware_drivers</exec_depend>
   <exec_depend>as2_motion_reference_handlers</exec_depend>
-  <exec_depend>as2_behaviors</exec_depend>
-  <exec_depend>as2_python_api</exec_depend>
+  <exec_depend>as2_msgs</exec_depend>
+  <!-- TODO: convert python interface into as2_python_api -->
+  <exec_depend>python_interface</exec_depend> 
   <exec_depend>as2_simulation_assets</exec_depend>
   <exec_depend>as2_state_estimator</exec_depend>
   <exec_depend>as2_user_interface</exec_depend>

--- a/as2_aerial_platforms/as2_aerial_platform/CMakeLists.txt
+++ b/as2_aerial_platforms/as2_aerial_platform/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(as2_aerial_platform)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/as2_aerial_platforms/as2_aerial_platform/package.xml
+++ b/as2_aerial_platforms/as2_aerial_platform/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>as2_aerial_platform</name>
+  <version>0.2.1</version>
+  <description>
+    AS2 Aerial Platform Meta Package
+  </description>
+  <maintainer email="miguel.fernandez.cortizas@upm.es">Miguel Fernandez-Cortizas</maintainer>
+  <maintainer email="r.psegui@upm.es">Rafael Perez-Segui</maintainer>
+  <maintainer email="pedro.ariasp@upm.es">Pedro Arias-Perez</maintainer>
+  <maintainer email="david.perez.saura@upm.es">David Perez-Saura</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>as2_crazyflie_platform</exec_depend>
+  <!-- TODO: -->
+  <!-- <exec_depend>as2_ignition_platform</exec_depend> -->
+  <!-- <exec_depend>as2_pixhawk_platform</exec_depend> -->
+  <exec_depend>as2_tello_platform</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>

--- a/as2_aerial_platforms/as2_crazyflie_platform/package.xml
+++ b/as2_aerial_platforms/as2_crazyflie_platform/package.xml
@@ -21,6 +21,7 @@
   <depend>as2_msgs</depend>
   <depend>libusb-1.0</depend>
   <depend>libusb-1.0-dev</depend>
+  <depend>eigen</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>

--- a/as2_aerial_platforms/as2_pixhawk_platform/as2_pixhawk_platform/package.xml
+++ b/as2_aerial_platforms/as2_pixhawk_platform/as2_pixhawk_platform/package.xml
@@ -22,6 +22,7 @@
   <depend>px4_msgs</depend>
   <depend>px4_ros_com</depend>
   <depend>pyros-setup-pip</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_aerial_platforms/as2_tello_platform/package.xml
+++ b/as2_aerial_platforms/as2_tello_platform/package.xml
@@ -19,6 +19,7 @@
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>eigen</depend>
   <exec_depend>rclpy</exec_depend>
 
   

--- a/as2_behaviors/movement_behaviors/follow_path/follow_path_plugin_base/package.xml
+++ b/as2_behaviors/movement_behaviors/follow_path/follow_path_plugin_base/package.xml
@@ -16,6 +16,7 @@
   <depend>as2_behavior</depend>
   <depend>as2_motion_reference_handlers</depend>
   <depend>geometry_msgs</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_behaviors/movement_behaviors/follow_path/follow_path_plugins/package.xml
+++ b/as2_behaviors/movement_behaviors/follow_path/follow_path_plugins/package.xml
@@ -17,6 +17,7 @@
   <depend>as2_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>as2_motion_reference_handlers</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_behaviors/movement_behaviors/go_to/goto_behaviour/package.xml
+++ b/as2_behaviors/movement_behaviors/go_to/goto_behaviour/package.xml
@@ -18,6 +18,7 @@
   <depend>goto_plugin_base</depend>
   <depend>as2_motion_reference_handlers</depend>
   <depend>geometry_msgs</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_behaviors/movement_behaviors/go_to/goto_plugin_base/package.xml
+++ b/as2_behaviors/movement_behaviors/go_to/goto_plugin_base/package.xml
@@ -16,6 +16,7 @@
   <depend>as2_behavior</depend>
   <depend>as2_motion_reference_handlers</depend>
   <depend>geometry_msgs</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_behaviors/trajectory_generator/package.xml
+++ b/as2_behaviors/trajectory_generator/package.xml
@@ -18,7 +18,7 @@
   <depend>std_srvs</depend>
   <depend>trajectory_msgs</depend>
   <depend>as2_behavior</depend>
-  <depend>Eigen3</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_cmake_clang_format</test_depend>

--- a/as2_cli/CMakeLists.txt
+++ b/as2_cli/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(as2_cli)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/as2_cli/package.xml
+++ b/as2_cli/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>as2_cli</name>
+  <version>0.2.1</version>
+  <description>
+    AS2 CLI Package
+  </description>
+  <maintainer email="miguel.fernandez.cortizas@upm.es">Miguel Fernandez-Cortizas</maintainer>
+  <maintainer email="r.psegui@upm.es">Rafael Perez-Segui</maintainer>
+  <maintainer email="pedro.ariasp@upm.es">Pedro Arias-Perez</maintainer>
+  <maintainer email="david.perez.saura@upm.es">David Perez-Saura</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>

--- a/as2_controller/as2_controller_plugin_differential_flatness/package.xml
+++ b/as2_controller/as2_controller_plugin_differential_flatness/package.xml
@@ -20,6 +20,7 @@
   <depend>as2_msgs</depend>
   <depend>pluginlib</depend>
   <depend>as2_controller_plugin_base</depend>
+  <depend>eigen</depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_controller/as2_controller_plugin_speed_controller/package.xml
+++ b/as2_controller/as2_controller_plugin_speed_controller/package.xml
@@ -18,6 +18,7 @@
   <depend>pluginlib</depend>
   <depend>as2_controller_plugin_base</depend>
   <depend>pid_controller</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_hardware_drivers/as2_hardware_drivers/CMakeLists.txt
+++ b/as2_hardware_drivers/as2_hardware_drivers/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(as2_hardware_drivers)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/as2_hardware_drivers/as2_hardware_drivers/package.xml
+++ b/as2_hardware_drivers/as2_hardware_drivers/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>as2_hardware_drivers</name>
+  <version>0.2.1</version>
+  <description>
+    AS2 Hardware Drivers Platform Meta Package
+  </description>
+  <maintainer email="miguel.fernandez.cortizas@upm.es">Miguel Fernandez-Cortizas</maintainer>
+  <maintainer email="r.psegui@upm.es">Rafael Perez-Segui</maintainer>
+  <maintainer email="pedro.ariasp@upm.es">Pedro Arias-Perez</maintainer>
+  <maintainer email="david.perez.saura@upm.es">David Perez-Saura</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>as2_realsense_interface</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>

--- a/as2_hardware_drivers/as2_realsense_interface/package.xml
+++ b/as2_hardware_drivers/as2_realsense_interface/package.xml
@@ -16,8 +16,8 @@
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>std_svrs</depend>
-  <depend>realsense2</depend>
+  <depend>std_srvs </depend>
+  <depend>realsense2_camera</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/as2_motion_reference_handlers/package.xml
+++ b/as2_motion_reference_handlers/package.xml
@@ -21,6 +21,7 @@
   <depend>rclcpp_action</depend>
   <depend>geometry_msgs</depend>
   <depend>trajectory_msgs</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_simulation_assets/as2_simulation_assets/CMakeLists.txt
+++ b/as2_simulation_assets/as2_simulation_assets/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(as2_simulation_assets)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/as2_simulation_assets/as2_simulation_assets/package.xml
+++ b/as2_simulation_assets/as2_simulation_assets/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>as2_simulation_assets</name>
+  <version>0.2.1</version>
+  <description>
+    AS2 Simulation Assets Meta Package
+  </description>
+  <maintainer email="miguel.fernandez.cortizas@upm.es">Miguel Fernandez-Cortizas</maintainer>
+  <maintainer email="r.psegui@upm.es">Rafael Perez-Segui</maintainer>
+  <maintainer email="pedro.ariasp@upm.es">Pedro Arias-Perez</maintainer>
+  <maintainer email="david.perez.saura@upm.es">David Perez-Saura</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>ignition_assets</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>

--- a/as2_simulation_assets/as2_simulation_assets/package.xml
+++ b/as2_simulation_assets/as2_simulation_assets/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>ignition_assets</exec_depend>
+  <!-- <exec_depend>ignition_assets</exec_depend> -->
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_user_interfaces/alphanumeric_viewer/package.xml
+++ b/as2_user_interfaces/alphanumeric_viewer/package.xml
@@ -17,6 +17,7 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_user_interfaces/alphanumeric_viewer/package.xml
+++ b/as2_user_interfaces/alphanumeric_viewer/package.xml
@@ -18,6 +18,8 @@
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
   <depend>eigen</depend>
+  <depend>libncurses-dev</depend>
+
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_user_interfaces/as2_user_interface/CMakeLists.txt
+++ b/as2_user_interfaces/as2_user_interface/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(as2_user_interface)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/as2_user_interfaces/as2_user_interface/package.xml
+++ b/as2_user_interfaces/as2_user_interface/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>as2_user_interface</name>
+  <version>0.2.1</version>
+  <description>
+    AS2 User Interface Meta Package
+  </description>
+  <maintainer email="miguel.fernandez.cortizas@upm.es">Miguel Fernandez-Cortizas</maintainer>
+  <maintainer email="r.psegui@upm.es">Rafael Perez-Segui</maintainer>
+  <maintainer email="pedro.ariasp@upm.es">Pedro Arias-Perez</maintainer>
+  <maintainer email="david.perez.saura@upm.es">David Perez-Saura</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>keyboard_teleoperation</exec_depend>
+  <exec_depend>alphanumeric_viewer</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>

--- a/libs/pid_controller/package.xml
+++ b/libs/pid_controller/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_cmake</depend>
+  <depend>eigen</depend>
 
   <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points
* Create meta-packages for each aerostack folder 
* Aerostack package have all meta packages dependencies
* Fix as2_realsense package dependencies
* Add eigen dependencies
* Modify workflow to check aerostack package, which depend on all aerostack packages

## Future work that may be required in bullet points
* Aerial platform meta package not check ignition platform  and pixhawk platform, solve dependencies
* Simulation assets meta package not check ignition assets, neither gazebo assets
* Convert gazebo assets into a package
