### PR TITLE
[as2_core] New launch utils to declare parameters from a config file

### DIFF
--- a/as2_behaviors/as2_behaviors_motion/launch/follow_path_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/follow_path_behavior_launch.py
@@ -37,7 +37,8 @@ __license__ = 'BSD-3-Clause'
 import os
 
 from ament_index_python.packages import get_package_share_directory
-import as2_core.launch_param_utils as as2_utils
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -70,10 +71,9 @@ def generate_launch_description() -> LaunchDescription:
                               description='Plugin name',
                               choices=get_available_plugins(
                                   'as2_behaviors_motion', BEHAVIOR_NAME)),
-        *as2_utils.declare_launch_arguments(
-            'behavior_config_file',
-            default_value=behavior_config_file,
-            description='Path to behavior config file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='behavior_config_file', source_file=behavior_config_file,
+            description='Path to behavior configuration file'),
         Node(
             package='as2_behaviors_motion',
             executable=BEHAVIOR_NAME + '_behavior_node',
@@ -83,11 +83,12 @@ def generate_launch_description() -> LaunchDescription:
                        LaunchConfiguration('log_level')],
             emulate_tty=True,
             parameters=[
-                *as2_utils.launch_configuration('behavior_config_file',
-                                                default_value=behavior_config_file),
                 {
                     'use_sim_time': LaunchConfiguration('use_sim_time'),
                     'plugin_name': LaunchConfiguration('plugin_name'),
-                }
+                },
+                LaunchConfigurationFromConfigFile(
+                    'behavior_config_file',
+                    default_file=behavior_config_file)
             ]
         )])

--- a/as2_behaviors/as2_behaviors_motion/launch/follow_reference_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/follow_reference_behavior_launch.py
@@ -35,7 +35,8 @@ __license__ = 'BSD-3-Clause'
 import os
 
 from ament_index_python.packages import get_package_share_directory
-import as2_core.launch_param_utils as as2_utils
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
@@ -64,10 +65,9 @@ def generate_launch_description() -> LaunchDescription:
                               description='Drone namespace',
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID')),
-        *as2_utils.declare_launch_arguments(
-            'behavior_config_file',
-            default_value=behavior_config_file,
-            description='Path to behavior config file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='behavior_config_file', source_file=behavior_config_file,
+            description='Path to behavior configuration file'),
         Node(
             package='as2_behaviors_motion',
             executable=BEHAVIOR_NAME + '_behavior_node',
@@ -77,10 +77,11 @@ def generate_launch_description() -> LaunchDescription:
                        LaunchConfiguration('log_level')],
             emulate_tty=True,
             parameters=[
-                *as2_utils.launch_configuration('behavior_config_file',
-                                                default_value=behavior_config_file),
                 {
                     'use_sim_time': LaunchConfiguration('use_sim_time'),
-                }
+                },
+                LaunchConfigurationFromConfigFile(
+                    'behavior_config_file',
+                    default_file=behavior_config_file)
             ]
         )])

--- a/as2_behaviors/as2_behaviors_motion/launch/go_to_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/go_to_behavior_launch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2024 Universidad Politécnica de Madrid
 #
 # Redistribution and use in source and binary forms, with or without
@@ -37,7 +35,8 @@ __license__ = 'BSD-3-Clause'
 import os
 
 from ament_index_python.packages import get_package_share_directory
-import as2_core.launch_param_utils as as2_utils
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -70,10 +69,9 @@ def generate_launch_description() -> LaunchDescription:
                               description='Plugin name',
                               choices=get_available_plugins(
                                   'as2_behaviors_motion', BEHAVIOR_NAME)),
-        *as2_utils.declare_launch_arguments(
-            'behavior_config_file',
-            default_value=behavior_config_file,
-            description='Path to behavior config file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='behavior_config_file', source_file=behavior_config_file,
+            description='Path to behavior configuration file'),
         Node(
             package='as2_behaviors_motion',
             executable=BEHAVIOR_NAME + '_behavior_node',
@@ -83,11 +81,12 @@ def generate_launch_description() -> LaunchDescription:
                        LaunchConfiguration('log_level')],
             emulate_tty=True,
             parameters=[
-                *as2_utils.launch_configuration('behavior_config_file',
-                                                default_value=behavior_config_file),
                 {
                     'use_sim_time': LaunchConfiguration('use_sim_time'),
                     'plugin_name': LaunchConfiguration('plugin_name'),
-                }
+                },
+                LaunchConfigurationFromConfigFile(
+                    'behavior_config_file',
+                    default_file=behavior_config_file)
             ]
         )])

