### PR TITLE
Add node interfaces to motion_ref_handlers and sync clients

### DIFF
--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -59,11 +59,26 @@ namespace as2 {
 namespace motionReferenceHandlers {
 class BasicMotionReferenceHandler {
 public:
+  BasicMotionReferenceHandler(
+      rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+      rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+      rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+      rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+      rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+      rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+      rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+      const std::string &ns = "");
   BasicMotionReferenceHandler(as2::Node *as2_ptr, const std::string &ns = "");
   ~BasicMotionReferenceHandler();
 
 protected:
-  as2::Node *node_ptr_;
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr_;
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr_;
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr_;
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr_;
+  rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr_;
+  rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr_;
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr_;
   std::string namespace_;
 
   as2_msgs::msg::TrajectoryPoint command_trajectory_msg_;

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/hover_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/hover_motion.hpp
@@ -56,6 +56,26 @@ class HoverMotion : public as2::motionReferenceHandlers::BasicMotionReferenceHan
 public:
   /**
    * @brief HoverMotion Constructor.
+   * @param node_base_ptr rclcpp::node_interfaces::NodeBaseInterface::SharedPtr pointer.
+   * @param node_graph_ptr rclcpp::node_interfaces::NodeGraphInterface::SharedPtr pointer.
+   * @param node_parameters_ptr rclcpp::node_interfaces::NodeParametersInterface::SharedPtr pointer.
+   * @param node_topics_ptr rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr pointer.
+   * @param node_services_ptr rclcpp::node_interfaces::NodeServicesInterface::SharedPtr pointer.
+   * @param node_clock_ptr rclcpp::node_interfaces::NodeClockInterface::SharedPtr pointer.
+   * @param node_logging_ptr rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr pointer.
+   * @param ns namespace.
+   */
+  HoverMotion(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+              rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+              rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+              rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+              rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+              rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+              rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+              const std::string &ns = "");
+
+  /**
+   * @brief HoverMotion Constructor.
    * @param node as2::Node pointer.
    */
   HoverMotion(as2::Node *node_ptr, const std::string &ns = "");

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/position_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/position_motion.hpp
@@ -58,6 +58,26 @@ class PositionMotion : public as2::motionReferenceHandlers::BasicMotionReference
 public:
   /**
    * @brief PositionMotion Constructor.
+   * @param node_base_ptr rclcpp::node_interfaces::NodeBaseInterface::SharedPtr pointer.
+   * @param node_graph_ptr rclcpp::node_interfaces::NodeGraphInterface::SharedPtr pointer.
+   * @param node_parameters_ptr rclcpp::node_interfaces::NodeParametersInterface::SharedPtr pointer.
+   * @param node_topics_ptr rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr pointer.
+   * @param node_services_ptr rclcpp::node_interfaces::NodeServicesInterface::SharedPtr pointer.
+   * @param node_clock_ptr rclcpp::node_interfaces::NodeClockInterface::SharedPtr pointer.
+   * @param node_logging_ptr rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr pointer.
+   * @param ns namespace.
+   */
+  PositionMotion(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+                 rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+                 rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+                 rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+                 rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+                 rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+                 rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+                 const std::string &ns = "");
+
+  /**
+   * @brief PositionMotion Constructor.
    * @param node as2::Node pointer.
    */
   PositionMotion(as2::Node *node_ptr, const std::string &ns = "");

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_in_a_plane_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_in_a_plane_motion.hpp
@@ -57,6 +57,27 @@ namespace motionReferenceHandlers {
 class SpeedInAPlaneMotion : public as2::motionReferenceHandlers::BasicMotionReferenceHandler {
 public:
   /**
+   * @brief SpeedInAPlaneMotion Constructor.
+   * @param node_base_ptr rclcpp::node_interfaces::NodeBaseInterface::SharedPtr pointer.
+   * @param node_graph_ptr rclcpp::node_interfaces::NodeGraphInterface::SharedPtr pointer.
+   * @param node_parameters_ptr rclcpp::node_interfaces::NodeParametersInterface::SharedPtr pointer.
+   * @param node_topics_ptr rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr pointer.
+   * @param node_services_ptr rclcpp::node_interfaces::NodeServicesInterface::SharedPtr pointer.
+   * @param node_clock_ptr rclcpp::node_interfaces::NodeClockInterface::SharedPtr pointer.
+   * @param node_logging_ptr rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr pointer.
+   * @param ns namespace.
+   */
+  SpeedInAPlaneMotion(
+      rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+      rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+      rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+      rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+      rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+      rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+      rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+      const std::string &ns = "");
+
+  /**
    * @brief PositionMotion Constructor.
    * @param node as2::Node pointer.
    */

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/speed_motion.hpp
@@ -57,6 +57,26 @@ namespace motionReferenceHandlers {
 class SpeedMotion : public as2::motionReferenceHandlers::BasicMotionReferenceHandler {
 public:
   /**
+   * @brief SpeedMotion Constructor.
+   * @param node_base_ptr rclcpp::node_interfaces::NodeBaseInterface::SharedPtr pointer.
+   * @param node_graph_ptr rclcpp::node_interfaces::NodeGraphInterface::SharedPtr pointer.
+   * @param node_parameters_ptr rclcpp::node_interfaces::NodeParametersInterface::SharedPtr pointer.
+   * @param node_topics_ptr rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr pointer.
+   * @param node_services_ptr rclcpp::node_interfaces::NodeServicesInterface::SharedPtr pointer.
+   * @param node_clock_ptr rclcpp::node_interfaces::NodeClockInterface::SharedPtr pointer.
+   * @param node_logging_ptr rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr pointer.
+   * @param ns namespace.
+   */
+  SpeedMotion(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+              rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+              rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+              rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+              rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+              rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+              rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+              const std::string &ns = "");
+
+  /**
    * @brief PositionMotion Constructor.
    * @param node as2::Node pointer.
    */

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/trajectory_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/trajectory_motion.hpp
@@ -51,6 +51,26 @@ namespace motionReferenceHandlers {
 class TrajectoryMotion : public as2::motionReferenceHandlers::BasicMotionReferenceHandler {
 public:
   /**
+   * @brief TrajectoryMotion Constructor.
+   * @param node_base_ptr rclcpp::node_interfaces::NodeBaseInterface::SharedPtr pointer.
+   * @param node_graph_ptr rclcpp::node_interfaces::NodeGraphInterface::SharedPtr pointer.
+   * @param node_parameters_ptr rclcpp::node_interfaces::NodeParametersInterface::SharedPtr pointer.
+   * @param node_topics_ptr rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr pointer.
+   * @param node_services_ptr rclcpp::node_interfaces::NodeServicesInterface::SharedPtr pointer.
+   * @param node_clock_ptr rclcpp::node_interfaces::NodeClockInterface::SharedPtr pointer.
+   * @param node_logging_ptr rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr pointer.
+   * @param ns namespace.
+   */
+  TrajectoryMotion(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+                   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+                   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+                   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+                   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+                   rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+                   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+                   const std::string &ns = "");
+
+  /**
    * @brief TrajectoryMotion constructor.
    * @param node as2::Node pointer.
    */

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -50,7 +50,7 @@ BasicMotionReferenceHandler::BasicMotionReferenceHandler(
     : node_base_ptr_(node_base_ptr), node_graph_ptr_(node_graph_ptr),
       node_parameters_ptr_(node_parameters_ptr), node_topics_ptr_(node_topics_ptr),
       node_services_ptr_(node_services_ptr), node_clock_ptr_(node_clock_ptr),
-      node_logging_ptr_(node_logging_ptr) {
+      node_logging_ptr_(node_logging_ptr), namespace_(ns) {
   if (number_of_instances_ == 0) {
     namespace_ = ns == "" ? ns : "/" + ns + "/";
 

--- a/as2_motion_reference_handlers/src/hover_motion.cpp
+++ b/as2_motion_reference_handlers/src/hover_motion.cpp
@@ -38,12 +38,37 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-HoverMotion::HoverMotion(as2::Node *node_ptr, const std::string &ns)
-    : BasicMotionReferenceHandler(node_ptr, ns) {
+HoverMotion::HoverMotion(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+    rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+    const std::string &ns)
+    : BasicMotionReferenceHandler(node_base_ptr,
+                                  node_graph_ptr,
+                                  node_parameters_ptr,
+                                  node_topics_ptr,
+                                  node_services_ptr,
+                                  node_clock_ptr,
+                                  node_logging_ptr,
+                                  ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::HOVER;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
-};
+}
+
+HoverMotion::HoverMotion(as2::Node *node_ptr, const std::string &ns)
+    : HoverMotion(node_ptr->get_node_base_interface(),
+                  node_ptr->get_node_graph_interface(),
+                  node_ptr->get_node_parameters_interface(),
+                  node_ptr->get_node_topics_interface(),
+                  node_ptr->get_node_services_interface(),
+                  node_ptr->get_node_clock_interface(),
+                  node_ptr->get_node_logging_interface(),
+                  ns) {}
 
 bool HoverMotion::sendHover() {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
@@ -51,5 +76,6 @@ bool HoverMotion::sendHover() {
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
   return checkMode();
 }
+
 }  // namespace motionReferenceHandlers
 }  // namespace as2

--- a/as2_motion_reference_handlers/src/position_motion.cpp
+++ b/as2_motion_reference_handlers/src/position_motion.cpp
@@ -54,7 +54,8 @@ PositionMotion::PositionMotion(
                                   node_topics_ptr,
                                   node_services_ptr,
                                   node_clock_ptr,
-                                  node_logging_ptr) {
+                                  node_logging_ptr,
+                                  ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::POSITION;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;

--- a/as2_motion_reference_handlers/src/position_motion.cpp
+++ b/as2_motion_reference_handlers/src/position_motion.cpp
@@ -38,12 +38,37 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-PositionMotion::PositionMotion(as2::Node *node_ptr, const std::string &ns)
-    : BasicMotionReferenceHandler(node_ptr, ns) {
+
+PositionMotion::PositionMotion(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+    rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+    const std::string &ns)
+    : BasicMotionReferenceHandler(node_base_ptr,
+                                  node_graph_ptr,
+                                  node_parameters_ptr,
+                                  node_topics_ptr,
+                                  node_services_ptr,
+                                  node_clock_ptr,
+                                  node_logging_ptr) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::POSITION;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
-};
+}
+
+PositionMotion::PositionMotion(as2::Node *node_ptr, const std::string &ns)
+    : PositionMotion(node_ptr->get_node_base_interface(),
+                     node_ptr->get_node_graph_interface(),
+                     node_ptr->get_node_parameters_interface(),
+                     node_ptr->get_node_topics_interface(),
+                     node_ptr->get_node_services_interface(),
+                     node_ptr->get_node_clock_interface(),
+                     node_ptr->get_node_logging_interface(),
+                     ns) {}
 
 bool PositionMotion::ownSendCommand() {
   bool send_pose  = sendPoseCommand();
@@ -87,7 +112,7 @@ bool PositionMotion::sendPositionCommandWithYawAngle(const std::string &frame_id
   twist_msg.twist.linear.y  = vy;
   twist_msg.twist.linear.z  = vz;
 
-  rclcpp::Time stamp     = node_ptr_->now();
+  rclcpp::Time stamp     = node_clock_ptr_->get_clock()->now();
   pose_msg.header.stamp  = stamp;
   twist_msg.header.stamp = stamp;
 
@@ -98,7 +123,7 @@ bool PositionMotion::sendPositionCommandWithYawAngle(
     const geometry_msgs::msg::PoseStamped &pose,
     const geometry_msgs::msg::TwistStamped &twist) {
   if (pose.header.frame_id == "" || twist.header.frame_id == "") {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Frame id is empty");
+    RCLCPP_ERROR(node_logging_ptr_->get_logger(), "Frame id is empty");
     return false;
   }
 
@@ -131,7 +156,7 @@ bool PositionMotion::sendPositionCommandWithYawSpeed(const std::string &frame_id
   twist_msg.twist.linear.z  = vz;
   twist_msg.twist.angular.z = yaw_speed;
 
-  rclcpp::Time stamp     = node_ptr_->now();
+  rclcpp::Time stamp     = node_clock_ptr_->get_clock()->now();
   pose_msg.header.stamp  = stamp;
   twist_msg.header.stamp = stamp;
 
@@ -142,7 +167,7 @@ bool PositionMotion::sendPositionCommandWithYawSpeed(
     const geometry_msgs::msg::PoseStamped &pose,
     const geometry_msgs::msg::TwistStamped &twist) {
   if (pose.header.frame_id == "" || twist.header.frame_id == "") {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Frame id is empty");
+    RCLCPP_ERROR(node_logging_ptr_->get_logger(), "Frame id is empty");
     return false;
   }
   desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::YAW_SPEED;

--- a/as2_motion_reference_handlers/src/speed_in_a_plane_motion.cpp
+++ b/as2_motion_reference_handlers/src/speed_in_a_plane_motion.cpp
@@ -38,12 +38,37 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-SpeedInAPlaneMotion::SpeedInAPlaneMotion(as2::Node *node_ptr, const std::string &ns)
-    : BasicMotionReferenceHandler(node_ptr, ns) {
+
+SpeedInAPlaneMotion::SpeedInAPlaneMotion(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+    rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+    const std::string &ns)
+    : BasicMotionReferenceHandler(node_base_ptr,
+                                  node_graph_ptr,
+                                  node_parameters_ptr,
+                                  node_topics_ptr,
+                                  node_services_ptr,
+                                  node_clock_ptr,
+                                  node_logging_ptr) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
-};
+}
+
+SpeedInAPlaneMotion::SpeedInAPlaneMotion(as2::Node *node_ptr, const std::string &ns)
+    : SpeedInAPlaneMotion(node_ptr->get_node_base_interface(),
+                          node_ptr->get_node_graph_interface(),
+                          node_ptr->get_node_parameters_interface(),
+                          node_ptr->get_node_topics_interface(),
+                          node_ptr->get_node_services_interface(),
+                          node_ptr->get_node_clock_interface(),
+                          node_ptr->get_node_logging_interface(),
+                          ns) {}
 
 bool SpeedInAPlaneMotion::ownSendCommand() {
   bool send_pose  = sendPoseCommand();
@@ -73,7 +98,7 @@ bool SpeedInAPlaneMotion::sendSpeedInAPlaneCommandWithYawSpeed(
     const geometry_msgs::msg::PoseStamped &pose,
     const geometry_msgs::msg::TwistStamped &twist) {
   if (pose.header.frame_id == "" || twist.header.frame_id == "") {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Frame id is empty");
+    RCLCPP_ERROR(node_logging_ptr_->get_logger(), "Frame id is empty");
     return false;
   }
   desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::YAW_SPEED;
@@ -123,7 +148,7 @@ bool SpeedInAPlaneMotion::sendSpeedInAPlaneCommandWithYawAngle(
     const geometry_msgs::msg::PoseStamped &pose,
     const geometry_msgs::msg::TwistStamped &twist) {
   if (pose.header.frame_id == "" || twist.header.frame_id == "") {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Frame id is empty");
+    RCLCPP_ERROR(node_logging_ptr_->get_logger(), "Frame id is empty");
     return false;
   }
   desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::YAW_ANGLE;

--- a/as2_motion_reference_handlers/src/speed_in_a_plane_motion.cpp
+++ b/as2_motion_reference_handlers/src/speed_in_a_plane_motion.cpp
@@ -54,7 +54,8 @@ SpeedInAPlaneMotion::SpeedInAPlaneMotion(
                                   node_topics_ptr,
                                   node_services_ptr,
                                   node_clock_ptr,
-                                  node_logging_ptr) {
+                                  node_logging_ptr,
+                                  ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;

--- a/as2_motion_reference_handlers/src/speed_motion.cpp
+++ b/as2_motion_reference_handlers/src/speed_motion.cpp
@@ -38,12 +38,37 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-SpeedMotion::SpeedMotion(as2::Node *node_ptr, const std::string &ns)
-    : BasicMotionReferenceHandler(node_ptr, ns) {
+
+SpeedMotion::SpeedMotion(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+    rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+    const std::string &ns)
+    : BasicMotionReferenceHandler(node_base_ptr,
+                                  node_graph_ptr,
+                                  node_parameters_ptr,
+                                  node_topics_ptr,
+                                  node_services_ptr,
+                                  node_clock_ptr,
+                                  node_logging_ptr) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::SPEED;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
-};
+}
+
+SpeedMotion::SpeedMotion(as2::Node *node_ptr, const std::string &ns)
+    : SpeedMotion(node_ptr->get_node_base_interface(),
+                  node_ptr->get_node_graph_interface(),
+                  node_ptr->get_node_parameters_interface(),
+                  node_ptr->get_node_topics_interface(),
+                  node_ptr->get_node_services_interface(),
+                  node_ptr->get_node_clock_interface(),
+                  node_ptr->get_node_logging_interface(),
+                  ns) {}
 
 bool SpeedMotion::ownSendCommand() {
   bool send_pose  = sendPoseCommand();
@@ -78,7 +103,7 @@ bool SpeedMotion::sendSpeedCommandWithYawAngle(const std::string &frame_id_speed
   twist_msg.twist.linear.y  = vy;
   twist_msg.twist.linear.z  = vz;
 
-  rclcpp::Time stamp     = node_ptr_->now();
+  rclcpp::Time stamp     = node_clock_ptr_->get_clock()->now();
   pose_msg.header.stamp  = stamp;
   twist_msg.header.stamp = stamp;
 
@@ -88,7 +113,7 @@ bool SpeedMotion::sendSpeedCommandWithYawAngle(const std::string &frame_id_speed
 bool SpeedMotion::sendSpeedCommandWithYawAngle(const geometry_msgs::msg::PoseStamped &pose,
                                                const geometry_msgs::msg::TwistStamped &twist) {
   if (pose.header.frame_id == "" || twist.header.frame_id == "") {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Frame id is empty");
+    RCLCPP_ERROR(node_logging_ptr_->get_logger(), "Frame id is empty");
     return false;
   }
   desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::YAW_ANGLE;
@@ -110,7 +135,7 @@ bool SpeedMotion::sendSpeedCommandWithYawSpeed(const std::string &frame_id,
   twist_msg.twist.linear.z  = vz;
   twist_msg.twist.angular.z = yaw_speed;
 
-  rclcpp::Time stamp     = node_ptr_->now();
+  rclcpp::Time stamp     = node_clock_ptr_->get_clock()->now();
   twist_msg.header.stamp = stamp;
 
   return sendSpeedCommandWithYawSpeed(twist_msg);
@@ -118,7 +143,7 @@ bool SpeedMotion::sendSpeedCommandWithYawSpeed(const std::string &frame_id,
 
 bool SpeedMotion::sendSpeedCommandWithYawSpeed(const geometry_msgs::msg::TwistStamped &twist) {
   if (twist.header.frame_id == "") {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Frame id is empty");
+    RCLCPP_ERROR(node_logging_ptr_->get_logger(), "Frame id is empty");
     return false;
   }
   desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::YAW_SPEED;

--- a/as2_motion_reference_handlers/src/speed_motion.cpp
+++ b/as2_motion_reference_handlers/src/speed_motion.cpp
@@ -54,7 +54,8 @@ SpeedMotion::SpeedMotion(
                                   node_topics_ptr,
                                   node_services_ptr,
                                   node_clock_ptr,
-                                  node_logging_ptr) {
+                                  node_logging_ptr,
+                                  ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::SPEED;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;

--- a/as2_motion_reference_handlers/src/trajectory_motion.cpp
+++ b/as2_motion_reference_handlers/src/trajectory_motion.cpp
@@ -54,7 +54,8 @@ TrajectoryMotion::TrajectoryMotion(
                                   node_topics_ptr,
                                   node_services_ptr,
                                   node_clock_ptr,
-                                  node_logging_ptr) {
+                                  node_logging_ptr,
+                                  ns) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::YAW_ANGLE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::TRAJECTORY;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::LOCAL_ENU_FRAME;

--- a/as2_motion_reference_handlers/src/trajectory_motion.cpp
+++ b/as2_motion_reference_handlers/src/trajectory_motion.cpp
@@ -38,12 +38,37 @@
 
 namespace as2 {
 namespace motionReferenceHandlers {
-TrajectoryMotion::TrajectoryMotion(as2::Node *node_ptr, const std::string &ns)
-    : BasicMotionReferenceHandler(node_ptr, ns) {
+
+TrajectoryMotion::TrajectoryMotion(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_ptr,
+    rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_ptr,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_ptr,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_ptr,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_ptr,
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_ptr,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_ptr,
+    const std::string &ns)
+    : BasicMotionReferenceHandler(node_base_ptr,
+                                  node_graph_ptr,
+                                  node_parameters_ptr,
+                                  node_topics_ptr,
+                                  node_services_ptr,
+                                  node_clock_ptr,
+                                  node_logging_ptr) {
   desired_control_mode_.yaw_mode        = as2_msgs::msg::ControlMode::YAW_ANGLE;
   desired_control_mode_.control_mode    = as2_msgs::msg::ControlMode::TRAJECTORY;
   desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::LOCAL_ENU_FRAME;
 }
+
+TrajectoryMotion::TrajectoryMotion(as2::Node *node_ptr, const std::string &ns)
+    : TrajectoryMotion(node_ptr->get_node_base_interface(),
+                       node_ptr->get_node_graph_interface(),
+                       node_ptr->get_node_parameters_interface(),
+                       node_ptr->get_node_topics_interface(),
+                       node_ptr->get_node_services_interface(),
+                       node_ptr->get_node_clock_interface(),
+                       node_ptr->get_node_logging_interface(),
+                       ns) {}
 
 bool TrajectoryMotion::sendTrajectoryCommandWithYawAngle(const std::string &frame_id,
                                                          const double x,
@@ -57,12 +82,12 @@ bool TrajectoryMotion::sendTrajectoryCommandWithYawAngle(const std::string &fram
                                                          const double ay,
                                                          const double az) {
   if (frame_id == "") {
-    RCLCPP_ERROR(this->node_ptr_->get_logger(), "Frame id is empty");
+    RCLCPP_ERROR(this->node_logging_ptr_->get_logger(), "Frame id is empty");
     return false;
   }
 
   this->command_trajectory_msg_.header.frame_id = frame_id;
-  this->command_trajectory_msg_.header.stamp    = this->node_ptr_->now();
+  this->command_trajectory_msg_.header.stamp    = this->node_clock_ptr_->get_clock()->now();
 
   this->command_trajectory_msg_.yaw_angle = yaw_angle;
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #369 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Ignition |

---

## Description of contribution in a few bullet points

* Motion reference handlers and synchronous client uses node interfaces to extend compatibility to other Nodes (not only as2::Node). Constructors with as2::Node arguments are kept to maintain compatibility.

## Description of documentation updates required from your changes

* Update API with new methods
