### PR TITLE
[as2_gazebo_assets] Fix Crazyflie Model

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
@@ -14,7 +14,7 @@ Copyright (c) 2022 Bitcraze
 <sdf version="1.8">
     <model name='{{ namespace }}'>
         <pose>0 0 0.0 0 0 3.14</pose>
-        <link name="crazyflie/body">
+        <link name="base_link">
         <inertial>
             <pose>0 0 0 0 0 0</pose>
             <mass>0.025</mass>
@@ -27,7 +27,7 @@ Copyright (c) 2022 Bitcraze
                 <izz>0.000029262</izz>
             </inertia>
         </inertial>
-        <collision name="crazyflie/body_collision">
+        <collision name="base_link_collision">
             <pose>0 0 0 0 0 0</pose>
             <geometry>
                 <box>
@@ -35,7 +35,7 @@ Copyright (c) 2022 Bitcraze
                 </box>
             </geometry>
         </collision>
-        <visual name="crazyflie/body_visual">
+        <visual name="base_link_visual">
             <pose>0 0 0 0 -0 0</pose>
             <geometry>
                 <mesh>
@@ -143,7 +143,7 @@ Copyright (c) 2022 Bitcraze
         </link>
         <joint name="crazyflie/m1_joint" type="revolute">
             <child>crazyflie/m1_prop</child>
-            <parent>crazyflie/body</parent>
+            <parent>base_link</parent>
             <axis>
                 <xyz>0 0 1</xyz>
                 <limit>
@@ -159,7 +159,7 @@ Copyright (c) 2022 Bitcraze
         </joint>
         <joint name="crazyflie/m2_joint" type="revolute">
             <child>crazyflie/m2_prop</child>
-            <parent>crazyflie/body</parent>
+            <parent>base_link</parent>
             <axis>
                 <xyz>0 0 1</xyz>
                 <limit>
@@ -175,7 +175,7 @@ Copyright (c) 2022 Bitcraze
         </joint>
         <joint name="crazyflie/m3_joint" type="revolute">
             <child>crazyflie/m3_prop</child>
-            <parent>crazyflie/body</parent>
+            <parent>base_link</parent>
             <axis>
                 <xyz>0 0 1</xyz>
                 <limit>
@@ -191,7 +191,7 @@ Copyright (c) 2022 Bitcraze
         </joint>
         <joint name="crazyflie/m4_joint" type="revolute">
             <child>crazyflie/m4_prop</child>
-            <parent>crazyflie/body</parent>
+            <parent>base_link</parent>
             <axis>
                 <xyz>0 0 1</xyz>
                 <limit>
@@ -206,7 +206,7 @@ Copyright (c) 2022 Bitcraze
             </axis>
         </joint>
 
-        <plugin filename="ignition-gazebo-pose-publisher-system"
+    <plugin filename="ignition-gazebo-pose-publisher-system"
         name="ignition::gazebo::systems::PosePublisher">
         <publish_link_pose>true</publish_link_pose>
         <publish_sensor_pose>true</publish_sensor_pose>
@@ -216,13 +216,13 @@ Copyright (c) 2022 Bitcraze
         <publish_model_pose>false</publish_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
-        <static_update_frequency>1</static_update_frequency>
+        <static_update_frequency>100</static_update_frequency>
     </plugin>
 
       <plugin
         filename="ignition-gazebo-multicopter-motor-model-system"
         name="ignition::gazebo::systems::MulticopterMotorModel">
-        <robotNamespace>{{ namespace }}</robotNamespace>
+        <robotNamespace>model/{{ namespace }}</robotNamespace>
         <jointName>crazyflie/m1_joint</jointName>
         <linkName>crazyflie/m1_prop</linkName>
         <turningDirection>ccw</turningDirection>
@@ -231,7 +231,7 @@ Copyright (c) 2022 Bitcraze
         <maxRotVelocity>2618</maxRotVelocity>
         <motorConstant>1.28192e-08</motorConstant>
         <momentConstant>0.005964552</momentConstant>
-        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <commandSubTopic>command/motor_speed</commandSubTopic>
         <motorNumber>0</motorNumber>
         <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
         <rollingMomentCoefficient>0.0000001</rollingMomentCoefficient>
@@ -242,7 +242,7 @@ Copyright (c) 2022 Bitcraze
       <plugin
         filename="ignition-gazebo-multicopter-motor-model-system"
         name="ignition::gazebo::systems::MulticopterMotorModel">
-        <robotNamespace>{{ namespace }}</robotNamespace>
+        <robotNamespace>model/{{ namespace }}</robotNamespace>
         <jointName>crazyflie/m2_joint</jointName>
         <linkName>crazyflie/m2_prop</linkName>
         <turningDirection>cw</turningDirection>
@@ -251,7 +251,7 @@ Copyright (c) 2022 Bitcraze
         <maxRotVelocity>2618</maxRotVelocity>
         <motorConstant>1.28192e-08</motorConstant>
         <momentConstant>0.005964552</momentConstant>
-        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <commandSubTopic>command/motor_speed</commandSubTopic>
         <motorNumber>1</motorNumber>
         <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
         <rollingMomentCoefficient>0.0000001</rollingMomentCoefficient>
@@ -262,7 +262,7 @@ Copyright (c) 2022 Bitcraze
       <plugin
         filename="ignition-gazebo-multicopter-motor-model-system"
         name="ignition::gazebo::systems::MulticopterMotorModel">
