### PR TITLE
[as2_platform_dji_osdk] Links qos subscritions changed to reliable

### DIFF
--- a/as2_aerial_platforms/as2_platform_dji_osdk/include/dji_mop_handler.hpp
+++ b/as2_aerial_platforms/as2_platform_dji_osdk/include/dji_mop_handler.hpp
@@ -49,12 +49,15 @@ class DJIMopHandler {
     uplink_pub_ = node_ptr_->create_publisher<std_msgs::msg::String>(
         "/uplink", as2_names::topics::global::qos);
 
+    // Create a custom QoS profile with the desired settings
+    rclcpp::QoS custom_qos_profile =
+        rclcpp::QoS(rclcpp::KeepLast(10)).reliable();
     downlink_sub_ = node_ptr_->create_subscription<std_msgs::msg::String>(
-        "/downlink", as2_names::topics::global::qos,
+        "/downlink", custom_qos_profile,
         std::bind(&DJIMopHandler::downlinkCB, this, std::placeholders::_1));
 
     keep_alive_sub_ = node_ptr_->create_subscription<std_msgs::msg::String>(
-        "/keep_alive", rclcpp::QoS(1),
+        "/keep_alive", custom_qos_profile,
         std::bind(&DJIMopHandler::keepAliveCB, this, std::placeholders::_1));
 
     static auto timer_ = node_ptr_->create_timer(


### PR DESCRIPTION
@javilinos please kindly review these changes. If merged update also `generadrone` branch to contain this.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on |  |

---

## Description of contribution in a few bullet points

* MOP links qos subscritions changed to reliable
