### PR TITLE
[as2_behaviors_motion] Not overwritting behavior config file if user config file is empty

### DIFF
--- a/as2_behaviors/as2_behaviors_motion/launch/motion_behaviors_launch.py
+++ b/as2_behaviors/as2_behaviors_motion/launch/motion_behaviors_launch.py
@@ -84,6 +84,8 @@ def override_plugin_name_in_context(context: LaunchContext, behavior_name: str):
 
 def override_behavior_default_config_file(context: LaunchContext, behavior_name: str):
     """Override behavior config file in context from the common one."""
+    if LaunchConfiguration('config_file').perform(context) == '':
+        return
     context.launch_configurations[
         behavior_name + '_config_file'] = LaunchConfiguration('config_file').perform(context)
     # Use sim time back to string


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #569 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* Launcher works now if no config file is given.
