### PR TITLE
Only use tf2_geometry_msgs library when needed

### DIFF
--- a/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
+++ b/as2_aerial_platforms/as2_platform_dji_osdk/src/dji_matrice_platform.cpp
@@ -9,7 +9,6 @@
 #include "dji_flight_controller.hpp"
 #include "dji_subscriber.hpp"
 #include "dji_telemetry.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 DJIMatricePlatform::DJIMatricePlatform(int argc, char** argv)
     : as2::AerialPlatform() {

--- a/as2_behaviors/as2_behaviors_motion/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_motion/CMakeLists.txt
@@ -25,7 +25,6 @@ set(PROJECT_DEPENDENCIES
   as2_behavior
   as2_motion_reference_handlers
   geometry_msgs
-  tf2_geometry_msgs
   Eigen3
 )
 

--- a/as2_core/include/as2_core/sensor.hpp
+++ b/as2_core/include/as2_core/sensor.hpp
@@ -66,8 +66,8 @@
 #include <image_transport/image_transport.hpp>
 
 // tf2
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace as2 {
 namespace sensors {

--- a/as2_core/include/as2_core/sensor.hpp
+++ b/as2_core/include/as2_core/sensor.hpp
@@ -66,8 +66,8 @@
 #include <image_transport/image_transport.hpp>
 
 // tf2
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace as2 {
 namespace sensors {

--- a/as2_core/include/as2_core/utils/frame_utils.hpp
+++ b/as2_core/include/as2_core/utils/frame_utils.hpp
@@ -35,10 +35,9 @@
 #define __AEROSTACK2_CODE_UTILS_HPP__
 
 #include <math.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-
 #include <Eigen/Geometry>
 #include <geometry_msgs/msg/quaternion.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace as2 {
 namespace frame {

--- a/as2_core/include/as2_core/utils/frame_utils.hpp
+++ b/as2_core/include/as2_core/utils/frame_utils.hpp
@@ -35,9 +35,9 @@
 #define __AEROSTACK2_CODE_UTILS_HPP__
 
 #include <math.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <Eigen/Geometry>
 #include <geometry_msgs/msg/quaternion.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace as2 {
 namespace frame {

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -34,13 +34,13 @@
 #define TF_UTILS_HPP_
 
 #include <tf2/time.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <nav_msgs/msg/path.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <tf2/convert.h>
 #include <chrono>

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -33,17 +33,16 @@
 #ifndef TF_UTILS_HPP_
 #define TF_UTILS_HPP_
 
+#include <tf2/convert.h>
 #include <tf2/time.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <chrono>
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <nav_msgs/msg/path.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/convert.h>
-#include <chrono>
 #include "as2_core/node.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"

--- a/as2_core/package.xml
+++ b/as2_core/package.xml
@@ -26,6 +26,7 @@
   
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>image_transport</depend>
   <depend>cv_bridge</depend>
 

--- a/as2_hardware_drivers/as2_realsense_interface/CMakeLists.txt
+++ b/as2_hardware_drivers/as2_realsense_interface/CMakeLists.txt
@@ -21,7 +21,6 @@ set(PROJECT_DEPENDENCIES
   realsense2
   tf2
   tf2_ros
-  tf2_geometry_msgs
   )
 
 foreach(dependency ${PROJECT_DEPENDENCIES})

--- a/as2_hardware_drivers/as2_realsense_interface/include/as2_realsense_interface/as2_realsense_interface.hpp
+++ b/as2_hardware_drivers/as2_realsense_interface/include/as2_realsense_interface/as2_realsense_interface.hpp
@@ -38,7 +38,6 @@
 #include "as2_core/sensor.hpp"
 #include "as2_core/utils/tf_utils.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <librealsense2/rs.hpp>
 

--- a/as2_hardware_drivers/as2_realsense_interface/package.xml
+++ b/as2_hardware_drivers/as2_realsense_interface/package.xml
@@ -22,7 +22,6 @@
   <depend>librealsense2</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>tf2_geometry_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_motion_controller/CMakeLists.txt
+++ b/as2_motion_controller/CMakeLists.txt
@@ -27,7 +27,6 @@ set(PROJECT_DEPENDENCIES
   as2_msgs
   as2_motion_reference_handlers
   geometry_msgs
-  tf2_geometry_msgs
   Eigen3
   benchmark
 )

--- a/as2_motion_controller/package.xml
+++ b/as2_motion_controller/package.xml
@@ -19,7 +19,6 @@
   <depend>as2_msgs</depend>
   <depend>as2_motion_reference_handlers</depend>
   <depend>geometry_msgs</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>eigen</depend>
   <depend>benchmark</depend>
 

--- a/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
@@ -50,7 +50,6 @@
 #include "as2_msgs/msg/trajectory_point.hpp"
 
 #include <Eigen/src/Core/GlobalFunctions.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 namespace differential_flatness_controller {
 struct UAV_state {

--- a/as2_motion_controller/plugins/differential_flatness_controller/tests/controller_node.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/tests/controller_node.cpp
@@ -12,7 +12,6 @@
 
 using namespace std::chrono_literals;
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <pid_controller/PID_3D.hpp>
 #include <vector>
 

--- a/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
@@ -51,7 +51,6 @@
 #include "pid_controller/PID.hpp"
 #include "pid_controller/PID_3D.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/hover_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/hover_motion.hpp
@@ -45,7 +45,6 @@
 
 #include "as2_core/node.hpp"
 #include "basic_motion_references.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 namespace as2 {
 namespace motionReferenceHandlers {

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/position_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/position_motion.hpp
@@ -46,7 +46,6 @@
 
 #include "as2_core/node.hpp"
 #include "basic_motion_references.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 namespace as2 {
 namespace motionReferenceHandlers {

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_in_a_plane_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_in_a_plane_motion.hpp
@@ -46,7 +46,6 @@
 
 #include "as2_core/node.hpp"
 #include "basic_motion_references.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 namespace as2 {
 namespace motionReferenceHandlers {

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_motion.hpp
@@ -46,7 +46,6 @@
 
 #include "as2_core/node.hpp"
 #include "basic_motion_references.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 namespace as2 {
 namespace motionReferenceHandlers {

--- a/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
+++ b/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
@@ -39,7 +39,6 @@
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Vector3.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <as2_state_estimator/plugin_base.hpp>
 #include <rclcpp/duration.hpp>
 namespace mocap_pose {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #316 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* Add dependency to `as2_core` package.xml
* Removed include from `as2_platform_dji_osdk`, `as2_behaviors_motion`, `as2_realsense_interface`, `as2_motion_controller`, `as2_state_estimator` and `as2_motion_reference_handlers`
* Using **.hpp** instead of **.h** library following deprecation warning suggestion