### PR TITLE
Runs PX4 in the foreground if gzclient is disabled (HEADLESS)

### DIFF
--- a/as2_simulation_assets/as2_gazebo_classic_assets/scripts/run_sitl.sh
+++ b/as2_simulation_assets/as2_gazebo_classic_assets/scripts/run_sitl.sh
@@ -239,7 +239,7 @@ function run_sitl() {
 	mkdir -p "$working_dir"
 	pushd "$working_dir" >/dev/null
 
-	sitl_command="\"$sitl_bin\" -i $N $no_pxh \"$build_path\"/etc -s etc/init.d-posix/rcS -w $working_dir &"
+	sitl_command="\"$sitl_bin\" -i $N $no_pxh \"$build_path\"/etc -s etc/init.d-posix/rcS -w $working_dir $headless"
 	test_test___="\"$sitl_bin\" -i $N $no_pxh \"$build_path\"/etc -s etc/init.d-posix/rcS -w sitl_${MODEL}_${N} >out.log 2>err.log &"
 	# TODO verbose
 
@@ -328,6 +328,13 @@ if [[ -n "$VERBOSE_SIM" ]]; then
 	verbose="--verbose"
 else
 	verbose=""
+fi
+
+# To run PX4 in foregroud
+if [[ -n "$HEADLESS" ]]; then
+	headless=""
+else
+	headless="&"
 fi
 
 # kill process names that might stil


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #322 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | PX4 |

---

## Description of contribution in a few bullet points

* if HEADLESS has a non-empty value then runs PX4 in the foreground, which stops the script from exiting