### PR TITLE
Remove backward_ros dependency

### DIFF
--- a/as2_behaviors/as2_behaviors_path_planning/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_path_planning/CMakeLists.txt
@@ -29,8 +29,9 @@ set(PROJECT_DEPENDENCIES
   nav_msgs
   visualization_msgs
   tf2_ros
-  backward_ros
 )
+
+# find_package(backward_ros REQUIRED)
 
 # Find dependencies
 foreach(DEPENDENCY ${PROJECT_DEPENDENCIES})

--- a/as2_map_server/CMakeLists.txt
+++ b/as2_map_server/CMakeLists.txt
@@ -36,7 +36,7 @@ set(PROJECT_DEPENDENCIES
   OpenCV
 )
 
-find_package(backward_ros REQUIRED)
+# find_package(backward_ros REQUIRED)
 
 foreach(DEPENDENCY ${PROJECT_DEPENDENCIES})
   find_package(${DEPENDENCY} REQUIRED)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #644 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* Removed not needed dependency: backward_ros