### PR TITLE
Bug fixed, getPoseStamped function differs from timeout 0 and not 0

### DIFF
--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -230,8 +230,8 @@ geometry_msgs::msg::PoseStamped TfHandler::getPoseStamped(
   const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
   const std::chrono::nanoseconds timeout)
 {
+  // if-else needed for galactic 
   geometry_msgs::msg::TransformStamped transform;
-
   if (timeout != std::chrono::nanoseconds::zero()) {
     transform = tf_buffer_->lookupTransform(
       target_frame, tf2_ros::fromMsg(node_->get_clock()->now()), source_frame, time, "earth",

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -128,6 +128,7 @@ geometry_msgs::msg::PoseStamped TfHandler::convert(
   const std::chrono::nanoseconds timeout)
 {
   geometry_msgs::msg::PoseStamped pose_out;
+
   if (timeout != std::chrono::nanoseconds::zero()) {
     tf2::doTransform(
       _pose, pose_out,
@@ -169,6 +170,7 @@ geometry_msgs::msg::Vector3Stamped TfHandler::convert(
   const std::chrono::nanoseconds timeout)
 {
   geometry_msgs::msg::Vector3Stamped vector_out;
+
   if (timeout != std::chrono::nanoseconds::zero()) {
     tf2::doTransform(
       _vector, vector_out,
@@ -193,6 +195,7 @@ nav_msgs::msg::Path TfHandler::convert(
   const std::chrono::nanoseconds timeout)
 {
   nav_msgs::msg::Path path_out;
+
   for (auto & pose : _path.poses) {
     geometry_msgs::msg::PoseStamped pose_out;
     if (timeout != std::chrono::nanoseconds::zero()) {
@@ -227,9 +230,17 @@ geometry_msgs::msg::PoseStamped TfHandler::getPoseStamped(
   const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
   const std::chrono::nanoseconds timeout)
 {
-  auto transform = tf_buffer_->lookupTransform(
-    target_frame, tf2_ros::fromMsg(node_->get_clock()->now()), source_frame, time, "earth",
-    timeout);
+  geometry_msgs::msg::TransformStamped transform;
+
+  if (timeout != std::chrono::nanoseconds::zero()) {
+    transform = tf_buffer_->lookupTransform(
+      target_frame, tf2_ros::fromMsg(node_->get_clock()->now()), source_frame, time, "earth",
+      timeout);
+  } else {
+    transform = tf_buffer_->lookupTransform(
+      target_frame, tf2::TimePointZero, source_frame, tf2::TimePointZero, "earth",
+      timeout);
+  }
 
   geometry_msgs::msg::PoseStamped pose;
   pose.header.frame_id = target_frame;


### PR DESCRIPTION
Works on Galactic when timeout parameter is 0.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #392 |
| ROS2 version tested on |Humble, Galactic|
| Aerial platform tested on |Gazebo, Crazyflie, DJI_OSDK|

---

## Description of contribution in a few bullet points

* Timeout 0 parameter now works in Galactic
