### PR TITLE
[as2_motion_controller] Add trajectory reference to actuators commands

### DIFF
--- a/as2_core/include/as2_core/aerial_platform.hpp
+++ b/as2_core/include/as2_core/aerial_platform.hpp
@@ -49,6 +49,7 @@
 #include "as2_msgs/msg/platform_info.hpp"
 #include "as2_msgs/msg/platform_status.hpp"
 #include "as2_msgs/msg/thrust.hpp"
+#include "as2_msgs/msg/trajectory_point.hpp"
 #include "as2_msgs/srv/list_control_modes.hpp"
 #include "as2_msgs/srv/set_control_mode.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -85,6 +86,7 @@ protected:
   float cmd_freq_;
   float info_freq_;
 
+  as2_msgs::msg::TrajectoryPoint command_trajectory_msg_;
   geometry_msgs::msg::PoseStamped command_pose_msg_;
   geometry_msgs::msg::TwistStamped command_twist_msg_;
   as2_msgs::msg::Thrust command_thrust_msg_;
@@ -273,6 +275,7 @@ protected:
 private:
   rclcpp::Publisher<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_pub_;
 
+  rclcpp::Subscription<as2_msgs::msg::TrajectoryPoint>::SharedPtr trajectory_command_sub_;
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_command_sub_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_command_sub_;
   rclcpp::Subscription<as2_msgs::msg::Thrust>::SharedPtr thrust_command_sub_;

--- a/as2_core/include/as2_core/names/topics.hpp
+++ b/as2_core/include/as2_core/names/topics.hpp
@@ -81,10 +81,11 @@ const std::string traj_gen_info = "traj_gen/info";
 const rclcpp::QoS traj_gen_qos  = rclcpp::QoS(10);
 }  // namespace motion_reference
 namespace actuator_command {
-const rclcpp::QoS qos    = rclcpp::SensorDataQoS();
-const std::string pose   = "actuator_command/pose";
-const std::string twist  = "actuator_command/twist";
-const std::string thrust = "actuator_command/thrust";
+const rclcpp::QoS qos        = rclcpp::SensorDataQoS();
+const std::string pose       = "actuator_command/pose";
+const std::string twist      = "actuator_command/twist";
+const std::string thrust     = "actuator_command/thrust";
+const std::string trajectory = "actuator_command/trajectory";
 }  // namespace actuator_command
 namespace platform {
 const rclcpp::QoS qos  = rclcpp::QoS(10);

--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -60,6 +60,13 @@ void AerialPlatform::initialize() {
 
     this->loadControlModes(control_modes_file);
 
+    trajectory_command_sub_ = this->create_subscription<as2_msgs::msg::TrajectoryPoint>(
+        this->generate_global_name(as2_names::topics::actuator_command::trajectory),
+        as2_names::topics::actuator_command::qos,
+        [this](const as2_msgs::msg::TrajectoryPoint::ConstSharedPtr msg) {
+          this->command_trajectory_msg_ = *msg.get();
+          has_new_references_           = true;
+        });
     pose_command_sub_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
         this->generate_global_name(as2_names::topics::actuator_command::pose),
         as2_names::topics::actuator_command::qos,

--- a/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
@@ -106,6 +106,7 @@ private:
   rclcpp::Subscription<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_sub_;
   rclcpp::Subscription<as2_msgs::msg::TrajectoryPoint>::SharedPtr ref_traj_sub_;
 
+  rclcpp::Publisher<as2_msgs::msg::TrajectoryPoint>::SharedPtr trajectory_pub_;
   rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr thrust_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | as2_multirotor_simulator |

---

## Description of contribution in a few bullet points

* Now `as2_motion_controller` can bypass trajectory references and send them to `as2_aerial_platforms`
* Aerial platform now subscribe to trajectory commands

## Description of documentation updates required from your changes

* Motion Controller and Aerial Platform topics and msg must be updated.
