### PR TITLE
[as2_behaviors_perception] migrate deprecated api from cv::aruco::drawAxis to cv::drawFrameAxes

### DIFF
--- a/as2_behaviors/as2_behaviors_perception/detect_aruco_markers_behavior/src/detect_aruco_markers_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_perception/detect_aruco_markers_behavior/src/detect_aruco_markers_behavior.cpp
@@ -191,7 +191,7 @@ void DetectArucoMarkersBehavior::imageCallback(const sensor_msgs::msg::Image::Sh
       cv::composeRT(rvec * 0, tvec * 0, rvec, tvec, rout, tout);
       aruco_position = tout;
       aruco_rotation = rout;
-      cv::aruco::drawAxis(output_image, camera_matrix_, dist_coeffs_, rout, tout, 0.08625);
+      cv::drawFrameAxes(output_image, camera_matrix_, dist_coeffs_, rout, tout, 0.08625, 3);
     }
   }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | https://github.com/aerostack2/aerostack2/issues/508 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

cv::aruco::drawAxis has been [deprecated](https://github.com/opencv/opencv_contrib/commit/0f030dd0) on opencv-contrib 3.4.7/4.1.1 from Apri 2019 and [removed](https://github.com/opencv/opencv_contrib/commit/56d492cf) on 3.4.18/4.6.0 from Mar 17, 2022. Migrate the deprecated api to cv::drawFrameAxes.

## Future work that may be required in bullet points

Need to update dependency in release repo. 
