### PR TITLE
[as2_python_api] Changed pymap3d to apt pkg

### DIFF
--- a/as2_python_api/package.xml
+++ b/as2_python_api/package.xml
@@ -16,7 +16,7 @@
   <depend>geographic_msgs</depend>
   <depend>action_msgs</depend>
   <depend>as2_motion_reference_handlers</depend>
-  <depend>pymap3d-pip</depend>
+  <depend>python3-pymap3d</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #150  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* Changed to apt package instead of pip, since pip package is not working properly on jenkins build (see #150)