### PR TITLE
[as2_state_estimator] map generates at the drone initial position

### DIFF
--- a/as2_state_estimator/plugins/ground_truth/include/ground_truth.hpp
+++ b/as2_state_estimator/plugins/ground_truth/include/ground_truth.hpp
@@ -189,10 +189,10 @@ private:
       return;
     }
 
-    // if (!earth_to_map_set_) {
-    //   generate_map_frame_from_ground_truth_pose(*msg);
-    //   earth_to_map_set_ = true;
-    // }
+    if (!earth_to_map_set_) {
+      generate_map_frame_from_ground_truth_pose(*msg);
+      earth_to_map_set_ = true;
+    }
 
     earth_to_baselink.setOrigin(
       tf2::Vector3(msg->pose.position.x, msg->pose.position.y, msg->pose.position.z));


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #615 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo|

---

## Description of contribution in a few bullet points

* Ground truth plugin generates map at drone initial position

