### PR TITLE
[as2_motion_controller_manager] Publish speed limits when bypassing and control mode is Position

### DIFF
--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -711,6 +711,7 @@ void ControllerHandler::publishCommand()
       break;
     case as2_msgs::msg::ControlMode::POSITION:
       pose_pub_->publish(command_pose_);
+      twist_pub_->publish(command_twist_);  // For twist limits
       break;
     case as2_msgs::msg::ControlMode::SPEED:
       twist_pub_->publish(command_twist_);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | (add issues here #1) |
| ROS2 version tested on | (Humble, Galactic, Other) |
| Aerial platform tested on | (Gazebo, Crazyflie, Tello, PX4, Other) |

---

## Description of contribution in a few bullet points

* Publish speed limits when bypassing and control mode is Position, so the platform can use it