-        <robotNamespace>{{ namespace }}</robotNamespace>
+        <robotNamespace>{model/{ namespace }}</robotNamespace>
         <jointName>crazyflie/m3_joint</jointName>
         <linkName>crazyflie/m3_prop</linkName>
         <turningDirection>ccw</turningDirection>
@@ -271,7 +271,7 @@ Copyright (c) 2022 Bitcraze
         <maxRotVelocity>2618</maxRotVelocity>
         <motorConstant>1.28192e-08</motorConstant>
         <momentConstant>0.005964552</momentConstant>
-        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <commandSubTopic>command/motor_speed</commandSubTopic>
         <motorNumber>2</motorNumber>
         <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
         <rollingMomentCoefficient>0.0000001</rollingMomentCoefficient>
@@ -282,7 +282,7 @@ Copyright (c) 2022 Bitcraze
       <plugin
         filename="ignition-gazebo-multicopter-motor-model-system"
         name="ignition::gazebo::systems::MulticopterMotorModel">
-        <robotNamespace>{{ namespace }}</robotNamespace>
+        <robotNamespace>model/{{ namespace }}</robotNamespace>
         <jointName>crazyflie/m4_joint</jointName>
         <linkName>crazyflie/m4_prop</linkName>
         <turningDirection>cw</turningDirection>
@@ -291,7 +291,7 @@ Copyright (c) 2022 Bitcraze
         <maxRotVelocity>2618</maxRotVelocity>
         <motorConstant>1.28192e-08</motorConstant>
         <momentConstant>0.005964552</momentConstant>
-        <commandSubTopic>gazebo/command/motor_speed</commandSubTopic>
+        <commandSubTopic>command/motor_speed</commandSubTopic>
         <motorNumber>3</motorNumber>
         <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
         <rollingMomentCoefficient>0.000001</rollingMomentCoefficient>
@@ -303,17 +303,18 @@ Copyright (c) 2022 Bitcraze
         filename="ignition-gazebo-odometry-publisher-system"
         name="ignition::gazebo::systems::OdometryPublisher">
         <dimensions>3</dimensions>
+        <odom_publish_frequency>100</odom_publish_frequency>
       </plugin>
 
       <!--Multicopter velocity controller-->
       <plugin
         filename="ignition-gazebo-multicopter-control-system"
         name="ignition::gazebo::systems::MulticopterVelocityControl">
-        <robotNamespace>{{ namespace }}</robotNamespace>
+        <robotNamespace>model/{{ namespace }}</robotNamespace>
         <commandSubTopic>cmd_vel</commandSubTopic>
-        <motorControlPubTopic>gazebo/command/motor_speed</motorControlPubTopic>
-        <enableSubTopic>enable</enableSubTopic>
-        <comLinkName>crazyflie/body</comLinkName>
+        <motorControlPubTopic>command/motor_speed</motorControlPubTopic>
+        <enableSubTopic>velocity_controller/enable</enableSubTopic>
+        <comLinkName>base_link</comLinkName>
         <velocityGain>1000 1000 5000</velocityGain>
         <attitudeGain>0.5 0.5 0.5</attitudeGain>
         <angularRateGain>1.5 1.5 1.5</angularRateGain>

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -58,6 +58,7 @@ class DroneTypeEnum(str, Enum):
 
     QUADROTOR = "quadrotor_base"
     HEXROTOR = "hexrotor_base"
+    CRAZYFLIE = "crazyflie"
 
 
 class Drone(Entity):


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | (#421 ) |
| ROS2 version tested on | (Humble) |
| Aerial platform tested on | (Gazebo Fortress) |

---

## Description of contribution in a few bullet points

This PR fixes issues with the existing crazyflie model not being able to fly and connects it up to the Aerostack2 api. 
Changes Crazyflie model names and plugins to mirror that of the quadcopter_base. 

It would be good to triple check it does work for others too. 

## Description of documentation updates required from your changes

* Renamed the base_link of the crazyflie from `crazyflie/body` to `base_link`
  * This is required as the motion_behaviour plugins seem to be hardcoded to`base_link` - see #421 for details 
* `static_update_frequency` of `ignition-gazebo-pose-publisher-system` increased to 100 as expected by controllers 
* `ignition-gazebo-multicopter-motor-model-system` plugin:
  * `commandSubTopic` changed from `gazebo/command/motor_speed` to `command/motor_speed` 
  * `robotNamespace changed from `{{namespace}}` to `model/{{namespace}}`
* `ignition-gazebo-multicopter-control-system` plugin `enable_sub_topic` now set to `velocity_controller/enable`
* Crazyflie added to `DroneTypeEnum` in `as2_gazebo_assets/model/drone.py` 

Changes tested by building and using the `project_crazyflie` example. To enable in the `world.json` change the `model_type: crazyflie`

Example world.json:
```json
{
    "world_name": "empty",
    "drones": [
        {
            "model_type": "crazyflie",
            "model_name": "cf0",
            "xyz": [
                0.5,
                0.5,
                0.3
            ],
            "rpy": [
                0,
                0,
                0.0
            ],
            "flight_time": 60
        }
    ]
}
```

Running the mission.py, the model arms and takesoff, but appears to be very poor at actually flying to targets. Probably needs some tuning.

---

## Future work that may be required in bullet points

* Probably a good idea to take the `base_link_id` as a parameter for the `as2_behaviors_motion` so the base link is not hardcoded to `base_link`. 
* Crazyflie model probably needs PID tuning for default flight. 