--- a/as2_behaviors/as2_behaviors_motion/launch/land_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/land_behavior_launch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2024 Universidad Politécnica de Madrid
 #
 # Redistribution and use in source and binary forms, with or without
@@ -37,7 +35,8 @@ __license__ = 'BSD-3-Clause'
 import os
 
 from ament_index_python.packages import get_package_share_directory
-import as2_core.launch_param_utils as as2_utils
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -70,10 +69,9 @@ def generate_launch_description() -> LaunchDescription:
                               description='Plugin name',
                               choices=get_available_plugins(
                                   'as2_behaviors_motion', BEHAVIOR_NAME)),
-        *as2_utils.declare_launch_arguments(
-            'behavior_config_file',
-            default_value=behavior_config_file,
-            description='Path to behavior config file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='behavior_config_file', source_file=behavior_config_file,
+            description='Path to behavior configuration file'),
         Node(
             package='as2_behaviors_motion',
             executable=BEHAVIOR_NAME + '_behavior_node',
@@ -83,11 +81,12 @@ def generate_launch_description() -> LaunchDescription:
                        LaunchConfiguration('log_level')],
             emulate_tty=True,
             parameters=[
-                *as2_utils.launch_configuration('behavior_config_file',
-                                                default_value=behavior_config_file),
                 {
                     'use_sim_time': LaunchConfiguration('use_sim_time'),
                     'plugin_name': LaunchConfiguration('plugin_name'),
-                }
+                },
+                LaunchConfigurationFromConfigFile(
+                    'behavior_config_file',
+                    default_file=behavior_config_file)
             ]
         )])

--- a/as2_behaviors/as2_behaviors_motion/launch/motion_behaviors_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/motion_behaviors_launch.py
@@ -38,10 +38,92 @@ from ament_index_python.packages import get_package_share_directory
 from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
 from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 from as2_core.launch_plugin_utils import get_available_plugins
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch import LaunchContext, LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
 from launch_ros.actions import Node
+import yaml
+
+
+def recursive_search(data_dict, target_key, result=None):
+    """Search for a target key in a nested dictionary or list."""
+    if result is None:
+        result = []
+
+    if isinstance(data_dict, dict):
+        for key, value in data_dict.items():
+            if key == target_key:
+                result.append(value)
+            else:
+                recursive_search(value, target_key, result)
+    elif isinstance(data_dict, list):
+        for item in data_dict:
+            recursive_search(item, target_key, result)
+
+    return result
+
+
+def override_plugin_name_in_context(context: LaunchContext, behavior_name: str):
+    """Override plugin_name in the context from config_file if it is not provided as argument."""
+    plugin_name = LaunchConfiguration(behavior_name + '_plugin_name').perform(context)
+    if plugin_name == '':
+        config_file = LaunchConfiguration('config_file').perform(context)
+        with open(config_file, 'r') as file:
+            config = yaml.safe_load(file)
+        plugin_names = recursive_search(config, behavior_name + '_plugin_name')
+        for plugin_name in plugin_names:
+            if plugin_name in get_available_plugins('as2_behaviors_motion'):
+                break
+
+    if plugin_name == '':
+        raise RuntimeError('No plugin_name provided or not found in config_file.')
+
+    context.launch_configurations[behavior_name + '_plugin_name'] = plugin_name
+    return
+
+
+def override_behavior_default_config_file(context: LaunchContext, behavior_name: str):
+    """Override behavior config file in context from the common one."""
+    context.launch_configurations[
+        behavior_name + '_config_file'] = LaunchConfiguration('config_file').perform(context)
+    return
+
+
+def get_behavior_launch_description(behavior_name: str) -> list:
+    plugin_choices = get_available_plugins('as2_behaviors_motion', behavior_name)
+    plugin_choices.append('')
+    package_folder = get_package_share_directory('as2_behaviors_motion')
+    behavior_config_file = os.path.join(package_folder,
+                                        behavior_name +
+                                        '_behavior/config/config_default.yaml')
+    launch_description = [
+        DeclareLaunchArgument(
+            behavior_name + '_plugin_name',
+            default_value='',
+            description='Plugin name. If empty, it must be declared in config file.',
+            choices=plugin_choices),
+        OpaqueFunction(function=override_plugin_name_in_context, args=[behavior_name]),
+        DeclareLaunchArgumentsFromConfigFile(
+            name=behavior_name + '_config_file', source_file=behavior_config_file,
+            description='Path to behavior configuration file'),
+        OpaqueFunction(function=override_behavior_default_config_file, args=[behavior_name]),
+        Node(
+            package='as2_behaviors_motion',
+            executable=behavior_name + '_behavior_node',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+            emulate_tty=True,
+            parameters=[
+                {
+                    'use_sim_time': LaunchConfiguration('use_sim_time'),
+                    'plugin_name': LaunchConfiguration(behavior_name + '_plugin_name'),
+                },
+                LaunchConfigurationFromConfigFile(
+                    behavior_name + '_config_file', behavior_config_file),
+            ])
+    ]
+    return launch_description
 
 
 def generate_launch_description():
