### PR TITLE
Add external object gps

### DIFF
--- a/as2_simulation_assets/as2_ign_gazebo_assets/models/windmill/windmill.sdf
+++ b/as2_simulation_assets/as2_ign_gazebo_assets/models/windmill/windmill.sdf
@@ -120,7 +120,7 @@
             <name>gps</name>
             <uri>model://gps</uri>
             <pose relative_to="motor_link">
-                0.005 -0.75 0.57 0 0 -1.57
+                0 0 0 0 0 -1.57
             </pose>
             <plugin
                 filename="ignition-gazebo-odometry-publisher-system"

--- a/as2_simulation_assets/as2_ign_gazebo_assets/src/azimuth_bridge.cpp
+++ b/as2_simulation_assets/as2_ign_gazebo_assets/src/azimuth_bridge.cpp
@@ -93,7 +93,7 @@ private:
 
   static float toAzimuth(float yaw) {
     float deg = yaw * 360 / (M_PI * 2);  // [-180, 180]
-    deg       = deg - 90;
+    deg       = -deg + 90;
     if (deg < 0) {
       deg = 360 + deg;
     }

--- a/as2_simulation_assets/as2_ign_gazebo_assets/src/azimuth_bridge.cpp
+++ b/as2_simulation_assets/as2_ign_gazebo_assets/src/azimuth_bridge.cpp
@@ -35,15 +35,15 @@
 #include <memory>
 #include <string>
 
+#include <math.h>
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include <math.h>
 
 #include <as2_core/names/topics.hpp>
-#include <std_msgs/msg/float32.hpp>
 #include <ignition/msgs.hh>
 #include <ignition/transport.hh>
 #include <ros_gz_bridge/convert.hpp>
+#include <std_msgs/msg/float32.hpp>
 
 class AzimuthBridge : public rclcpp::Node {
 public:
@@ -51,24 +51,24 @@ public:
     this->declare_parameter<std::string>("name_space");
     this->get_parameter("name_space", model_name_);
 
-    ps_pub_ = this->create_publisher<std_msgs::msg::Float32>(
-        "gps/azimuth", as2_names::topics::ground_truth::qos);
+    ps_pub_ = this->create_publisher<std_msgs::msg::Float32>("gps/azimuth",
+                                                             as2_names::topics::ground_truth::qos);
 
     // Initialize the ignition node
     ign_node_ptr_                  = std::make_shared<ignition::transport::Node>();
     std::string ground_truth_topic = "/model/gps/odometry";
     ign_node_ptr_->Subscribe(ground_truth_topic, this->ignitionGroundTruthCallback);
   }
+
 private:
   std::shared_ptr<ignition::transport::Node> ign_node_ptr_;
   std::string model_name_;
   static rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr ps_pub_;
   struct Quaternion {
-      float w, x, y, z;
+    float w, x, y, z;
   };
 
 private:
-
   static void ignitionGroundTruthCallback(const ignition::msgs::Odometry &ign_msg,
                                           const ignition::transport::MessageInfo &msg_info) {
     std_msgs::msg::Float32 az_msg;
@@ -86,23 +86,22 @@ private:
   static float toEulerYaw(Quaternion q) {
     float siny_cosp = 2 * (q.w * q.z + q.x * q.y);
     float cosy_cosp = 1 - 2 * (q.y * q.y + q.z * q.z);
-    float yaw = std::atan2(siny_cosp, cosy_cosp);
+    float yaw       = std::atan2(siny_cosp, cosy_cosp);
 
     return yaw;
   }
 
-  static float toAzimuth(float yaw){
-    float deg = yaw * 360 / (M_PI * 2); // [-180, 180]
-    deg = -deg;
-    if (deg < 0){
+  static float toAzimuth(float yaw) {
+    float deg = yaw * 360 / (M_PI * 2);  // [-180, 180]
+    deg       = deg - 90;
+    if (deg < 0) {
       deg = 360 + deg;
     }
-
     return deg;
   }
 };
 
-rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr AzimuthBridge::ps_pub_  = nullptr;
+rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr AzimuthBridge::ps_pub_ = nullptr;
 
 int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);

--- a/as2_simulation_assets/as2_ign_gazebo_assets/src/ign_assets/model.py
+++ b/as2_simulation_assets/as2_ign_gazebo_assets/src/ign_assets/model.py
@@ -436,12 +436,20 @@ class ObjectModel(Model):
         # TODO: temporal
         if self.model_type == 'windmill':
             bridges.append(
-                Bridge(ign_topic='/model/windmill_0/model/debug_viz/pose',
+                Bridge(ign_topic=f'/model/{self.model_name}/model/debug_viz/pose',
                        ros_topic='debug/pose',
                        ign_type='ignition.msgs.Pose',
                        ros_type='geometry_msgs/msg/PoseStamped',
                        direction=BridgeDirection.IGN_TO_ROS)
             )
+        if self.model_type == 'aruco_gate_1':
+            bridges.append(
+                Bridge(ign_topic=f'/model/{self.model_name}/pose',
+                       ros_topic=f'/{self.model_name}/pose',
+                       ign_type='ignition.msgs.Pose',
+                       ros_type='geometry_msgs/msg/PoseStamped',
+                       direction=BridgeDirection.IGN_TO_ROS)
+            )            
         nodes = []
         if (self.model_type in gps_object_models()):
             nodes = [Node(
@@ -466,20 +474,20 @@ class ObjectModel(Model):
                     {'name_space': self.model_name}
                 ]
             )]
-        nodes.extend([Node(
-                package='as2_ign_gazebo_assets',
-                executable='object_tf_broadcaster',
-                namespace=self.model_name,
-                output='screen',
-                parameters=[
-                    {
-                        'world_frame': 'earth',
-                        'namespace': self.model_name,
-                        'world_name': world_name,
-                        'use_sim_time': self.use_sim_time
-                    }
-                ]
-            )])
+        # nodes.extend([Node(
+        #         package='as2_ign_gazebo_assets',
+        #         executable='object_tf_broadcaster',
+        #         namespace=self.model_name,
+        #         output='screen',
+        #         parameters=[
+        #             {
+        #                 'world_frame': 'earth',
+        #                 'namespace': self.model_name,
+        #                 'world_name': world_name,
+        #                 'use_sim_time': self.use_sim_time
+        #             }
+        #         ]
+        #     )])
         bridges.extend(self.joint_bridges())
 
         return bridges, nodes

--- a/as2_simulation_assets/as2_ign_gazebo_assets/worlds/empty_gps.sdf
+++ b/as2_simulation_assets/as2_ign_gazebo_assets/worlds/empty_gps.sdf
@@ -34,7 +34,7 @@
       <latitude_deg>52.171776</latitude_deg>
       <longitude_deg>4.416351</longitude_deg>
       <elevation>45.110</elevation>
-      <heading_deg>90</heading_deg><!-- Temporary fix for issue https://bitbucket.org/osrf/gazebo/issues/2022/default-sphericalcoordinates-frame-should -->
+      <heading_deg>0</heading_deg><!-- Temporary fix for issue https://bitbucket.org/osrf/gazebo/issues/2022/default-sphericalcoordinates-frame-should -->
     </spherical_coordinates>
 
     <light type="directional" name="sun">


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #230 #229 #228  |
| ROS2 version tested on |Humble|
| Aerial platform tested on |Ignition|

---

## Description of contribution in a few bullet points

* Gps moved to Nacelle frame
* Gps alligned to Nacelle frame
* Gps alligned in ENU Frame
* ground truth plugin supports gps (dev will be in other branch)

## Future work that may be required in bullet points

* Origin is placed in 0,0 cartessian coordinate by the simulator, origin should be set by service or parameter (pref parameter)
* Build odom->base_link frame with the Inverse(map->odom) * Inverse(earth->map) * (earth->base_link) as we are receiving this last transformation as information coming from the simulation.
