### PR TITLE
[as2_platform_dji_osdk] Add take off sleep to wait until it has finished

### DIFF
--- a/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
+++ b/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
@@ -76,7 +76,7 @@ bool DJIMatricePlatform::ownTakeoff() {
   int timeout = 10;
   ErrorCode::ErrorCodeType error =
       vehicle_->flightController->startTakeoffSync(timeout);
-  
+
   // Wait timeout
   rclcpp::sleep_for(std::chrono::seconds(timeout));
 

--- a/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
+++ b/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
@@ -73,8 +73,13 @@ bool DJIMatricePlatform::ownSetArmingState(bool state) {
 
 bool DJIMatricePlatform::ownTakeoff() {
   RCLCPP_INFO(this->get_logger(), "Taking off");
+  int timeout = 10;
   ErrorCode::ErrorCodeType error =
-      vehicle_->flightController->startTakeoffSync(10);
+      vehicle_->flightController->startTakeoffSync(timeout);
+  
+  // Wait timeout
+  rclcpp::sleep_for(std::chrono::seconds(timeout));
+
   // RCLCPP_WARN(this->get_logger(),"ERROR CODE: %ld ", error);
   if (error) {
     printDJIError(error);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #298 |
| ROS2 version tested on | Humble, Galactic |
| Aerial platform tested on | DJI |

---

## Description of contribution in a few bullet points

* Add a sleep to wait the take off finish by the DJI platform