@@ -50,7 +132,8 @@ def generate_launch_description():
         'follow_path',
         'go_to',
         'land',
-        'takeoff']
+        'takeoff'
+    ]
 
     launch_description = []
     launch_description.append(
@@ -66,36 +149,12 @@ def generate_launch_description():
                               description='Drone namespace',
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID')))
+    launch_description.append(
+        DeclareLaunchArgument('config_file',
+                              description='Path to behaviors configuration file',
+                              default_value=''))
 
-    package_folder = get_package_share_directory('as2_behaviors_motion')
     for behavior in behaviors:
-        launch_description.append(
-            DeclareLaunchArgument(behavior + '_plugin_name', description='Plugin name',
-                                  choices=get_available_plugins('as2_behaviors_motion', behavior)))
-        behavior_config_file = os.path.join(package_folder,
-                                            behavior +
-                                            '_behavior/config/config_default.yaml')
-        launch_description.append(
-            DeclareLaunchArgumentsFromConfigFile(
-                name=behavior + '_config_file', source_file=behavior_config_file,
-                description='Path to behavior configuration file'),)
-        launch_description.append(
-            Node(
-                package='as2_behaviors_motion',
-                executable=behavior + '_behavior_node',
-                namespace=LaunchConfiguration('namespace'),
-                output='screen',
-                arguments=['--ros-args', '--log-level',
-                           LaunchConfiguration('log_level')],
-                emulate_tty=True,
-                parameters=[
-                    {
-                        'use_sim_time': LaunchConfiguration('use_sim_time'),
-                        'plugin_name': LaunchConfiguration(behavior + '_plugin_name'),
-                    },
-                    LaunchConfigurationFromConfigFile(
-                        behavior + '_config_file',
-                        default_file=behavior_config_file)
-                ]))
+        launch_description += get_behavior_launch_description(behavior)
 
     return LaunchDescription(launch_description)

--- a/as2_behaviors/as2_behaviors_motion/launch/motion_behaviors_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/motion_behaviors_launch.py
@@ -86,6 +86,9 @@ def override_behavior_default_config_file(context: LaunchContext, behavior_name:
     """Override behavior config file in context from the common one."""
     context.launch_configurations[
         behavior_name + '_config_file'] = LaunchConfiguration('config_file').perform(context)
+    # Use sim time back to string
+    context.launch_configurations['use_sim_time'] = str(LaunchConfiguration(
+        'use_sim_time').perform(context)).lower()
     return
 
 

--- a/as2_behaviors/as2_behaviors_motion/launch/takeoff_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/takeoff_behavior_launch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2024 Universidad Politécnica de Madrid
 #
 # Redistribution and use in source and binary forms, with or without
@@ -37,7 +35,8 @@ __license__ = 'BSD-3-Clause'
 import os
 
 from ament_index_python.packages import get_package_share_directory
-import as2_core.launch_param_utils as as2_utils
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -70,10 +69,9 @@ def generate_launch_description() -> LaunchDescription:
                               description='Plugin name',
                               choices=get_available_plugins(
                                   'as2_behaviors_motion', BEHAVIOR_NAME)),
-        *as2_utils.declare_launch_arguments(
-            'behavior_config_file',
-            default_value=behavior_config_file,
-            description='Path to behavior config file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='behavior_config_file', source_file=behavior_config_file,
+            description='Path to behavior configuration file'),
         Node(
             package='as2_behaviors_motion',
             executable=BEHAVIOR_NAME + '_behavior_node',
@@ -83,11 +81,12 @@ def generate_launch_description() -> LaunchDescription:
                        LaunchConfiguration('log_level')],
             emulate_tty=True,
             parameters=[
-                *as2_utils.launch_configuration('behavior_config_file',
-                                                default_value=behavior_config_file),
                 {
                     'use_sim_time': LaunchConfiguration('use_sim_time'),
                     'plugin_name': LaunchConfiguration('plugin_name'),
-                }
+                },
+                LaunchConfigurationFromConfigFile(
+                    'behavior_config_file',
+                    default_file=behavior_config_file)
             ]
         )])

