### PR TITLE
Nodes use Aerostack2 Node Create Timer method, not create wall timer

### DIFF
--- a/as2_aerial_platforms/as2_platform_crazyflie/src/crazyflie_platform.cpp
+++ b/as2_aerial_platforms/as2_platform_crazyflie/src/crazyflie_platform.cpp
@@ -133,9 +133,8 @@ void CrazyfliePlatform::init() {
   }
 
   /*  TIMERS */
-  ping_timer_ = this->create_wall_timer(std::chrono::milliseconds(10), [this]() { pingCB(); });
-  bat_timer_ =
-      this->create_wall_timer(std::chrono::milliseconds(100), [this]() { onLogBattery(); });
+  ping_timer_ = this->create_timer(std::chrono::milliseconds(10), [this]() { pingCB(); });
+  bat_timer_  = this->create_timer(std::chrono::milliseconds(100), [this]() { onLogBattery(); });
 
   RCLCPP_INFO(this->get_logger(), "Finished Init");
 }

--- a/as2_aerial_platforms/as2_platform_dji_osdk/include/dji_subscriber.hpp
+++ b/as2_aerial_platforms/as2_platform_dji_osdk/include/dji_subscriber.hpp
@@ -105,8 +105,9 @@ class DJISubscription {
     };
 
     update_timer_ =
-        node_->create_wall_timer(std::chrono::milliseconds(1000 / frequency_),
-                                 std::bind(&DJISubscription::update, this));
+        node_->create_timer(std::chrono::duration<double>(1.0f / frequency_),
+                            std::bind(&DJISubscription::update, this));
+
     started_ = true;
     return true;
   };

--- a/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
+++ b/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
@@ -16,7 +16,7 @@ DJIMatricePlatform::DJIMatricePlatform(int argc, char** argv)
   // TODO: READ_PARAMS
   linux_env_ptr_ =
       std::make_shared<LinuxSetup>(argc, argv, enable_advanced_sensing_);
-  static auto timer_commands_ = this->create_wall_timer(
+  static auto timer_commands_ = this->create_timer(
       std::chrono::milliseconds(30), [this]() { this->sendCommand(); });
 }
 

--- a/as2_aerial_platforms/as2_platform_tello/src/tello_platform.cpp
+++ b/as2_aerial_platforms/as2_platform_tello/src/tello_platform.cpp
@@ -54,32 +54,29 @@ TelloPlatform::TelloPlatform() : as2::AerialPlatform() {
   base_link_frame_id_ = as2::tf::generateTfName(this, "base_link");
   resetOdometry();
 
-  this->timer_ =
-      this->create_wall_timer(std::chrono::duration<double>(1.0f / sensor_freq_), [this]() {
-        recvIMU();
-        recvBattery();
-        recvBarometer();
-        // recvOdometry();
-      });
+  this->timer_ = this->create_timer(std::chrono::duration<double>(1.0f / sensor_freq_), [this]() {
+    recvIMU();
+    recvBattery();
+    recvBarometer();
+    // recvOdometry();
+  });
 
-  static auto odom_timer = this->create_wall_timer(std::chrono::duration<double>(1.0f / 200.0f),
-                                                   [this]() { recvOdometry(); });
+  static auto odom_timer = this->create_timer(std::chrono::duration<double>(1.0f / 200.0f),
+                                              [this]() { recvOdometry(); });
 
-  static auto time_ping_timer =
-      this->create_wall_timer(std::chrono::duration<double>(5.0f), [this]() {
-        std::string response;
-        tello->sendCommand("time?", true, &response);
-        const auto& clock = this->get_clock();
-        // cast response to int
-        const auto& time = std::stoi(response);
-        if (time > 0) {
-          RCLCPP_INFO_THROTTLE(this->get_logger(), *clock, 15000, "Flight Time: %s",
-                               response.c_str());
-        }
-      });
+  static auto time_ping_timer = this->create_timer(std::chrono::duration<double>(5.0f), [this]() {
+    std::string response;
+    tello->sendCommand("time?", true, &response);
+    const auto& clock = this->get_clock();
+    // cast response to int
+    const auto& time = std::stoi(response);
+    if (time > 0) {
+      RCLCPP_INFO_THROTTLE(this->get_logger(), *clock, 15000, "Flight Time: %s", response.c_str());
+    }
+  });
 
   this->cam_timer_ =
-      this->create_wall_timer(std::chrono::duration<double>(1.0f / 10), [this]() { recvVideo(); });
+      this->create_timer(std::chrono::duration<double>(1.0f / 10), [this]() { recvVideo(); });
 }
 
 TelloPlatform::~TelloPlatform() {}

