### PR TITLE
[as2_core] In as2_aerial_platform enable ownSendCommand when Hover

### DIFF
--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -215,7 +215,13 @@ bool AerialPlatform::setOffboardControl(bool offboard)
 bool AerialPlatform::setPlatformControlMode(const as2_msgs::msg::ControlMode & msg)
 {
   if (ownSetPlatformControlMode(msg)) {
-    has_new_references_ = false;
+    if (msg.control_mode == as2_msgs::msg::ControlMode::HOVER ||
+      msg.control_mode == as2_msgs::msg::ControlMode::UNSET)
+    {
+      has_new_references_ = true;
+    } else {
+      has_new_references_ = false;
+    }
     platform_info_msg_.current_control_mode = msg;
     return true;
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Enable `ownSendCommand` when `Hover`, as no reference is expected