### PR TITLE
[as2_state_estimator] Improve mocap plugin

### DIFF
--- a/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
+++ b/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
@@ -105,7 +105,7 @@ public:
     }
 
     rigid_bodies_sub_ = node_ptr_->create_subscription<mocap4r2_msgs::msg::RigidBodies>(
-      mocap_topic_, rclcpp::QoS(1000),
+      mocap_topic_, rclcpp::QoS(10),
       std::bind(&Plugin::rigid_bodies_callback, this, std::placeholders::_1));
 
     // publish static transform from earth to map and map to odom

--- a/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
+++ b/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
@@ -230,7 +230,9 @@ private:
 
     // Publish pose
     geometry_msgs::msg::PoseStamped pose_msg;
-    pose_msg.header.stamp = msg.header.stamp;
+    // To avoid time divergence between mocap node and state estimator node
+    // pose_msg.header.stamp = msg.header.stamp;
+    pose_msg.header.stamp = node_ptr_->now();
     pose_msg.header.frame_id = get_earth_frame();
     pose_msg.pose = msg.pose;
     pose_msg.pose.orientation.x = orientation_alpha_ * msg.pose.orientation.x +


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | PX4 |

---

## Description of contribution in a few bullet points

* Change callback QoS queue size
* Use state estimator node time to avoid time divergence when mocap node and state estimator node are running in differents computers (quick fix)


## Future work that may be required in bullet points

* Instead of using state estimator node time, we should use rigid bodies timestamp for topics and tf, and synchronize computers
