### PR TITLE
[aerostack2] Fix gtest warning: publisher already registered

### DIFF
--- a/as2_hardware_drivers/as2_usb_camera_interface/tests/as2_usb_camera_interface_gtest.cpp
+++ b/as2_hardware_drivers/as2_usb_camera_interface/tests/as2_usb_camera_interface_gtest.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<usb_camera_interface::UsbCameraInterface> get_node(
 
 TEST(UsbCameraInterfaceGTest, Constructor) {
   EXPECT_NO_THROW(get_node());
-  auto node = get_node();
+  auto node = get_node("test_usb_camera_interface_spin");
 
   // Spin the node
   rclcpp::executors::MultiThreadedExecutor executor;

--- a/as2_state_estimator/tests/as2_state_estimator_gtest.cpp
+++ b/as2_state_estimator/tests/as2_state_estimator_gtest.cpp
@@ -40,9 +40,9 @@
 #include "as2_state_estimator.hpp"
 
 std::shared_ptr<as2_state_estimator::StateEstimator> getStateEstimatorNode(
-  const std::string plugin_name)
+  const std::string plugin_name, const std::string node_name_prefix = "test_state_estimator")
 {
-  const std::string & name_space = "test_state_estimator";
+  const std::string & name_space = node_name_prefix + plugin_name;
   const std::string package_path =
     ament_index_cpp::get_package_share_directory("as2_state_estimator");
   const std::string state_estimator_config_file = package_path +
@@ -72,7 +72,7 @@ std::shared_ptr<as2_state_estimator::StateEstimator> getStateEstimatorNode(
 
 TEST(As2StateEstimatorGTest, PluginLoadGroundTruth) {
   EXPECT_NO_THROW(getStateEstimatorNode("ground_truth"));
-  auto node = getStateEstimatorNode("ground_truth");
+  auto node = getStateEstimatorNode("ground_truth", "test_state_estimator_spin");
 
   // Spin the node
   rclcpp::executors::MultiThreadedExecutor executor;
@@ -82,7 +82,7 @@ TEST(As2StateEstimatorGTest, PluginLoadGroundTruth) {
 
 TEST(As2StateEstimatorGTest, PluginLoadMocapPose) {
   EXPECT_NO_THROW(getStateEstimatorNode("mocap_pose"));
-  auto node = getStateEstimatorNode("mocap_pose");
+  auto node = getStateEstimatorNode("mocap_pose", "test_state_estimator_spin");
 
   // Spin the node
   rclcpp::executors::MultiThreadedExecutor executor;
@@ -92,7 +92,7 @@ TEST(As2StateEstimatorGTest, PluginLoadMocapPose) {
 
 TEST(As2StateEstimatorGTest, PluginLoadRawOdometry) {
   EXPECT_NO_THROW(getStateEstimatorNode("raw_odometry"));
-  auto node = getStateEstimatorNode("raw_odometry");
+  auto node = getStateEstimatorNode("raw_odometry", "test_state_estimator_spin");
 
   // Spin the node
   rclcpp::executors::MultiThreadedExecutor executor;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on |  |

---

## Description of contribution in a few bullet points

* Fix gtest warning: 
`[WARN] [1723143702.107190823] [rcl.logging_rosout]: Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.`
