### PR TITLE
[as2_platform_crazyflie] Fix wrong sensor name for multiranger deck

### DIFF
--- a/as2_aerial_platforms/as2_platform_crazyflie/src/crazyflie_platform.cpp
+++ b/as2_aerial_platforms/as2_platform_crazyflie/src/crazyflie_platform.cpp
@@ -303,8 +303,9 @@ void CrazyfliePlatform::configureSensors() {
   battery_sensor_ptr_ =
       std::make_unique<as2::sensors::Sensor<sensor_msgs::msg::BatteryState>>("battery", this);
   if (enable_multiranger_) {
+    // TODO: Create new laser scan sensor that gathers lidar/scan and lidar/points
     multi_ranger_sensor_ptr_ =
-        std::make_unique<as2::sensors::Sensor<sensor_msgs::msg::LaserScan>>("scan", this);
+        std::make_unique<as2::sensors::Sensor<sensor_msgs::msg::LaserScan>>("lidar/scan", this);
   }
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #340  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Crazyflie |

---

## Description of contribution in a few bullet points

* Fix bug on sensor naming

---

## Future work that may be required in bullet points

* See #341 