### PR TITLE
get quaternion stamped included in tf utils

### DIFF
--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -225,7 +225,32 @@ public:
    * @param target_frame the target frame
    * @param source_frame the source frame
    * @param time the time of the transform
-   * @return geometry_msgs::msg::TransformStamped
+   * @return geometry_msgs::msg::QuaternionStamped
+   * @throw tf2::TransformException if the transform is not available
+   */
+  geometry_msgs::msg::QuaternionStamped getQuaternionStamped(
+    const std::string & target_frame, const std::string & source_frame,
+    const tf2::TimePoint & time = tf2::TimePointZero,
+    const std::chrono::nanoseconds timeout = TF_TIMEOUT);
+
+  /**
+   * @brief obtain a TransformStamped from the TF_buffer
+   * @param target_frame the target frame
+   * @param source_frame the source frame
+   * @param time the time of the transform
+   * @return geometry_msgs::msg::QuaternionStamped
+   * @throw tf2::TransformException if the transform is not available
+   */
+  geometry_msgs::msg::QuaternionStamped getQuaternionStamped(
+    const std::string & target_frame, const std::string & source_frame, const rclcpp::Time & time,
+    const std::chrono::nanoseconds timeout = TF_TIMEOUT);
+
+  /**
+   * @brief obtain a TransformStamped from the TF_buffer
+   * @param target_frame the target frame
+   * @param source_frame the source frame
+   * @param time the time of the transform
+   * @return geometry_msgs::msg::QuaternionStamped
    * @throw tf2::TransformException if the transform is not available
    */
   geometry_msgs::msg::TransformStamped getTransform(

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -280,6 +280,38 @@ geometry_msgs::msg::PoseStamped TfHandler::getPoseStamped(
   return pose;
 }
 
+geometry_msgs::msg::QuaternionStamped TfHandler::getQuaternionStamped(
+  const std::string & target_frame, const std::string & source_frame, const rclcpp::Time & time,
+  const std::chrono::nanoseconds timeout)
+{
+  return getQuaternionStamped(target_frame, source_frame, tf2_ros::fromMsg(time), timeout);
+}
+
+geometry_msgs::msg::QuaternionStamped TfHandler::getQuaternionStamped(
+  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+  const std::chrono::nanoseconds timeout)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  if (timeout != std::chrono::nanoseconds::zero()) {
+    transform = tf_buffer_->lookupTransform(
+      target_frame, tf2_ros::fromMsg(node_->get_clock()->now()), source_frame, time, "earth",
+      timeout);
+  } else {
+    transform = tf_buffer_->lookupTransform(
+      target_frame, tf2::TimePointZero, source_frame, tf2::TimePointZero, "earth",
+      timeout);
+  }
+
+  geometry_msgs::msg::QuaternionStamped quaternion;
+  quaternion.header.frame_id = target_frame;
+  quaternion.header.stamp = transform.header.stamp;
+  quaternion.quaternion.x = transform.transform.rotation.x;
+  quaternion.quaternion.y = transform.transform.rotation.y;
+  quaternion.quaternion.z = transform.transform.rotation.z;
+  quaternion.quaternion.w = transform.transform.rotation.w;
+  return quaternion;
+}
+
 geometry_msgs::msg::TransformStamped TfHandler::getTransform(
   const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time)
 {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |#425 |
| ROS2 version tested on | Humble|
| Aerial platform tested on | None|

---

## Description of contribution in a few bullet points

* get quaternion stamped included in tf utils
* Also fixed a typo in a parameter name in as2_motion_controller_manager


