### PR TITLE
[as2_crazyflie_platform] Remove namespace from launch

### DIFF
--- a/as2_aerial_platforms/as2_platform_crazyflie/launch/crazyflie_aideck_stream_launch.py
+++ b/as2_aerial_platforms/as2_platform_crazyflie/launch/crazyflie_aideck_stream_launch.py
@@ -11,7 +11,7 @@ def generate_launch_description():
 
     aideck_config_file = PathJoinSubstitution([
         FindPackageShare('as2_platform_crazyflie'),
-        'aideck_config_file', 'aideck_config_file.yaml'
+        'config', 'aideck_config_file.yaml'
     ])
 
     return LaunchDescription([

--- a/as2_aerial_platforms/as2_platform_crazyflie/launch/crazyflie_swarm_launch.py
+++ b/as2_aerial_platforms/as2_platform_crazyflie/launch/crazyflie_swarm_launch.py
@@ -25,9 +25,6 @@ def generate_launch_description():
     ])
 
     return LaunchDescription([
-        DeclareLaunchArgument('namespace',
-                              default_value="crazyflie_swarm",
-                              description='Crazyflie swarm namespace'),
         DeclareLaunchArgument('control_modes_file',
                               default_value=control_modes,
                               description='Platform control modes file'),
@@ -42,7 +39,6 @@ def generate_launch_description():
             package="as2_platform_crazyflie",
             executable="as2_platform_crazyflie_swarm_node",
             name="platform",
-            namespace=LaunchConfiguration('namespace'),
             output="screen",
             emulate_tty=True,
             parameters=[


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Crazyflie |

---

## Description of contribution in a few bullet points

* Launch namespace was overriding each cf namespace