### PR TITLE
[as2_core] Make SensorData public to access getData and getTopicName

### DIFF
--- a/as2_core/include/as2_core/sensor.hpp
+++ b/as2_core/include/as2_core/sensor.hpp
@@ -387,7 +387,7 @@ private:
  * @brief Sensor handler to publish sensor data at a given frequency
 */
 template<typename T>
-class Sensor : public TFStatic, protected GenericSensor, protected SensorData<T>
+class Sensor : public TFStatic, protected GenericSensor, public SensorData<T>
 {
 public:
   /**


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* Make SensorData inheritance public to access getData and getTopicName when using as2_sensors