--- a/as2_behaviors/as2_behavior/include/as2_behavior/__impl/behavior_server__impl.hpp
+++ b/as2_behaviors/as2_behavior/include/as2_behavior/__impl/behavior_server__impl.hpp
@@ -89,14 +89,14 @@ void BehaviorServer<actionT>::register_publishers() {
 
 template <typename actionT>
 void BehaviorServer<actionT>::register_timers() {
-  behavior_status_timer_ = this->create_wall_timer(
+  behavior_status_timer_ = this->create_timer(
       std::chrono::milliseconds(100), std::bind(&BehaviorServer::publish_behavior_status, this));
 }
 
 template <typename actionT>
 void BehaviorServer<actionT>::register_run_timer() {
-  run_timer_ = this->create_wall_timer(std::chrono::milliseconds(100),
-                                       std::bind(&BehaviorServer::timer_callback, this));
+  run_timer_ = this->create_timer(std::chrono::milliseconds(100),
+                                  std::bind(&BehaviorServer::timer_callback, this));
 }
 template <typename actionT>
 void BehaviorServer<actionT>::cleanup_run_timer(const ExecutionStatus& state) {

--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -135,11 +135,11 @@ void AerialPlatform::initialize() {
         as2_names::topics::platform::qos);
 
     platform_info_timer_ =
-        this->create_wall_timer(std::chrono::duration<double>(1.0f / info_freq_),
-                                std::bind(&AerialPlatform::publishPlatformInfo, this));
+        this->create_timer(std::chrono::duration<double>(1.0f / info_freq_),
+                           std::bind(&AerialPlatform::publishPlatformInfo, this));
 
-    platform_cmd_timer_ = this->create_wall_timer(std::chrono::duration<double>(1.0f / cmd_freq_),
-                                                  std::bind(&AerialPlatform::sendCommand, this));
+    platform_cmd_timer_ = this->create_timer(std::chrono::duration<double>(1.0f / cmd_freq_),
+                                             std::bind(&AerialPlatform::sendCommand, this));
   }
 }
 

--- a/as2_hardware_drivers/as2_usb_camera_interface/src/as2_usb_camera_interface.cpp
+++ b/as2_hardware_drivers/as2_usb_camera_interface/src/as2_usb_camera_interface.cpp
@@ -42,7 +42,7 @@ UsbCameraInterface::UsbCameraInterface() : as2::Node("usb_camera_interface") {
   setupCamera();
 
   // create timer for image capture
-  static auto image_capture_timer_ = this->create_wall_timer(
+  static auto image_capture_timer_ = this->create_timer(
       std::chrono::milliseconds(10), std::bind(&UsbCameraInterface::captureImage, this));
 };
 

--- a/as2_motion_controller/plugins/differential_flatness_controller/tests/controller_node.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/tests/controller_node.cpp
@@ -169,7 +169,7 @@ public:
     pid_handler_->setGainKdY(3.0);
     pid_handler_->setGainKdZ(3.0);
 
-    timer_ = this->create_wall_timer(10ms, std::bind(&MinimalPublisher::timer_callback, this));
+    timer_ = this->create_timer(10ms, std::bind(&MinimalPublisher::timer_callback, this));
   }
 
 private:

--- a/as2_motion_controller/plugins/differential_flatness_controller/tests/plugin_test.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/tests/plugin_test.cpp
@@ -60,7 +60,7 @@ public:
         as2_names::topics::self_localization::twist, as2_names::topics::self_localization::qos,
         std::bind(&Plugin_test::state_callback, this, std::placeholders::_1));
 
-    timer_ = this->create_wall_timer(10ms, std::bind(&Plugin_test::timer_callback, this));
+    timer_ = this->create_timer(10ms, std::bind(&Plugin_test::timer_callback, this));
   }
 
 private:

--- a/as2_motion_controller/src/controller_manager.cpp
+++ b/as2_motion_controller/src/controller_manager.cpp
@@ -113,8 +113,8 @@ ControllerManager::ControllerManager()
   mode_pub_ = this->create_publisher<as2_msgs::msg::ControllerInfo>(
       as2_names::topics::controller::info, as2_names::topics::controller::qos_info);
 
-  mode_timer_ = this->create_wall_timer(std::chrono::duration<double>(info_freq_),
-                                        std::bind(&ControllerManager::mode_timer_callback, this));
+  mode_timer_ = this->create_timer(std::chrono::duration<double>(1.0f / info_freq_),
+                                   std::bind(&ControllerManager::mode_timer_callback, this));
 };
 
 ControllerManager::~ControllerManager(){};

--- a/as2_state_estimator/plugins/mocap_pose/tests/mocap_test.cpp
+++ b/as2_state_estimator/plugins/mocap_pose/tests/mocap_test.cpp
@@ -16,8 +16,8 @@ public:
   MocapMock() : as2::Node("mocap_pose_mock") {
     mocap_pose_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>(
         as2_names::topics::ground_truth::pose, as2_names::topics::ground_truth::qos);
-    timer_ = create_wall_timer(std::chrono::milliseconds(10),
-                               std::bind(&MocapMock::timer_callback, this));
+    timer_ =
+        create_timer(std::chrono::milliseconds(10), std::bind(&MocapMock::timer_callback, this));
 
     msg.pose.position.x = 0.0;
     msg.pose.position.y = 0.0;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #211  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Ignition |

---

## Description of contribution in a few bullet points
* Change create wall timer to as2 create timer, so the timer use the /clock time instead of the wall timer.

## Description of documentation updates required from your changes
* Development guide should have this as2 features.

