### PR TITLE
[as2_behavior_tree] GoTo Bt action missing frame

### DIFF
--- a/as2_behavior_tree/include/as2_behavior_tree/action/takeoff_action.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/action/takeoff_action.hpp
@@ -44,6 +44,9 @@
 #include "as2_core/names/actions.hpp"
 #include "as2_msgs/action/take_off.hpp"
 
+#include <chrono>
+#include <thread>
+
 namespace as2_behavior_tree {
 class TakeoffAction
     : public nav2_behavior_tree::BtActionNode<as2_msgs::action::TakeOff> {
@@ -52,6 +55,12 @@ public:
                 const BT::NodeConfiguration &conf);
 
   void on_tick() override;
+
+  BT::NodeStatus on_success() {
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(500ms);
+    return BT::NodeStatus::SUCCESS;
+  }
 
   void on_wait_for_result(
       std::shared_ptr<const as2_msgs::action::TakeOff::Feedback> feedback);

--- a/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
@@ -69,6 +69,7 @@ inline geometry_msgs::msg::PointStamped convertFromString(BT::StringView str) {
     throw RuntimeError("invalid input)");
   } else {
     geometry_msgs::msg::PointStamped output;
+    output.header.frame_id = "earth";
     output.point.x = convertFromString<double>(parts[0]);
     output.point.y = convertFromString<double>(parts[1]);
     output.point.z = convertFromString<double>(parts[2]);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #234  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Ignition |

---

## Description of contribution in a few bullet points

* Added fixed `earth` frame_id
* Short sleep after finishing takeoff to avoid post goto rejected due to *drone not flying* error

---

## Future work that may be required in bullet points

* Add support to different frame_ids
