### PR TITLE
[as2_platform_gazebo] Use sim time true by default in gazebo platform

### DIFF
--- a/as2_aerial_platforms/as2_platform_gazebo/launch/platform_gazebo_launch.py
+++ b/as2_aerial_platforms/as2_platform_gazebo/launch/platform_gazebo_launch.py
@@ -117,7 +117,7 @@ def generate_launch_description() -> LaunchDescription:
                               default_value='info'),
         DeclareLaunchArgument('use_sim_time',
                               description='Use simulation clock if true',
-                              default_value='false'),
+                              default_value='true'),
         DeclareLaunchArgument('namespace',
                               description='Drone namespace',
                               default_value=EnvironmentVariable(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Use sim time param default to true in launcher
