### PR TITLE
Load custom world in gazebo 11

### DIFF
--- a/as2_simulation_assets/as2_gazebo_classic_assets/scripts/run_sitl.sh
+++ b/as2_simulation_assets/as2_gazebo_classic_assets/scripts/run_sitl.sh
@@ -68,7 +68,16 @@ function run_gzserver() {
 
 	# Check if world file exist, else look for world
 	if [[ -f $world ]]; then
-		world_path="$world"
+		world_path=${world%/*}
+		target=${world##/*/}
+	else
+		target="${world}.world"
+		world_path="$(get_path ${target} ${GAZEBO_RESOURCE_PATH})"
+	fi
+
+	# Check if world_path exist, else empty
+	if [[ -d $world_path ]]; then
+		world_path="${world_path}/${target}"
 	else
 		echo "empty world, setting empty.world as default"
 		world_path="${src_path}/Tools/simulation/gazebo-classic/sitl_gazebo/worlds/empty.world"

--- a/as2_simulation_assets/as2_gazebo_classic_assets/scripts/run_sitl.sh
+++ b/as2_simulation_assets/as2_gazebo_classic_assets/scripts/run_sitl.sh
@@ -70,14 +70,6 @@ function run_gzserver() {
 	if [[ -f $world ]]; then
 		world_path="$world"
 	else
-		target="${world}.world"
-		world_path="$(get_path ${target} ${GAZEBO_RESOURCE_PATH})"
-	fi
-
-	# Check if world_path exist, else empty
-	if [[ -d $world_path ]]; then
-		world_path="${world_path}/${target}"
-	else
 		echo "empty world, setting empty.world as default"
 		world_path="${src_path}/Tools/simulation/gazebo-classic/sitl_gazebo/worlds/empty.world"
 	fi


### PR DESCRIPTION
---

## Basic Info

| ------ | ----------- |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo 11, PX4 |

---

## Description of contribution in a few bullet points

In the original file, it first checks if $world is a file; if it is, it continues with the directory part. However, during the second check with the -d parameter, it verifies the existence of a directory. Since $world is a file, this check will return false, assigning the address to "empty.world" and resulting in the launch of an empty world.

If only the directory is provided, appending only ".world" to the path will be incorrect. An approach to enable the addition of the world by specifying its absolute path could solve this problem.

## Description of documentation updates required from your changes

"An example of how the .json file would be set up to launch the world.:

```python3
{
    "world": "/home/user/workspace/install/package/share/package/worlds/map.world",
    "drones": [
        {
            "model": "iris_dual_cam",
            "name:": "drone0",
            "pose": [
                53.462,
                -10.734,
                0.004,
                -1.6
            ]
        }
    ]
}
```


---

