### PR TITLE
[as2_gazebo_assets] Sensor model name and sensor link name were swapped in camera bridges

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -73,10 +73,10 @@ class CameraTypeEnum(str, Enum):
         :return: list with bridges
         """
         bridges = [
-            gz_bridges.image(world_name, model_name, sensor_name,
-                             payload, model_prefix),
-            gz_bridges.camera_info(world_name, model_name,
-                                   sensor_name, payload, model_prefix)
+            gz_bridges.image(world_name, model_name, payload,
+                             sensor_name, model_prefix),
+            gz_bridges.camera_info(world_name, model_name, payload,
+                                   sensor_name, model_prefix)
         ]
         return bridges
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #443  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Sensor name and payload were swapped while creating gz-ros bridge so gz-topic was wrong.
* From `/world/empty/model/drone0/model/hd_camera/link/hd_camera1/sensor/camera/image` to `/world/empty/model/drone0/model/hd_camera1/link/hd_camera/sensor/camera/image`. Notice that model name and link name was mixed.