--- a/as2_behaviors/as2_behaviors_perception/point_gimbal_behavior/launch/point_gimbal_behavior.launch.py
+++ b/as2_behaviors/as2_behaviors_perception/point_gimbal_behavior/launch/point_gimbal_behavior.launch.py
@@ -31,7 +31,8 @@
 import os
 
 from ament_index_python.packages import get_package_share_directory
-import as2_core.launch_param_utils as as2_utils
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
@@ -40,8 +41,8 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     """Launch point gimbal behavior node."""
-    config = os.path.join(get_package_share_directory('as2_behaviors_perception'),
-                          'point_gimbal_behavior/config/config_default.yaml')
+    config_file = os.path.join(get_package_share_directory('as2_behaviors_perception'),
+                               'point_gimbal_behavior/config/config_default.yaml')
 
     return LaunchDescription([
         DeclareLaunchArgument('namespace', description='Drone namespace',
@@ -49,9 +50,8 @@ def generate_launch_description():
         DeclareLaunchArgument('use_sim_time', default_value='false'),
         DeclareLaunchArgument('log_level', default_value='info',
                               description='Log Severity Level'),
-        *as2_utils.declare_launch_arguments(
-            'config_file',
-            default_value=config,
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
             description='Configuration file'),
         Node(
             package='as2_behaviors_perception',
@@ -62,11 +62,12 @@ def generate_launch_description():
             arguments=['--ros-args', '--log-level',
                        LaunchConfiguration('log_level')],
             parameters=[
-                *as2_utils.launch_configuration('config_file',
-                                                default_value=config),
                 {
                     'use_sim_time': LaunchConfiguration('use_sim_time'),
                 },
+                LaunchConfigurationFromConfigFile(
+                    'config_file',
+                    default_file=config_file),
             ],
         ),
     ])

--- a/as2_core/as2_core/declare_launch_arguments_from_config_file.py
+++ b/as2_core/as2_core/declare_launch_arguments_from_config_file.py
@@ -1,0 +1,90 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Module for DeclareLaunchArgumentsFromConfigFile action."""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+from typing import List, Text, Optional
+import launch
+from as2_core.launch_param_utils import _get_declare_launch_argument
+import launch.utilities
+
+
+class DeclareLaunchArgumentsFromConfigFile(launch.actions.GroupAction):
+    """Action to declare Launch Arguments from elements in a config file."""
+
+    def __init__(
+        self,
+        name: Text,
+        source_file: launch.SomeSubstitutionsType,
+        *,
+        description: Optional[Text] = None,
+        **kwargs
+    ) -> None:
+
+        self.__name = name
+        self.__source_file = launch.utilities.normalize_to_list_of_substitutions(source_file)
+        self.__description = description
+
+        actions = [
+            launch.actions.DeclareLaunchArgument(
+                self.name, default_value=self.source_file, description=self.description),
+            # *_get_declare_launch_argument(source_file)
+        ]
+        if isinstance(source_file, Text):
+            actions.extend(_get_declare_launch_argument(source_file))
+
+        super().__init__(actions=actions, scoped=False, **kwargs)
+
+    @property
+    def name(self) -> Text:
+        """Getter for self.__name."""
+        return self.__name
+
+    @property
+    def source_file(self) -> List[launch.substitution.Substitution]:
+        """Getter for self.__default_value."""
+        return self.__source_file
+
+    @property
+    def description(self) -> Text:
+        """Getter for self.__description."""
+        return self.__description
+
+    def execute(self, context: launch.LaunchContext):
+        source_file = launch.utilities.perform_substitutions(context, self.source_file)
+
+        self._GroupAction__actions = [
+            launch.actions.DeclareLaunchArgument(
+                self.name, default_value=source_file, description=self.description),
+            *_get_declare_launch_argument(source_file)
+        ]
+        return super().execute(context)

--- a/as2_core/as2_core/declare_launch_arguments_from_config_file.py
+++ b/as2_core/as2_core/declare_launch_arguments_from_config_file.py
@@ -32,9 +32,10 @@ __authors__ = 'Pedro Arias Pérez'
 __copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
 
-from typing import List, Text, Optional
-import launch
+from typing import List, Optional, Text
+
 from as2_core.launch_param_utils import _get_declare_launch_argument
+import launch
 import launch.utilities
 
 

--- a/as2_core/as2_core/launch_configuration_from_config_file.py
+++ b/as2_core/as2_core/launch_configuration_from_config_file.py
@@ -151,7 +151,7 @@ class LaunchConfigurationFromConfigFile(launch.substitution.Substitution):
         dictionaries to then build a param file.
         """
         data_list = []
-        namespace = list(data.keys())[0]
-        for key, value in data[namespace].items():
-            data_list.append({namespace: {key: value}})
+        for namespace in data.keys():
+            for key, value in data[namespace].items():
+                data_list.append({namespace: {key: value}})
         return data_list

--- a/as2_core/as2_core/launch_configuration_from_config_file.py
+++ b/as2_core/as2_core/launch_configuration_from_config_file.py
@@ -1,0 +1,127 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Module for LaunchConfigurationFromConfigFile action.
+
+    Parameter priority:
+    1. Values in the default config file
+    2. Values given as single arguments in the launch file
+    3. Values given in the user config file argument
+"""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+from typing import Text, List
+import tempfile
+import yaml
+
+import launch
+import launch.utilities
+
+from as2_core.launch_param_utils import _open_yaml_file
+
+
+class LaunchConfigurationFromConfigFile(launch.substitution.Substitution):
+    """Override Launch Configuration from a config file with arguments."""
+
+    def __init__(
+        self,
+        name: Text,
+        default_file: launch.SomeSubstitutionsType,
+        **kwargs
+    ) -> None:
+        super().__init__(**kwargs)
+
+        self.__name = name
+        self.__default_file = launch.utilities.normalize_to_list_of_substitutions(default_file)
+
+    @property
+    def name(self) -> List[launch.Substitution]:
+        """Getter for name."""
+        return self.__name
+
+    @property
+    def default_file(self) -> List[launch.Substitution]:
+        """Getter for source_file."""
+        return self.__default_file
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return ''
+
+    def perform(self, context: launch.LaunchContext) -> Text:
+        """Perform the substitution."""
+        # Get default config file
+        yaml_filename = launch.utilities.perform_substitutions(context, self.default_file)
+        with open(yaml_filename, 'r', encoding='utf-8') as file:
+            lines = file.read()
+            default_data = yaml.load(lines, Loader=yaml.FullLoader)
+        # Update default values with context values. TODO(pariaspe): what if the key is not in the default data?
+        merged_data = self.update_leaf_keys(default_data, context.launch_configurations)
+
+        # Create temporary file with merged data
+        temp_yaml_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        yaml.dump(merged_data, temp_yaml_file)
+
+        # Get user config file from launch argument, if not given return
+        user_yaml_filename = launch.substitutions.LaunchConfiguration(self.name).perform(context)
+        if user_yaml_filename == yaml_filename:
+            return temp_yaml_file.name
+
+        # Append user config file to the temporary file
+        with open(user_yaml_filename, 'r', encoding='utf-8') as file:
+            user_data = yaml.load(file.read(), Loader=yaml.FullLoader)
+            yaml.dump(user_data, temp_yaml_file)
+            data, _ = _open_yaml_file(user_yaml_filename)
+            # update context with user config file
+            context.launch_configurations.update(data)
+
+        return temp_yaml_file.name
+
+    def update_leaf_keys(self, data: dict, new_values: dict) -> dict:
+        """Update leaf keys in a dictionary."""
+        for key, item in data.items():
+            if isinstance(item, dict):
+                self.update_leaf_keys(item, new_values)
+            else:
+                v = new_values.get(key, item)
+                data[key] = v
+                try:
+                    data[key] = float(v) if '.' in v else int(v)
+                except ValueError:
+                    v1 = v.lower()
+                    if v1 == 'true':
+                        data[key] = True
+                    elif v1 == 'false':
+                        data[key] = False
+                except TypeError:
+                    pass
+        return data

--- a/as2_core/as2_core/launch_configuration_from_config_file.py
+++ b/as2_core/as2_core/launch_configuration_from_config_file.py
@@ -39,14 +39,13 @@ __authors__ = 'Pedro Arias Pérez'
 __copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
 
-from typing import Text, List
 import tempfile
-import yaml
-
-import launch
-import launch.utilities
+from typing import List, Text
 
 from as2_core.launch_param_utils import _open_yaml_file
+import launch
+import launch.utilities
+import yaml
 
 
 class LaunchConfigurationFromConfigFile(launch.substitution.Substitution):
@@ -84,7 +83,8 @@ class LaunchConfigurationFromConfigFile(launch.substitution.Substitution):
         with open(yaml_filename, 'r', encoding='utf-8') as file:
             lines = file.read()
             default_data = yaml.load(lines, Loader=yaml.FullLoader)
-        # Update default values with context values. TODO(pariaspe): what if the key is not in the default data?
+        # Update default values with context values.
+        # TODO(pariaspe): what if the key is not in the default data?
         merged_data = self.update_leaf_keys(default_data, context.launch_configurations)
 
         # Create temporary file with merged data

--- a/as2_core/as2_core/launch_configuration_from_config_file.py
+++ b/as2_core/as2_core/launch_configuration_from_config_file.py
@@ -84,7 +84,6 @@ class LaunchConfigurationFromConfigFile(launch.substitution.Substitution):
             lines = file.read()
             default_data = yaml.load(lines, Loader=yaml.FullLoader)
         # Update default values with context values.
-        # TODO(pariaspe): what if the key is not in the default data?
         merged_data = self.update_leaf_keys(default_data, context.launch_configurations)
 
         # Create temporary file with merged data

--- a/as2_core/as2_core/launch_param_utils.py
+++ b/as2_core/as2_core/launch_param_utils.py
@@ -82,8 +82,6 @@ def _flat_dictionary(data: dict, prefix: str = '') -> dict:
             full_key = f'{prefix}{key}'
             result.update(_flat_dictionary(value, f'{full_key}.'))
         return result
-    elif isinstance(data, list):
-        return [_flat_dictionary(item, prefix) for item in data]
     else:
         # Returns a dictionary with the key and value.
         return {prefix.rstrip('.'): data}

--- a/as2_motion_controller/launch/controller_launch.py
+++ b/as2_motion_controller/launch/controller_launch.py
@@ -78,7 +78,7 @@ def generate_launch_description():
                               choices=get_available_plugins(
                                   'as2_motion_controller')),
         DeclareLaunchArgumentsFromConfigFile(
-            name='motion_controller_config_file',
+            name='config_file',
             source_file=get_package_config_file(),
             description='Configuration file'),
         DeclareLaunchArgument(
@@ -106,7 +106,7 @@ def generate_launch_description():
                         'plugin_available_modes_config_file')
                 },
                 LaunchConfigurationFromConfigFile(
-                    'motion_controller_config_file',
+                    'config_file',
                     default_file=get_package_config_file()),
                 LaunchConfigurationFromConfigFile(
                     'plugin_config_file',

--- a/as2_motion_controller/launch/differential_flatness_controller.launch.py
+++ b/as2_motion_controller/launch/differential_flatness_controller.launch.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the motion controller node with differential_flatness plugin."""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+
+package_folder = get_package_share_directory('as2_motion_controller')
+sys.path.append(package_folder + '/launch')
+
+
+def generate_launch_description() -> LaunchDescription:
+    from controller_launch import get_launch_description_from_plugin
+    return LaunchDescription(
+        get_launch_description_from_plugin('differential_flatness_controller')
+    )

--- a/as2_motion_controller/launch/pid_speed_controller.launch.py
+++ b/as2_motion_controller/launch/pid_speed_controller.launch.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the motion controller node with differential_flatness plugin."""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+
+package_folder = get_package_share_directory('as2_motion_controller')
+sys.path.append(package_folder + '/launch')
+
+
+def generate_launch_description() -> LaunchDescription:
+    from controller_launch import get_launch_description_from_plugin
+    return LaunchDescription(get_launch_description_from_plugin('pid_speed_controller'))

--- a/as2_state_estimator/launch/ground_truth_state_estimator.launch.py
+++ b/as2_state_estimator/launch/ground_truth_state_estimator.launch.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the state estimator node with ground_truth plugin."""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+
+package_folder = get_package_share_directory('as2_state_estimator')
+sys.path.append(package_folder + '/launch')
+
+
+def generate_launch_description() -> LaunchDescription:
+    from state_estimator_launch import get_launch_description_from_plugin
+    return LaunchDescription(get_launch_description_from_plugin('ground_truth'))

--- a/as2_state_estimator/launch/mocap_pose_state_estimator.launch.py
+++ b/as2_state_estimator/launch/mocap_pose_state_estimator.launch.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the state estimator node with mocap_pose plugin."""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+
+package_folder = get_package_share_directory('as2_state_estimator')
+sys.path.append(package_folder + '/launch')
+
+
+def generate_launch_description() -> LaunchDescription:
+    from state_estimator_launch import get_launch_description_from_plugin
+    return LaunchDescription(get_launch_description_from_plugin('mocap_pose'))

--- a/as2_state_estimator/launch/raw_odometry_state_estimator.launch.py
+++ b/as2_state_estimator/launch/raw_odometry_state_estimator.launch.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the state estimator node with raw_odometry plugin."""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+
+package_folder = get_package_share_directory('as2_state_estimator')
+sys.path.append(package_folder + '/launch')
+
+
+def generate_launch_description() -> LaunchDescription:
+    from state_estimator_launch import get_launch_description_from_plugin
+    return LaunchDescription(get_launch_description_from_plugin('raw_odometry'))

--- a/as2_state_estimator/launch/state_estimator_launch.py
+++ b/as2_state_estimator/launch/state_estimator_launch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Universidad Politécnica de Madrid
+# Copyright 2024 Universidad Politécnica de Madrid
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -30,53 +30,50 @@
 
 """Launch file for the state estimator node."""
 
-__authors__ = 'Rafael Pérez Seguí'
-__copyright__ = 'Copyright (c) 2022 Universidad Politécnica de Madrid'
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
-__version__ = '0.1.0'
 
 import os
 
 from ament_index_python.packages import get_package_share_directory
-import as2_core.launch_param_utils as as2_utils
 from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
 
-def get_package_config_file():
-    """Return the package config file."""
+
+def generate_launch_description() -> LaunchDescription:
+    """Entry point for launch file."""
     package_folder = get_package_share_directory('as2_state_estimator')
-    return os.path.join(package_folder,
-                        'config/state_estimator_default.yaml')
-
-
-def get_node(context, *args, **kwargs) -> list:
-    """
-    Get node.
-
-    :param context: Launch context
-    :type context: LaunchContext
-    :return: List with node
-    :rtype: list
-    """
-    # Get plugin name
-    plugin_name = LaunchConfiguration('plugin_name').perform(context)
-
-    # Get plugin configuration file
-    package_folder = get_package_share_directory(
-        'as2_state_estimator')
-    plugin_config_file = os.path.join(package_folder,
-                                      'plugins/' +
-                                      plugin_name +
-                                      '/config/plugin_default.yaml')
-
-    return [
-        *as2_utils.declare_launch_arguments(
-            'plugin_config_file',
-            default_value=plugin_config_file,
+    config_file = os.path.join(package_folder,
+                               'config/state_estimator_default.yaml')
+    plugin_config_file = PathJoinSubstitution([
+        package_folder,
+        'plugins', LaunchConfiguration('plugin_name'), 'config/plugin_default.yaml'
+    ])
+    return LaunchDescription([
+        DeclareLaunchArgument('log_level',
+                              description='Logging level',
+                              default_value='info'),
+        DeclareLaunchArgument('use_sim_time',
+                              description='Use simulation clock if true',
+                              default_value='false'),
+        DeclareLaunchArgument('namespace',
+                              description='Drone namespace',
+                              default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgument('plugin_name',
+                              description='Plugin name',
+                              choices=get_available_plugins('as2_state_estimator')),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
             description='Plugin configuration file'),
         Node(
             package='as2_state_estimator',
@@ -88,46 +85,16 @@ def get_node(context, *args, **kwargs) -> list:
                        LaunchConfiguration('log_level')],
             emulate_tty=True,
             parameters=[
-                *as2_utils.launch_configuration(
-                    'config_file',
-                    default_value=get_package_config_file()),
-                *as2_utils.launch_configuration(
-                    'plugin_config_file',
-                    default_value=plugin_config_file),
                 {
                     'use_sim_time': LaunchConfiguration('use_sim_time'),
-                    'plugin_name': plugin_name
+                    'plugin_name': LaunchConfiguration('plugin_name')
                 },
+                LaunchConfigurationFromConfigFile(
+                    'config_file',
+                    default_file=config_file),
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
             ]
         )
-    ]
-
-
-def generate_launch_description() -> LaunchDescription:
-    """
-    Entry point for launch file.
-
-    :return: Launch description
-    :rtype: LaunchDescription
-    """
-    return LaunchDescription([
-        DeclareLaunchArgument('log_level',
-                              description='Logging level',
-                              default_value='info'),
-        DeclareLaunchArgument('use_sim_time',
-                              description='Use simulation clock if true',
-                              default_value='false'),
-        DeclareLaunchArgument('namespace',
-                              description='Drone namespace',
-                              default_value=EnvironmentVariable(
-                                  'AEROSTACK2_SIMULATION_DRONE_ID')),
-        DeclareLaunchArgument('plugin_name',
-                              description='Plugin name',
-                              choices=get_available_plugins(
-                                  'as2_state_estimator')),
-        *as2_utils.declare_launch_arguments(
-            'config_file',
-            default_value=get_package_config_file(),
-            description='Configuration file'),
-        OpaqueFunction(function=get_node)
     ])

--- a/as2_state_estimator/launch/state_estimator_launch.py
+++ b/as2_state_estimator/launch/state_estimator_launch.py
@@ -82,7 +82,9 @@ def override_plugin_name_in_context(context):
     return
 
 
-def get_launch_description_from_plugin(plugin_name: str) -> LaunchDescription:
+def get_launch_description_from_plugin(
+        plugin_name: str | LaunchConfiguration) -> LaunchDescription:
+    """Get LaunchDescription from plugin."""
     package_folder = get_package_share_directory('as2_state_estimator')
     config_file = os.path.join(package_folder,
                                'config/state_estimator_default.yaml')
@@ -139,11 +141,14 @@ def get_launch_description_from_plugin(plugin_name: str) -> LaunchDescription:
 
 def generate_launch_description() -> LaunchDescription:
     """Entry point for launch file."""
+    plugin_choices = get_available_plugins('as2_state_estimator')
+    plugin_choices.append('')
     ld = [
-        DeclareLaunchArgument('plugin_name',
-                              default_value='',
-                              description='Plugin name',
-                              choices=get_available_plugins('as2_state_estimator').append('')),
+        DeclareLaunchArgument(
+            'plugin_name',
+            default_value='',
+            description='Plugin name. If empty, it must be declared in config file.',
+            choices=plugin_choices),
     ]
     ld.append(OpaqueFunction(function=override_plugin_name_in_context))
     ld.extend(get_launch_description_from_plugin(LaunchConfiguration('plugin_name')))


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #511 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Two new launch utils:
  * **DeclareLaunchArgumentsFromConfigFile**: a ros2 launch.Action that creates a DeclareLaunchArgument for each argument in a config file. It allows to easily inspect params from a default config file with -s launch option.
  * **LaunchConfigurationFromConfigFile**: a ros2 launch.Substitution to create a config file with default parameters from default config file overwritten with arguments and merged with user config file given as argument.
* Fixed bug on `launch_param_utils.py` while reading lists on yamls
* as2_platform_gazebo launcher updated
* as2_platform_multirotor_simulator launchers updated
* as2_platform_gazebo launcher updated
* as2_behaviors_motion launcher updated
* as2_behaviors_perception launcher updated
* as2_motion_controller launcher updated
* as2_state_estimator launcher updated

## Description of documentation updates required from your changes

* These changes brake compatibility with latest binary release. Projects have now tags that link to that release. Add some warning in the documentation.

---

## Future work that may be required in bullet points

* Some launchers are still to migrate: as2_usb_camera_interface, as2_realsense_interface, as2_external_object_to_tf...