### PR TITLE
[as2_gazebo_assets] Set magnetometer sensor by user instead of default sensor

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/README.md
+++ b/as2_simulation_assets/as2_gazebo_assets/README.md
@@ -7,13 +7,14 @@ Tested on **Gazebo Fortress**. Make sure to have it [installed](https://gazebosi
 Gazebo naming has changed between ROS2 Galactic and ROS2 Humble releases [(Gazeno new era)](https://discourse.ros.org/t/a-new-era-for-gazebo-cross-post/25012). You should use *as2_gazebo_assets* package version corresponding to your ROS2 version.
 
 ## INDEX
+- [INDEX](#index)
 - [RESOURCES](#resources)
-    - [DRONES](#drone-models)
-    - [SENSORS](#sensor-models)
-    - [WORLDS](#world-models)
-- [HOW TO RUN](#how-to-run-basic-usage)
-    - [OPTIONS](#options)
-    - [CONFIG FILE](#config-file)
+  - [DRONE MODELS](#drone-models)
+  - [SENSOR MODELS](#sensor-models)
+  - [WORLD MODELS](#world-models)
+- [HOW TO RUN: Basic usage](#how-to-run-basic-usage)
+  - [OPTIONS](#options)
+  - [CONFIG FILE](#config-file)
 - [EXAMPLES](#examples)
 ---
 
@@ -39,7 +40,7 @@ There are distinguish three kinds of reources: drone, sensor and world models.
 | - | - | - |
 | *imu* | **NOT SDF**: Alreay included in drone models. IMU sensor reports vertical position, angular velocity and linear acceleration readings. | ignition::gazebo::systems::Imu |
 | *air_pressure* | **NOT SDF**: Alreay included in drone models. Air pressure sensor reports vertical position and velocity readings. | ignition::gazebo::systems::AirPressure |
-| *magnetometer* | **NOT SDF**: Alreay included in drone models. Magnetometer sensor reports the magnetic field in its current location. | ignition::gazebo::systems::Magnetometer |
+| *magnetometer* | Magnetometer sensor reports the magnetic field in its current location. | ignition::gazebo::systems::Magnetometer |
 | *hd_camera* | RGB Camera with 1280x960 resolution. | - |
 | *vga_camera* | RGB Camera with 640x480 resolution. | - |
 | *semantic_camera* | RGB Camera with 1280x960 resolution with semantic segmentation data. | - |

--- a/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
@@ -232,10 +232,6 @@
           filename="ignition-gazebo-imu-system"
           name="ignition::gazebo::systems::Imu">
       </plugin>
-      <plugin
-          filename="ignition-gazebo-magnetometer-system"
-          name="ignition::gazebo::systems::Magnetometer">
-      </plugin>
 
   </model>
 </sdf>

--- a/as2_simulation_assets/as2_gazebo_assets/models/hexrotor_base/hexrotor_base.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/hexrotor_base/hexrotor_base.sdf.jinja
@@ -370,10 +370,6 @@
         filename="ignition-gazebo-imu-system"
         name="ignition::gazebo::systems::Imu">
         </plugin>
-        <plugin
-        filename="ignition-gazebo-magnetometer-system"
-        name="ignition::gazebo::systems::Magnetometer">
-        </plugin>
 
     </model>
 </sdf>

--- a/as2_simulation_assets/as2_gazebo_assets/models/magnetometer/magnetometer.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/magnetometer/magnetometer.sdf
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name='magnetometer'>
+    <plugin
+        filename="ignition-gazebo-magnetometer-system"
+        name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+    <link name="magnetometer">
+        <inertial>
+            <mass>0.005</mass>
+            <inertia>
+                <ixx>8.33e-06</ixx>
+                <ixy>0</ixy>
+                <ixz>0</ixz>
+                <iyy>8.33e-06</iyy>
+                <iyz>0</iyz>
+                <izz>8.33e-06</izz>
+            </inertia>
+        </inertial>
+        <sensor name='magnetometer' type='magnetometer'>
+            <always_on>1</always_on>
+            <update_rate>20</update_rate>
+            <magnetometer>
+                <x>
+                    <noise type='gaussian'>
+                        <mean>0.000000080</mean>
+                        <bias_mean>0.000000400</bias_mean>
+                    </noise>
+                </x>
+                <y>
+                    <noise type='gaussian'>
+                        <mean>0.000000080</mean>
+                        <bias_mean>0.000000400</bias_mean>
+                    </noise>
+                </y>
+                <z>
+                    <noise type='gaussian'>
+                        <mean>0.000000080</mean>
+                        <bias_mean>0.000000400</bias_mean>
+                    </noise>
+                </z>
+            </magnetometer>
+        </sensor>
+    </link>
+  </model>
+</sdf>

--- a/as2_simulation_assets/as2_gazebo_assets/models/magnetometer/model.config
+++ b/as2_simulation_assets/as2_gazebo_assets/models/magnetometer/model.config
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>magnetometer</name>
+  <version>1.0</version>
+  <sdf version="1.6">magnetometer.sdf</sdf>
+
+  <author>
+    <name>Pedro Arias-perez</name>
+    <email>pedro.ariasp@upm.es</email>
+  </author>
+
+  <author>
+    <name>Rafael Perez-Segui</name>
+    <email>r.psegui@upm.es</email>
+  </author>
+
+  <description>
+    A model of a magnetometer sensor.
+  </description>
+</model>

--- a/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf
+++ b/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf
@@ -191,52 +191,6 @@
             <child>air_pressure</child>
         </joint>
 
-        <!-- MAGNETOMETER -->
-        <model name='magnetometer'>
-            <link name="internal">
-                <inertial>
-                    <mass>0.005</mass>
-                    <inertia>
-                        <ixx>8.33e-06</ixx>
-                        <ixy>0</ixy>
-                        <ixz>0</ixz>
-                        <iyy>8.33e-06</iyy>
-                        <iyz>0</iyz>
-                        <izz>8.33e-06</izz>
-                    </inertia>
-                </inertial>
-                <sensor name='magnetometer' type='magnetometer'>
-                    <always_on>1</always_on>
-                    <update_rate>20</update_rate>
-                    <magnetometer>
-                        <x>
-                            <noise type='gaussian'>
-                                <mean>0.000000080</mean>
-                                <bias_mean>0.000000400</bias_mean>
-                            </noise>
-                        </x>
-                        <y>
-                            <noise type='gaussian'>
-                                <mean>0.000000080</mean>
-                                <bias_mean>0.000000400</bias_mean>
-                            </noise>
-                        </y>
-                        <z>
-                            <noise type='gaussian'>
-                                <mean>0.000000080</mean>
-                                <bias_mean>0.000000400</bias_mean>
-                            </noise>
-                        </z>
-                    </magnetometer>
-                </sensor>
-            </link>
-        </model>
-
-        <joint name="magnetometer_joint" type="fixed">
-            <parent>base_link</parent>
-            <child>magnetometer</child>
-        </joint>
-
         <link name='rotor_0'>
             <pose>0.13 -0.22 0.023 0 -0 0</pose>
             <inertial>

--- a/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf.jinja
@@ -239,10 +239,6 @@
             filename="ignition-gazebo-imu-system"
             name="ignition::gazebo::systems::Imu">
         </plugin>
-        <plugin
-            filename="ignition-gazebo-magnetometer-system"
-            name="ignition::gazebo::systems::Magnetometer">
-        </plugin>
 
     </model>
 </sdf>

--- a/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf.jinja
@@ -220,10 +220,6 @@
           filename="ignition-gazebo-imu-system"
           name="ignition::gazebo::systems::Imu">
       </plugin>
-      <plugin
-          filename="ignition-gazebo-magnetometer-system"
-          name="ignition::gazebo::systems::Magnetometer">
-      </plugin>
 
   </model>
 </sdf>

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -107,9 +107,6 @@ class Drone(Entity):
             # IMU
             gz_bridges.imu(
                 world_name, self.model_name, 'imu', 'internal'),
-            # Magnetometer
-            gz_bridges.magnetometer(
-                world_name, self.model_name, 'magnetometer', 'internal'),
             # Air Pressure
             gz_bridges.air_pressure(
                 world_name, self.model_name, 'air_pressure', 'internal'),

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -258,6 +258,34 @@ class GpsTypeEnum(str, Enum):
         return bridges
 
 
+class MagnetometerTypeEnum(str, Enum):
+    """Valid magnetometer model types."""
+
+    MAGNETOMETER = 'magnetometer'
+
+    @staticmethod
+    def bridges(
+        world_name: str,
+        model_name: str,
+        payload: str,
+        sensor_name: str,
+        model_prefix: str = '',
+    ) -> List[Bridge]:
+        """
+        Return bridges needed for magnetometer model.
+        :param world_name: gz world name
+        :param model_name: gz drone model name
+        :param payload: gz payload (sensor) model type
+        :param sensor_name: gz payload (sensor) model name
+        :param model_prefix: ros model prefix, defaults to ''
+        :return: list with bridges
+        """
+        bridges = [
+            gz_bridges.magnetometer(
+                world_name, model_name, sensor_name, payload, model_prefix)
+        ]
+        return bridges
+
 class GripperTypeEnum(str, Enum):
     """Valid gripper model types."""
 
@@ -344,7 +372,8 @@ class Payload(Entity):
     """
 
     model_type: Union[
-        CameraTypeEnum, DepthCameraTypeEnum, LidarTypeEnum, GpsTypeEnum, GimbalTypeEnum
+        CameraTypeEnum, DepthCameraTypeEnum, LidarTypeEnum, GpsTypeEnum, GimbalTypeEnum,
+        MagnetometerTypeEnum
     ] = None
     sensor_attached: str = 'None'
     sensor_attached_type: str = 'None'

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -273,6 +273,7 @@ class MagnetometerTypeEnum(str, Enum):
     ) -> List[Bridge]:
         """
         Return bridges needed for magnetometer model.
+
         :param world_name: gz world name
         :param model_name: gz drone model name
         :param payload: gz payload (sensor) model type
@@ -285,6 +286,7 @@ class MagnetometerTypeEnum(str, Enum):
                 world_name, model_name, sensor_name, payload, model_prefix)
         ]
         return bridges
+
 
 class GripperTypeEnum(str, Enum):
     """Valid gripper model types."""


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Set magnetometer sensor by user instead of default sensor.

## Description of documentation updates required from your changes

To add sensor, must be defined in world config file as:

```
world_name: "empty"
drones:
  - model_type: "quadrotor_base"
    model_name: "drone0"
    xyz:
      - 0.0
      - 0.0
      - 0.3
    payload:
      - model_type: "magnetometer"
        model_name: "magnetometer"
```
