### PR TITLE
[as2_python_api] Jenkins test fail

### DIFF
--- a/as2_python_api/hooks/resource_paths.sh
+++ b/as2_python_api/hooks/resource_paths.sh
@@ -1,3 +1,3 @@
-ament_prepend_unique_value AS2_MODULES_PATH "$COLCON_PREFIX_PATH/share/as2_python_api/modules"
+ament_prepend_unique_value AS2_MODULES_PATH "$COLCON_CURRENT_PREFIX/share/as2_python_api/modules"
 
-ament_prepend_unique_value LD_LIBRARY_PATH "$COLCON_PREFIX_PATH/lib"
+ament_prepend_unique_value LD_LIBRARY_PATH "$COLCON_CURRENT_PREFIX/lib"


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #402 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Hook links AS2_MODULES_PATH to `~/as2_ws/install/as2_python_api/share/as2_python_api/modules`, but sources are not installed when colcon building. The workaround is always looking at default as2 modules folder before looking at env var.  
