### PR TITLE
[as2_core] Fix adding as2_core tests

### DIFF
--- a/as2_core/tests/CMakeLists.txt
+++ b/as2_core/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(ament_cmake_gtest REQUIRED)
 
-file(GLOB TEST_SOURCES tests/*.cpp)
+file(GLOB TEST_SOURCES *.cpp)
 
 # create a test executable for each test file
 foreach(TEST_SOURCE ${TEST_SOURCES})


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* When using [add_subdirectory](https://cmake.org/cmake/help/latest/command/add_subdirectory.html) in `CMakeLists.txt`, paths are relative to the included `CMakeLists.txt`
* Adjust the path for the tests.