### PR TITLE
[ as2_simulation_assets] Use sim time default parameter

### DIFF
--- a/as2_simulation_assets/as2_ign_gazebo_assets/launch/launch_simulation.py
+++ b/as2_simulation_assets/as2_ign_gazebo_assets/launch/launch_simulation.py
@@ -147,7 +147,7 @@ def generate_launch_description():
             description='Launch config file (JSON or YAML format).'),
         DeclareLaunchArgument(
             'use_sim_time',
-            default_value='false',
+            default_value='true',
             choices=['true', 'false'],
             description='Deactivates clock bridge and object publishes tf in sys clock time.'),
         DeclareLaunchArgument(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #208  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Ignition |

---

## Description of contribution in a few bullet points
* Change use sim time default value for ignition simulator.

## Description of documentation updates required from your changes
* Use sim time in config file should be added to documentation
