### PR TITLE
Delete install_bt_dependencies.bash

### DIFF
--- a/as2_behavior_tree/install_bt_dependencies.bash
+++ b/as2_behavior_tree/install_bt_dependencies.bash
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-sudo apt-get update
-sudo apt-get install ros-$ROS_DISTRO-behaviortree-cpp-v3 -y 
-sudo apt-get install ros-$ROS_DISTRO-nav2-msgs -y 
-sudo apt-get install ros-$ROS_DISTRO-nav2-behavior-tree -y 


### PR DESCRIPTION
Closes #289

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #289 |
| ROS2 version tested on | - |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* Removing deprecated installation file

