### PR TITLE
[as2_gazebo_classic_assets] Add gazebo_ros_pkgs dependence

### DIFF
--- a/as2_simulation_assets/as2_gazebo_classic_assets/package.xml
+++ b/as2_simulation_assets/as2_gazebo_classic_assets/package.xml
@@ -9,7 +9,8 @@
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
+  <depend>rclcpp</depend>
+  <depend>gazebo_ros_pkgs</depend>
   <exec_depend>python3-jinja2</exec_depend>
 
   <export>

--- a/as2_simulation_assets/as2_gazebo_classic_assets/scripts/config.yaml
+++ b/as2_simulation_assets/as2_gazebo_classic_assets/scripts/config.yaml
@@ -1,3 +1,4 @@
 /**:
   ros__parameters:
-    publish_rate: 200.0  # Hz (default: 100.0)
+    use_sim_time: true
+    publish_rate: 100.0  # Hz (default: 100.0)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #347  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | PX4 |

---

## Description of contribution in a few bullet points
* Add gazebo_ros_pkgs dependence to make Gazebo been a ROS 2 node and publish `/clock` topic
