### PR TITLE
[as2_gazebo_assets] Set air pressure sensor by user instead of default sensor

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/README.md
+++ b/as2_simulation_assets/as2_gazebo_assets/README.md
@@ -7,13 +7,14 @@ Tested on **Gazebo Fortress**. Make sure to have it [installed](https://gazebosi
 Gazebo naming has changed between ROS2 Galactic and ROS2 Humble releases [(Gazeno new era)](https://discourse.ros.org/t/a-new-era-for-gazebo-cross-post/25012). You should use *as2_gazebo_assets* package version corresponding to your ROS2 version.
 
 ## INDEX
+- [INDEX](#index)
 - [RESOURCES](#resources)
-    - [DRONES](#drone-models)
-    - [SENSORS](#sensor-models)
-    - [WORLDS](#world-models)
-- [HOW TO RUN](#how-to-run-basic-usage)
-    - [OPTIONS](#options)
-    - [CONFIG FILE](#config-file)
+  - [DRONE MODELS](#drone-models)
+  - [SENSOR MODELS](#sensor-models)
+  - [WORLD MODELS](#world-models)
+- [HOW TO RUN: Basic usage](#how-to-run-basic-usage)
+  - [OPTIONS](#options)
+  - [CONFIG FILE](#config-file)
 - [EXAMPLES](#examples)
 ---
 
@@ -38,7 +39,7 @@ There are distinguish three kinds of reources: drone, sensor and world models.
 | SDF Name | Description | Plugin |
 | - | - | - |
 | *imu* | **NOT SDF**: Alreay included in drone models. IMU sensor reports vertical position, angular velocity and linear acceleration readings. | ignition::gazebo::systems::Imu |
-| *air_pressure* | **NOT SDF**: Alreay included in drone models. Air pressure sensor reports vertical position and velocity readings. | ignition::gazebo::systems::AirPressure |
+| *air_pressure* | Air pressure sensor reports vertical position and velocity readings. | ignition::gazebo::systems::AirPressure |
 | *magnetometer* | **NOT SDF**: Alreay included in drone models. Magnetometer sensor reports the magnetic field in its current location. | ignition::gazebo::systems::Magnetometer |
 | *hd_camera* | RGB Camera with 1280x960 resolution. | - |
 | *vga_camera* | RGB Camera with 640x480 resolution. | - |

--- a/as2_simulation_assets/as2_gazebo_assets/models/air_pressure/air_pressure.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/air_pressure/air_pressure.sdf
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <!-- AIR PRESSURE -->
+  <model name='air_pressure'>
+      <plugin
+          filename="ignition-gazebo-air-pressure-system"
+          name="ignition::gazebo::systems::AirPressure">
+      </plugin>
+
+      <link name="air_pressure">
+          <inertial>
+              <mass>0.005</mass>
+              <inertia>
+                  <ixx>8.33e-06</ixx>
+                  <ixy>0</ixy>
+                  <ixz>0</ixz>
+                  <iyy>8.33e-06</iyy>
+                  <iyz>0</iyz>
+                  <izz>8.33e-06</izz>
+              </inertia>
+          </inertial>
+          <sensor name='air_pressure' type='air_pressure'>
+              <always_on>1</always_on>
+              <update_rate>20</update_rate>
+              <air_pressure>
+                  <reference_altitude>0</reference_altitude>
+                  <pressure>
+                    <noise type='gaussian'>
+                        <mean>0.00000008</mean>
+                    </noise>
+                  </pressure>
+              </air_pressure>
+          </sensor>
+      </link>
+  </model>
+</sdf>

--- a/as2_simulation_assets/as2_gazebo_assets/models/air_pressure/model.config
+++ b/as2_simulation_assets/as2_gazebo_assets/models/air_pressure/model.config
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>air_pressure</name>
+  <version>1.0</version>
+  <sdf version="1.6">air_pressure.sdf</sdf>
+
+  <author>
+    <name>Pedro Arias-perez</name>
+    <email>pedro.ariasp@upm.es</email>
+  </author>
+
+  <author>
+    <name>Rafael Perez-Segui</name>
+    <email>r.psegui@upm.es</email>
+  </author>
+
+  <description>
+    A model of a pressure sensor that measures the air pressure in the environment.
+  </description>
+</model>

--- a/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
@@ -225,10 +225,6 @@
       {% endfor -%}
 
       <plugin
-          filename="ignition-gazebo-air-pressure-system"
-          name="ignition::gazebo::systems::AirPressure">
-      </plugin>
-      <plugin
           filename="ignition-gazebo-imu-system"
           name="ignition::gazebo::systems::Imu">
       </plugin>

--- a/as2_simulation_assets/as2_gazebo_assets/models/hexrotor_base/hexrotor_base.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/hexrotor_base/hexrotor_base.sdf
@@ -198,38 +198,6 @@
             <child>imu</child>
         </joint>
 
-        <!-- AIR PRESSURE -->
-        <model name='air_pressure'>
-            <link name="internal">
-                <inertial>
-                    <mass>0.005</mass>
-                    <inertia>
-                        <ixx>8.33e-06</ixx>
-                        <ixy>0</ixy>
-                        <ixz>0</ixz>
-                        <iyy>8.33e-06</iyy>
-                        <iyz>0</iyz>
-                        <izz>8.33e-06</izz>
-                    </inertia>
-                </inertial>
-                <sensor name='air_pressure' type='air_pressure'>
-                    <always_on>1</always_on>
-                    <update_rate>20</update_rate>
-                    <air_pressure>
-                        <reference_altitude>0</reference_altitude>
-                        <noise type='gaussian'>
-                            <mean>0.00000008</mean>
-                        </noise>
-                    </air_pressure>
-                </sensor>
-            </link>
-        </model>
-
-        <joint name="air_pressure_joint" type="fixed">
-            <parent>base_link</parent>
-            <child>air_pressure</child>
-        </joint>
-
         <!-- MAGNETOMETER -->
         <model name='magnetometer'>
             <link name="internal">

--- a/as2_simulation_assets/as2_gazebo_assets/models/hexrotor_base/hexrotor_base.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/hexrotor_base/hexrotor_base.sdf.jinja
@@ -363,10 +363,6 @@
             <child>{{ sensor.name }}</child>
         </joint> {% endif -%} {% endif -%} {% endfor -%}
         <plugin
-        filename="ignition-gazebo-air-pressure-system"
-        name="ignition::gazebo::systems::AirPressure">
-        </plugin>
-        <plugin
         filename="ignition-gazebo-imu-system"
         name="ignition::gazebo::systems::Imu">
         </plugin>

--- a/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf
@@ -159,38 +159,6 @@
             <child>imu</child>
         </joint>
 
-        <!-- AIR PRESSURE -->
-        <model name='air_pressure'>
-            <link name="internal">
-                <inertial>
-                    <mass>0.005</mass>
-                    <inertia>
-                        <ixx>8.33e-06</ixx>
-                        <ixy>0</ixy>
-                        <ixz>0</ixz>
-                        <iyy>8.33e-06</iyy>
-                        <iyz>0</iyz>
-                        <izz>8.33e-06</izz>
-                    </inertia>
-                </inertial>
-                <sensor name='air_pressure' type='air_pressure'>
-                    <always_on>1</always_on>
-                    <update_rate>20</update_rate>
-                    <air_pressure>
-                        <reference_altitude>0</reference_altitude>
-                        <noise type='gaussian'>
-                            <mean>0.00000008</mean>
-                        </noise>
-                    </air_pressure>
-                </sensor>
-            </link>
-        </model>
-
-        <joint name="air_pressure_joint" type="fixed">
-            <parent>base_link</parent>
-            <child>air_pressure</child>
-        </joint>
-
         <!-- MAGNETOMETER -->
         <model name='magnetometer'>
             <link name="internal">

--- a/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf.jinja
@@ -230,11 +230,6 @@
                 </joint>
             {% endif -%}
         {% endfor -%}
-            
-        <plugin
-            filename="ignition-gazebo-air-pressure-system"
-            name="ignition::gazebo::systems::AirPressure">
-        </plugin>
         <plugin
             filename="ignition-gazebo-imu-system"
             name="ignition::gazebo::systems::Imu">

--- a/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base_viz.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base_viz.sdf
@@ -157,36 +157,6 @@
             <child>imu_link</child>
         </joint>
 
-        <- AIR PRESSURE ->
-        <link name="air_pressure_link">
-            <inertial>
-                <mass>0.005</mass>
-                <inertia>
-                    <ixx>8.33e-06</ixx>
-                    <ixy>0</ixy>
-                    <ixz>0</ixz>
-                    <iyy>8.33e-06</iyy>
-                    <iyz>0</iyz>
-                    <izz>8.33e-06</izz>
-                </inertia>
-            </inertial>
-            <sensor name='air_pressure' type='air_pressure'>
-                <always_on>1</always_on>
-                <update_rate>20</update_rate>
-                <air_pressure>
-                    <reference_altitude>0</reference_altitude>
-                    <noise type='gaussian'>
-                        <mean>0.00000008</mean>
-                    </noise>
-                </air_pressure>
-            </sensor>
-        </link>
-
-        <joint name="air_pressure_joint" type="fixed">
-            <parent>base_link</parent>
-            <child>air_pressure_link</child>
-        </joint>
-
         <- MAGNETOMETER ->
         <link name="magnetometer_link">
             <inertial>

--- a/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf
@@ -212,18 +212,6 @@
           </friction>
         </surface>
       </collision>
-      <sensor name="air_pressure_sensor" type="air_pressure">
-        <always_on>1</always_on>
-        <update_rate>50</update_rate>
-        <air_pressure>
-          <pressure>
-            <noise type="gaussian">
-              <mean>0</mean>
-              <stddev>0.01</stddev>
-            </noise>
-          </pressure>
-        </air_pressure>
-      </sensor>
       <sensor name="imu_sensor" type="imu">
         <always_on>1</always_on>
         <update_rate>250</update_rate>

--- a/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf.jinja
@@ -213,10 +213,6 @@
         {% endfor -%}
 
       <plugin
-          filename="ignition-gazebo-air-pressure-system"
-          name="ignition::gazebo::systems::AirPressure">
-      </plugin>
-      <plugin
           filename="ignition-gazebo-imu-system"
           name="ignition::gazebo::systems::Imu">
       </plugin>

--- a/as2_simulation_assets/as2_gazebo_assets/models/x500/x500_viz.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/x500/x500_viz.sdf
@@ -212,24 +212,6 @@
           </friction>
         </surface>
       </collision>
-      <!--
-      <sensor name="air_pressure_sensor" type="air_pressure">
-        <always_on>1</always_on>
-        <update_rate>50</update_rate>
-        <air_pressure>
-          <pressure>
-            <noise type="gaussian">
-              <mean>0</mean>
-              <stddev>0.01</stddev>
-            </noise>
-          </pressure>
-        </air_pressure>
-      </sensor>
-      <sensor name="imu_sensor" type="imu">
-        <always_on>1</always_on>
-        <update_rate>250</update_rate>
-      </sensor>
-      -->
     </link>
     <link name="rotor_0">
       <gravity>true</gravity>

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/bridges/bridges.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/bridges/bridges.py
@@ -71,7 +71,7 @@ def magnetometer(world_name, model_name, sensor_name, link_name, model_prefix=''
     sensor_prefix = prefix(world_name, model_name, sensor_name, link_name)
     return Bridge(
         gz_topic=f'{sensor_prefix}/magnetometer/magnetometer',
-        ros_topic='sensor_measurements/magnetic_field',
+        ros_topic=f'sensor_measurements/{sensor_name}',
         gz_type='ignition.msgs.Magnetometer',
         ros_type='sensor_msgs/msg/MagneticField',
         direction=BridgeDirection.GZ_TO_ROS,
@@ -83,7 +83,7 @@ def air_pressure(world_name, model_name, sensor_name, link_name, model_prefix=''
     sensor_prefix = prefix(world_name, model_name, sensor_name, link_name)
     return Bridge(
         gz_topic=f'{sensor_prefix}/air_pressure/air_pressure',
-        ros_topic='sensor_measurements/air_pressure',
+        ros_topic=f'sensor_measurements/{sensor_name}',
         gz_type='ignition.msgs.FluidPressure',
         ros_type='sensor_msgs/msg/FluidPressure',
         direction=BridgeDirection.GZ_TO_ROS,

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -110,9 +110,6 @@ class Drone(Entity):
             # Magnetometer
             gz_bridges.magnetometer(
                 world_name, self.model_name, 'magnetometer', 'internal'),
-            # Air Pressure
-            gz_bridges.air_pressure(
-                world_name, self.model_name, 'air_pressure', 'internal'),
             # odom: deprecated; not used, use ground_truth instead
             # gz_bridges.odom(self.model_name),
             # pose

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -258,6 +258,36 @@ class GpsTypeEnum(str, Enum):
         return bridges
 
 
+class AirPressureTypeEnum(str, Enum):
+    """Valid Air Pressure model types."""
+
+    AIR_PRESSURE = 'air_pressure'
+
+    @staticmethod
+    def bridges(
+        world_name: str,
+        model_name: str,
+        payload: str,
+        sensor_name: str,
+        model_prefix: str = '',
+    ) -> List[Bridge]:
+        """
+        Return bridges needed for air_pressure model.
+
+        :param world_name: gz world name
+        :param model_name: gz drone model name
+        :param payload: gz payload (sensor) model type
+        :param sensor_name: gz payload (sensor) model name
+        :param model_prefix: ros model prefix, defaults to ''
+        :return: list with bridges
+        """
+        bridges = [
+            gz_bridges.air_pressure(
+                world_name, model_name, sensor_name, payload, model_prefix)
+        ]
+        return bridges
+
+
 class GripperTypeEnum(str, Enum):
     """Valid gripper model types."""
 
@@ -344,7 +374,7 @@ class Payload(Entity):
     """
 
     model_type: Union[
-        CameraTypeEnum, DepthCameraTypeEnum, LidarTypeEnum, GpsTypeEnum, GimbalTypeEnum
+        CameraTypeEnum, DepthCameraTypeEnum, LidarTypeEnum, GpsTypeEnum, GimbalTypeEnum, AirPressureTypeEnum
     ] = None
     sensor_attached: str = 'None'
     sensor_attached_type: str = 'None'

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -374,7 +374,8 @@ class Payload(Entity):
     """
 
     model_type: Union[
-        CameraTypeEnum, DepthCameraTypeEnum, LidarTypeEnum, GpsTypeEnum, GimbalTypeEnum, AirPressureTypeEnum
+        CameraTypeEnum, DepthCameraTypeEnum, LidarTypeEnum, GpsTypeEnum, GimbalTypeEnum,
+        AirPressureTypeEnum
     ] = None
     sensor_attached: str = 'None'
     sensor_attached_type: str = 'None'

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -273,6 +273,7 @@ class AirPressureTypeEnum(str, Enum):
     ) -> List[Bridge]:
         """
         Return bridges needed for air_pressure model.
+
         :param world_name: gz world name
         :param model_name: gz drone model name
         :param payload: gz payload (sensor) model type
@@ -302,6 +303,7 @@ class MagnetometerTypeEnum(str, Enum):
     ) -> List[Bridge]:
         """
         Return bridges needed for magnetometer model.
+
         :param world_name: gz world name
         :param model_name: gz drone model name
         :param payload: gz payload (sensor) model type

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -266,10 +266,10 @@ class AirPressureTypeEnum(str, Enum):
     @staticmethod
     def bridges(
         world_name: str,
-        model_name: str,
-        payload: str,
-        sensor_name: str,
-        model_prefix: str = '',
+        drone_model_name: str,
+        sensor_model_name: str,
+        sensor_model_type: str,
+        sensor_model_prefix: str = '',
     ) -> List[Bridge]:
         """
         Return bridges needed for air_pressure model.
@@ -277,13 +277,15 @@ class AirPressureTypeEnum(str, Enum):
         :param world_name: gz world name
         :param model_name: gz drone model name
         :param payload: gz payload (sensor) model type
+
         :param sensor_name: gz payload (sensor) model name
         :param model_prefix: ros model prefix, defaults to ''
         :return: list with bridges
         """
         bridges = [
             gz_bridges.air_pressure(
-                world_name, model_name, sensor_name, payload, model_prefix)
+                world_name, drone_model_name, sensor_model_name,
+                sensor_model_type, sensor_model_prefix)
         ]
         return bridges
 

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -277,7 +277,6 @@ class AirPressureTypeEnum(str, Enum):
         :param world_name: gz world name
         :param model_name: gz drone model name
         :param payload: gz payload (sensor) model type
-
         :param sensor_name: gz payload (sensor) model name
         :param model_prefix: ros model prefix, defaults to ''
         :return: list with bridges
@@ -298,10 +297,10 @@ class MagnetometerTypeEnum(str, Enum):
     @staticmethod
     def bridges(
         world_name: str,
-        model_name: str,
-        payload: str,
-        sensor_name: str,
-        model_prefix: str = '',
+        drone_model_name: str,
+        sensor_model_name: str,
+        sensor_model_type: str,
+        sensor_model_prefix: str = '',
     ) -> List[Bridge]:
         """
         Return bridges needed for magnetometer model.
@@ -315,7 +314,8 @@ class MagnetometerTypeEnum(str, Enum):
         """
         bridges = [
             gz_bridges.magnetometer(
-                world_name, model_name, sensor_name, payload, model_prefix)
+                world_name, drone_model_name, sensor_model_name,
+                sensor_model_type, sensor_model_prefix)
         ]
         return bridges
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Set air pressure sensor by user instead of default sensor.
* Fix air pressure sdf format.

## Description of documentation updates required from your changes

To add sensor, must be defined in world config file as:

```
world_name: "empty"
drones:
  - model_type: "quadrotor_base"
    model_name: "drone0"
    xyz:
      - 0.0
      - 0.0
      - 0.3
    payload:
      - model_type: "air_pressure"
        model_name: "air_pressure"
```

