### PR TITLE
[as2_core] Don't call ownSendCommand until new ref arrives after control mode change

### DIFF
--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -291,8 +291,10 @@ void AerialPlatform::sendCommand()
   if (state_machine_.getState().state == as2_msgs::msg::PlatformStatus::EMERGENCY) {
     RCLCPP_WARN_THROTTLE(this->get_logger(), clk, 1000, "SEND PLATFORM STOP COMMAND");
     ownStopPlatform();
-  } else if (!ownSendCommand()) {
-    RCLCPP_DEBUG_THROTTLE(this->get_logger(), clk, 5000, "Platform command failed");
+  } else if (has_new_references_) {
+    if (!ownSendCommand()) {
+      RCLCPP_DEBUG_THROTTLE(this->get_logger(), clk, 5000, "Platform command failed");
+    }
   }
 }  // namespace as2
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | [#69](https://github.com/aerostack2/aerostack2.github.io/issues/69) |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Don't call ownSendCommand until new ref arrives after control mode change