### PR TITLE
Added local frame to simulated gimbal msg

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/src/gimbal_bridge.cpp
+++ b/as2_simulation_assets/as2_gazebo_assets/src/gimbal_bridge.cpp
@@ -162,6 +162,8 @@ private:
       }
     }
     as2::frame::eulerToQuaternion(roll, pitch, yaw, gimbal_attitude_msg.quaternion);
+    gimbal_attitude_msg.header.frame_id         = model_name_ + "/" + gimbal_name_;
+    gimbal_angular_velocity_msg.header.frame_id = model_name_ + "/" + gimbal_name_;
     gimbal_attitude_pub_->publish(gimbal_attitude_msg);
     gimbal_angular_velocity_pub_->publish(gimbal_angular_velocity_msg);
   };


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #431  |
| ROS2 version tested on |Humble|
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Added local frame to gimbal attitude and speed msgs

---

## Future work that may be required in bullet points

* Gimbal's displayed position frame is still incorrect, as it is relative to its initial position, it should be some kind of /gimbal/odom, but right now it is set asthe same as the speed. 
