### PR TITLE
Explicit namespace for motion reference handlers

### DIFF
--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -43,6 +43,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <memory>
+#include <string>
 #include <thread>
 
 #include "as2_core/names/services.hpp"
@@ -58,11 +59,12 @@ namespace as2 {
 namespace motionReferenceHandlers {
 class BasicMotionReferenceHandler {
 public:
-  BasicMotionReferenceHandler(as2::Node *as2_ptr);
+  BasicMotionReferenceHandler(as2::Node *as2_ptr, const std::string &ns = "");
   ~BasicMotionReferenceHandler();
 
 protected:
   as2::Node *node_ptr_;
+  std::string namespace_;
 
   as2_msgs::msg::TrajectoryPoint command_trajectory_msg_;
   geometry_msgs::msg::PoseStamped command_pose_msg_;

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/hover_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/hover_motion.hpp
@@ -58,7 +58,7 @@ public:
    * @brief HoverMotion Constructor.
    * @param node as2::Node pointer.
    */
-  HoverMotion(as2::Node *node_ptr);
+  HoverMotion(as2::Node *node_ptr, const std::string &ns = "");
   ~HoverMotion(){};
 
 public:

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/position_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/position_motion.hpp
@@ -60,7 +60,7 @@ public:
    * @brief PositionMotion Constructor.
    * @param node as2::Node pointer.
    */
-  PositionMotion(as2::Node *node_ptr);
+  PositionMotion(as2::Node *node_ptr, const std::string &ns = "");
   ~PositionMotion(){};
 
 public:

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_in_a_plane_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_in_a_plane_motion.hpp
@@ -60,7 +60,7 @@ public:
    * @brief PositionMotion Constructor.
    * @param node as2::Node pointer.
    */
-  SpeedInAPlaneMotion(as2::Node *node_ptr);
+  SpeedInAPlaneMotion(as2::Node *node_ptr, const std::string &ns = "");
   ~SpeedInAPlaneMotion(){};
 
 public:

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_motion.hpp
@@ -60,7 +60,7 @@ public:
    * @brief PositionMotion Constructor.
    * @param node as2::Node pointer.
    */
-  SpeedMotion(as2::Node *node_ptr);
+  SpeedMotion(as2::Node *node_ptr, const std::string &ns = "");
   ~SpeedMotion(){};
 
 public:

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/trajectory_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/trajectory_motion.hpp
@@ -54,7 +54,7 @@ public:
    * @brief TrajectoryMotion constructor.
    * @param node as2::Node pointer.
    */
-  TrajectoryMotion(as2::Node *node_ptr);
+  TrajectoryMotion(as2::Node *node_ptr, const std::string &ns = "");
   ~TrajectoryMotion(){};
 
 public:

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -38,21 +38,27 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-BasicMotionReferenceHandler::BasicMotionReferenceHandler(as2::Node *as2_ptr) : node_ptr_(as2_ptr) {
+BasicMotionReferenceHandler::BasicMotionReferenceHandler(as2::Node *as2_ptr, const std::string &ns)
+    : node_ptr_(as2_ptr), namespace_(ns) {
   if (number_of_instances_ == 0) {
+    namespace_ = ns == "" ? ns : "/" + ns + "/";
+
     // Publisher
     command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectoryPoint>(
-        as2_names::topics::motion_reference::trajectory, as2_names::topics::motion_reference::qos);
+        namespace_ + as2_names::topics::motion_reference::trajectory,
+        as2_names::topics::motion_reference::qos);
 
     command_pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
-        as2_names::topics::motion_reference::pose, as2_names::topics::motion_reference::qos);
+        namespace_ + as2_names::topics::motion_reference::pose,
+        as2_names::topics::motion_reference::qos);
 
     command_twist_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::TwistStamped>(
-        as2_names::topics::motion_reference::twist, as2_names::topics::motion_reference::qos);
+        namespace_ + as2_names::topics::motion_reference::twist,
+        as2_names::topics::motion_reference::qos);
 
     // Subscriber
     controller_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::ControllerInfo>(
-        as2_names::topics::controller::info, rclcpp::QoS(1),
+        namespace_ + as2_names::topics::controller::info, rclcpp::QoS(1),
         [](const as2_msgs::msg::ControllerInfo::SharedPtr msg) {
           current_mode_ = msg->input_control_mode;
         });
@@ -131,7 +137,7 @@ bool BasicMotionReferenceHandler::setMode(const as2_msgs::msg::ControlMode &mode
   request.control_mode = mode;
 
   auto set_mode_cli = as2::SynchronousServiceClient<as2_msgs::srv::SetControlMode>(
-      as2_names::services::controller::set_control_mode, node_ptr_);
+      namespace_ + as2_names::services::controller::set_control_mode, node_ptr_);
 
   bool out = set_mode_cli.sendRequest(request, response);
 

--- a/as2_motion_reference_handlers/src/hover_motion.cpp
+++ b/as2_motion_reference_handlers/src/hover_motion.cpp
@@ -38,7 +38,8 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-HoverMotion::HoverMotion(as2::Node *node_ptr) : BasicMotionReferenceHandler(node_ptr) {
+HoverMotion::HoverMotion(as2::Node *node_ptr, const std::string &ns)
+    : BasicMotionReferenceHandler(node_ptr, ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::HOVER;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;

--- a/as2_motion_reference_handlers/src/position_motion.cpp
+++ b/as2_motion_reference_handlers/src/position_motion.cpp
@@ -38,7 +38,8 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-PositionMotion::PositionMotion(as2::Node *node_ptr) : BasicMotionReferenceHandler(node_ptr) {
+PositionMotion::PositionMotion(as2::Node *node_ptr, const std::string &ns)
+    : BasicMotionReferenceHandler(node_ptr, ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::POSITION;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;

--- a/as2_motion_reference_handlers/src/speed_in_a_plane_motion.cpp
+++ b/as2_motion_reference_handlers/src/speed_in_a_plane_motion.cpp
@@ -38,8 +38,8 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-SpeedInAPlaneMotion::SpeedInAPlaneMotion(as2::Node *node_ptr)
-    : BasicMotionReferenceHandler(node_ptr) {
+SpeedInAPlaneMotion::SpeedInAPlaneMotion(as2::Node *node_ptr, const std::string &ns)
+    : BasicMotionReferenceHandler(node_ptr, ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;

--- a/as2_motion_reference_handlers/src/speed_motion.cpp
+++ b/as2_motion_reference_handlers/src/speed_motion.cpp
@@ -38,7 +38,8 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-SpeedMotion::SpeedMotion(as2::Node *node_ptr) : BasicMotionReferenceHandler(node_ptr) {
+SpeedMotion::SpeedMotion(as2::Node *node_ptr, const std::string &ns)
+    : BasicMotionReferenceHandler(node_ptr, ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::SPEED;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;

--- a/as2_motion_reference_handlers/src/trajectory_motion.cpp
+++ b/as2_motion_reference_handlers/src/trajectory_motion.cpp
@@ -38,7 +38,8 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-TrajectoryMotion::TrajectoryMotion(as2::Node *node_ptr) : BasicMotionReferenceHandler(node_ptr) {
+TrajectoryMotion::TrajectoryMotion(as2::Node *node_ptr, const std::string &ns)
+    : BasicMotionReferenceHandler(node_ptr, ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::YAW_ANGLE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::TRAJECTORY;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::LOCAL_ENU_FRAME;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #329 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Ignition |

---

## Description of contribution in a few bullet points

* Namespace now can be given in the class constructor
