### PR TITLE
302-Parametrize tf timeout in go to and follow reference behavior

### DIFF
--- a/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/config/config_default.yaml
@@ -3,3 +3,4 @@
     follow_reference_max_speed_x: 10.0 # Maximum speed in x direction
     follow_reference_max_speed_y: 10.0 # Maximum speed in y direction
     follow_reference_max_speed_z: 10.0 # Maximum speed in z direction
+    tf_timeout_threshold: 0.05 # Default tf timeout (50ms)

--- a/as2_behaviors/as2_behaviors_motion/go_to_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_motion/go_to_behavior/config/config_default.yaml
@@ -2,3 +2,4 @@
   ros__parameters:
     go_to_speed: 0.5 # Default go_to speed
     go_to_threshold: 0.2 # Default go_to threshold
+    tf_timeout_threshold: 0.05 # Default tf timeout (50ms)

--- a/as2_behaviors/as2_behaviors_motion/go_to_behavior/include/go_to_behavior/go_to_base.hpp
+++ b/as2_behaviors/as2_behaviors_motion/go_to_behavior/include/go_to_behavior/go_to_base.hpp
@@ -54,8 +54,9 @@
 namespace go_to_base {
 
 struct go_to_plugin_params {
-  double go_to_speed     = 0.0;
-  double go_to_threshold = 0.0;
+  double go_to_speed          = 0.0;
+  double go_to_threshold      = 0.0;
+  double tf_timeout_threshold = 0.0;
 };
 
 class GoToBase {

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -204,7 +204,9 @@ public:
    * @return bool true if the conversion was successful
    * @throw tf2::TransformException if the transform is not available
    */
-  bool tryConvert(geometry_msgs::msg::PointStamped &_point, const std::string &_target_frame);
+  bool tryConvert(geometry_msgs::msg::PointStamped &_point,
+                  const std::string &_target_frame,
+                  const std::chrono::nanoseconds timeout = TF_TIMEOUT);
 
   /**
    * @brief convert a geometry_msgs::msg::PoseStamped to desired frame, checking if frames are
@@ -214,7 +216,9 @@ public:
    * @return bool true if the conversion was successful
    * @throw tf2::TransformException if the transform is not available
    */
-  bool tryConvert(geometry_msgs::msg::PoseStamped &_pose, const std::string &_target_frame);
+  bool tryConvert(geometry_msgs::msg::PoseStamped &_pose,
+                  const std::string &_target_frame,
+                  const std::chrono::nanoseconds timeout = TF_TIMEOUT);
 
   /**
    * @brief convert a geometry_msgs::msg::TwistStamped to desired frame, checking if frames are
@@ -224,7 +228,9 @@ public:
    * @return bool true if the conversion was successful
    * @throw tf2::TransformException if the transform is not available
    */
-  bool tryConvert(geometry_msgs::msg::TwistStamped &_twist, const std::string &_target_frame);
+  bool tryConvert(geometry_msgs::msg::TwistStamped &_twist,
+                  const std::string &_target_frame,
+                  const std::chrono::nanoseconds timeout = TF_TIMEOUT);
 
   /**
    * @brief Get the pose and twist of the UAV at the given twist timestamp, in the given frames

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -189,9 +189,10 @@ geometry_msgs::msg::TransformStamped TfHandler::getTransform(const std::string &
 };
 
 bool TfHandler::tryConvert(geometry_msgs::msg::PointStamped &_point,
-                           const std::string &_target_frame) {
+                           const std::string &_target_frame,
+                           const std::chrono::nanoseconds timeout) {
   try {
-    _point = convert(_point, _target_frame);
+    _point = convert(_point, _target_frame, timeout);
     return true;
   } catch (tf2::TransformException &ex) {
     RCLCPP_WARN(node_->get_logger(), "Could not get transform: %s", ex.what());
@@ -201,9 +202,10 @@ bool TfHandler::tryConvert(geometry_msgs::msg::PointStamped &_point,
 };
 
 bool TfHandler::tryConvert(geometry_msgs::msg::PoseStamped &_pose,
-                           const std::string &_target_frame) {
+                           const std::string &_target_frame,
+                           const std::chrono::nanoseconds timeout) {
   try {
-    _pose = convert(_pose, _target_frame);
+    _pose = convert(_pose, _target_frame, timeout);
     return true;
   } catch (tf2::TransformException &ex) {
     RCLCPP_WARN(node_->get_logger(), "Could not get transform: %s", ex.what());
@@ -213,9 +215,10 @@ bool TfHandler::tryConvert(geometry_msgs::msg::PoseStamped &_pose,
 };
 
 bool TfHandler::tryConvert(geometry_msgs::msg::TwistStamped &_twist,
-                           const std::string &_target_frame) {
+                           const std::string &_target_frame,
+                           const std::chrono::nanoseconds timeout) {
   try {
-    _twist = convert(_twist, _target_frame);
+    _twist = convert(_twist, _target_frame, timeout);
     return true;
   } catch (tf2::TransformException &ex) {
     RCLCPP_ERROR(node_->get_logger(), "Could not get transform: %s", ex.what());


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |#302 |
| ROS2 version tested on |Humble|
| Aerial platform tested on |Ignition|

---

## Description of contribution in a few bullet points

* Tf utils try_convert function admits timeout parameter
* Go to and follow reference behavior admits this timeout parameter
