### PR TITLE
[as2_state_estimator_plugin_mocap] mocap test added to gtest and alpha reduced to 0.1

### DIFF
--- a/as2_state_estimator/as2_state_estimator_plugin_mocap/CMakeLists.txt
+++ b/as2_state_estimator/as2_state_estimator_plugin_mocap/CMakeLists.txt
@@ -45,15 +45,16 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>)
 ament_target_dependencies(${PROJECT_NAME} ${PROJECT_DEPENDENCIES})
 
-add_executable(${PROJECT_NAME}_test tests/plugin_test.cpp ${SOURCE_CPP_FILES})
-ament_target_dependencies(${PROJECT_NAME}_test ${PROJECT_DEPENDENCIES})
-
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_cppcheck REQUIRED)
   find_package(ament_cmake_clang_format REQUIRED)
   ament_cppcheck(src/ include/ tests/)
   ament_clang_format(src/ include/ tests/ --config ${CMAKE_CURRENT_SOURCE_DIR}/.clang-format)
+
+  ament_add_gtest(${PROJECT_NAME}_test tests/plugin_test.cpp ${SOURCE_CPP_FILES})
+  ament_target_dependencies(${PROJECT_NAME}_test ${PROJECT_DEPENDENCIES})
 
 endif()
 

--- a/as2_state_estimator/as2_state_estimator_plugin_mocap/include/state_estimator_plugin_mocap.hpp
+++ b/as2_state_estimator/as2_state_estimator_plugin_mocap/include/state_estimator_plugin_mocap.hpp
@@ -38,7 +38,7 @@ public:
   const geometry_msgs::msg::TwistStamped& twist_from_pose(
       const geometry_msgs::msg::PoseStamped& pose,
       std::vector<tf2::Transform>* data = nullptr) {
-    const double alpha = 0.01;
+    const double alpha = 0.1;
 
     const auto last_time = twist_msg_.header.stamp;
     auto dt              = (rclcpp::Time(pose.header.stamp) - last_time).seconds();

--- a/as2_state_estimator/as2_state_estimator_plugin_mocap/package.xml
+++ b/as2_state_estimator/as2_state_estimator_plugin_mocap/package.xml
@@ -22,6 +22,7 @@
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_state_estimator/as2_state_estimator_plugin_mocap/tests/plugin_test.cpp
+++ b/as2_state_estimator/as2_state_estimator_plugin_mocap/tests/plugin_test.cpp
@@ -1,3 +1,5 @@
+#include "gtest/gtest.h"
+
 #include <as2_core/names/topics.hpp>
 #include <as2_core/node.hpp>
 #include <as2_core/utils/frame_utils.hpp>
@@ -58,8 +60,7 @@ private:
   }
 };
 
-int main(int argc, char **argv) {
-  rclcpp::init(argc, argv);
+TEST(MocapMock, MocapMock) {
   auto node  = std::make_shared<as2::Node>("state_estimator");
   auto mocap = std::make_shared<as2_state_estimator_plugin_mocap::Plugin>();
   auto mock  = std::make_shared<MocapMock>();
@@ -74,7 +75,17 @@ int main(int argc, char **argv) {
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node);
   executor.add_node(mock);
-  executor.spin();
+  for (int i = 0; i < 1000; i++) {
+    executor.spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
   rclcpp::shutdown();
+}
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  return RUN_ALL_TESTS();
+
+  // executor.spin();
   return 0;
 }

--- a/as2_state_estimator/as2_state_estimator_plugin_mocap/tests/plugin_test.cpp
+++ b/as2_state_estimator/as2_state_estimator_plugin_mocap/tests/plugin_test.cpp
@@ -61,7 +61,26 @@ private:
 };
 
 TEST(MocapMock, MocapMock) {
-  auto node  = std::make_shared<as2::Node>("state_estimator");
+  auto node_options = rclcpp::NodeOptions()
+                          .allow_undeclared_parameters(true)
+                          .automatically_declare_parameters_from_overrides(true);
+  auto node = std::make_shared<as2::Node>("state_estimator", node_options);
+
+  auto rec_param = std::make_shared<rclcpp::AsyncParametersClient>(
+      node->get_node_base_interface(), node->get_node_topics_interface(),
+      node->get_node_graph_interface(), node->get_node_services_interface());
+
+  // DeclareLaunchArgument('base_frame', default_value='base_link'),
+  // DeclareLaunchArgument('global_ref_frame', default_value='earth'),
+  // DeclareLaunchArgument('odom_frame', default_value='odom'),
+  // DeclareLaunchArgument('map_frame', default_value='map'),
+  auto results = rec_param->set_parameters_atomically(
+      {rclcpp::Parameter("namespace", "test"), rclcpp::Parameter("base_frame", "base_link"),
+       rclcpp::Parameter("global_ref_frame", "earth"), rclcpp::Parameter("odom_frame", "odom"),
+       rclcpp::Parameter("map_frame", "map")});
+
+  rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
+
   auto mocap = std::make_shared<as2_state_estimator_plugin_mocap::Plugin>();
   auto mock  = std::make_shared<MocapMock>();
 
@@ -75,15 +94,17 @@ TEST(MocapMock, MocapMock) {
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node);
   executor.add_node(mock);
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     executor.spin_some();
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   rclcpp::shutdown();
+  ASSERT_TRUE([]() { return true; });
 }
 
 int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 
   // executor.spin();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | () |
| ROS2 version tested on | Galactic |
| Aerial platform tested on | PX4 |

---

## Description of contribution in a few bullet points
* mocap test converted into Gtest
* alpha value reduced to avoid huge delay in control loops
## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* Added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* There might be some optimizations to be made in ...
* A lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
-->
