### PR TITLE
Added camera_optical link and camera_optical joint to hd_camera

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/models/hd_camera/hd_camera.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/hd_camera/hd_camera.sdf
@@ -44,9 +44,32 @@
                         <mean>0</mean>
                         <stddev>0.007</stddev>
                     </noise>
-                </camera>
-            </sensor>
-        </link>
+                    <optical_frame_id>camera_optical</optical_frame_id>
+                 </camera>
+             </sensor>
+         </link>
++
++        <joint name="camera_optical_joint" type="fixed">
++          <parent>hd_camera</parent>
++          <child>camera_optical</child>
++          <pose>0 0 0 0 0 0</pose>
++        </joint>
++
++        <link name="camera_optical">
++          <pose>0 0 0 -1.57 0 -1.57</pose>
++          <inertial>
++            <mass>0.0</mass>
++            <inertia>
++                <ixx>8.33e-06</ixx>
++                <ixy>0</ixy>
++                <ixz>0</ixz>
++                <iyy>8.33e-06</iyy>
++                <iyz>0</iyz>
++                <izz>8.33e-06</izz>
++            </inertia>
++          </inertial>
++        </link>
++
         <frame name="mount_point"/>
     </model>
 </sdf>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |  |
| ROS2 version tested on | Humble|
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Added camera_optical link to hd_camera.sdf
* Added camera_optical_joint to hd_camera.sdf
* Set optical_frame_id parameter to camera_optical in hd_camera.sdf

## Description of documentation updates required from your changes

* It depends on whether the optical_frame_id gets fixed.

---

## Future work that may be required in bullet points

* Setting optical_frame_id involves losing the namespace of the drone in the frame_id of the camera_info message.
* Strange behavior of the footprint frame needs to be checked.

