### PR TITLE
[as2_map_server] New depth image to occupancy grid plugin

### DIFF
--- a/as2_map_server/CMakeLists.txt
+++ b/as2_map_server/CMakeLists.txt
@@ -36,7 +36,7 @@ set(PROJECT_DEPENDENCIES
   OpenCV
 )
 
-# find_package(backward_ros REQUIRED)
+find_package(backward_ros REQUIRED)
 
 foreach(DEPENDENCY ${PROJECT_DEPENDENCIES})
   find_package(${DEPENDENCY} REQUIRED)
@@ -112,40 +112,17 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-###### PLUGIN LIBRARIES ######
-set(PLUGIN_NAME mapping_2d)
-set(PLUGIN_CPP_FILES
-  plugins/${PLUGIN_NAME}/src/${PLUGIN_NAME}.cpp
+#####
+set(PLUGIN_LIST
+  mapping_2d
+  depth2occ_grid
 )
 
-include_directories(
-  plugins/${PLUGIN_NAME}/include
-  plugins/${PLUGIN_NAME}/include/${PLUGIN_NAME}
-)
-
-add_library(${PLUGIN_NAME} SHARED plugins/${PLUGIN_NAME}/src/${PLUGIN_NAME}.cpp)
-target_link_libraries(${PLUGIN_NAME} as2_map_server_base)
-ament_target_dependencies(${PLUGIN_NAME} ${PROJECT_DEPENDENCIES})
-
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
-
-ament_export_include_directories(include)
-ament_export_libraries(${PLUGIN_NAME})
-ament_export_targets(export_${PLUGIN_NAME})
-
-install(
-  TARGETS ${PLUGIN_NAME}
-  EXPORT export_${PLUGIN_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
+foreach(PLUGIN_NAME ${PLUGIN_LIST})
+  add_subdirectory(plugins/${PLUGIN_NAME})
+endforeach()
 
 pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)
-
 
 ###### SHARES INSTALLATION ######
 install(DIRECTORY
@@ -153,11 +130,19 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(DIRECTORY
-  # config
-  plugins/${PLUGIN_NAME}/config
-  DESTINATION share/${PROJECT_NAME}
-)
+# For each plugin, install shared files
+foreach(PLUGIN_NAME ${PLUGIN_LIST})
+  install(DIRECTORY
+    # launch
+    plugins/${PLUGIN_NAME}/launch
+    DESTINATION share/${PROJECT_NAME}
+  )
+  install(DIRECTORY
+    # config
+    plugins/${PLUGIN_NAME}/config
+    DESTINATION share/${PROJECT_NAME}/plugins/${PLUGIN_NAME}
+  )
+endforeach()
 
 # Build tests if testing is enabled
 if(BUILD_TESTING)

--- a/as2_map_server/package.xml
+++ b/as2_map_server/package.xml
@@ -21,6 +21,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>depthimage_to_laserscan</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/as2_map_server/plugins.xml
+++ b/as2_map_server/plugins.xml
@@ -1,7 +1,10 @@
 <class_libraries>
   <library path="mapping_2d">
     <class type="mapping_2d::Plugin" base_class_type="as2_map_server_plugin_base::MapServerBase">
-      <description>Map server plugin for 2d mapping.</description>
+      <description>Map server plugin for 2d mapping. From laser scan to occupancy grid.</description>
+    </class>
+    <class type="depth2occ_grid::Plugin" base_class_type="as2_map_server_plugin_base::MapServerBase">
+      <description>Map server plugin for 2d mapping. From depth image to occupancy grid.</description>
     </class>
   </library>
 </class_libraries>

--- a/as2_map_server/plugins/depth2occ_grid/CMakeLists.txt
+++ b/as2_map_server/plugins/depth2occ_grid/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5)
+set(PLUGIN_NAME depth2occ_grid)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# set Release as default
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# find dependencies
+set(PLUGIN_DEPENDENCIES
+  ament_cmake
+  depthimage_to_laserscan
+)
+
+foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
+  find_package(${DEPENDENCY} REQUIRED)
+endforeach()
+
+# PLUGIN TESTS
+# if(BUILD_TESTING)
+#   add_subdirectory(tests)
+# endif()

--- a/as2_map_server/plugins/depth2occ_grid/config/plugin_default.yaml
+++ b/as2_map_server/plugins/depth2occ_grid/config/plugin_default.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     # depthimage_to_laserscan
     depth_topic_in: sensor_measurements/front_camera/depth
-    depth_camera_info_topic_in: sensor_measurements/front_camera/depth
+    depth_camera_info_topic_in: sensor_measurements/front_camera/camera_info
     scan_topic_out: sensor_measurements/lidar/scan
     scan_height: 1  # [pixel]
     scan_time: 0.033  # [s]

--- a/as2_map_server/plugins/depth2occ_grid/config/plugin_default.yaml
+++ b/as2_map_server/plugins/depth2occ_grid/config/plugin_default.yaml
@@ -4,7 +4,7 @@
     depth_topic_in: sensor_measurements/front_camera/depth
     depth_camera_info_topic_in: sensor_measurements/front_camera/depth
     scan_topic_out: sensor_measurements/lidar/scan
-    scan_height: 5  # [pixel]
+    scan_height: 1  # [pixel]
     scan_time: 0.033  # [s]
     range_min: 0.45  # [m]
     range_max: 10.0  # [m]

--- a/as2_map_server/plugins/depth2occ_grid/config/plugin_default.yaml
+++ b/as2_map_server/plugins/depth2occ_grid/config/plugin_default.yaml
@@ -1,0 +1,16 @@
+/**:
+  ros__parameters:
+    # depthimage_to_laserscan
+    depth_topic_in: sensor_measurements/front_camera/depth
+    depth_camera_info_topic_in: sensor_measurements/front_camera/depth
+    scan_topic_out: sensor_measurements/lidar/scan
+    scan_height: 5  # [pixel]
+    scan_time: 0.033  # [s]
+    range_min: 0.45  # [m]
+    range_max: 10.0  # [m]
+    output_frame: drone0/front_camera/rgbd_camera
+    # laserscan_to_occgrid
+    scan_range_max: 30.0  # [m]
+    map_resolution: 0.1  # [m/cell]
+    map_width: 300  # [cells]
+    map_height: 300  # [cells]

--- a/as2_map_server/plugins/depth2occ_grid/launch/depth2occ_grid-map_server.launch.py
+++ b/as2_map_server/plugins/depth2occ_grid/launch/depth2occ_grid-map_server.launch.py
@@ -28,75 +28,63 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""as2_map_server generic launch file."""
+"""as2_map_server depth2occ_grid plugin launch file."""
 
 from __future__ import annotations
 
 import os
-from xml.etree import ElementTree
 
 from ament_index_python.packages import get_package_share_directory
 from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
-from launch import LaunchContext, LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
-
-
-def get_available_plugins(package_name: str, plugin_type: str = '') -> list[str]:
-    """Parse plugins.xml file from package and return a list of plugins from a specific type."""
-    plugins_file = os.path.join(
-        get_package_share_directory(package_name),
-        'plugins.xml'
-    )
-    root = ElementTree.parse(plugins_file).getroot()
-    root = root.find('library') if root.tag == 'class_libraries' else root
-
-    available_plugins = []
-    for class_element in root.findall('class'):
-        if plugin_type in class_element.attrib['type']:
-            available_plugins.append(
-                class_element.attrib['type'].split('::')[0])
-    return available_plugins
-
-
-def get_launch_file(context: LaunchContext) -> str:
-    """Return the python launcher for a specific plugin."""
-    plugin_name = LaunchConfiguration('plugin_name').perform(context)
-    return [
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([
-                os.path.join(
-                    get_package_share_directory('as2_map_server'), 'launch/'),
-                plugin_name + '-map_server.launch.py'
-            ]),
-            launch_arguments={
-                'use_sim_time': LaunchConfiguration('use_sim_time'),
-                'namespace': LaunchConfiguration('namespace'),
-                'plugin_config_file': LaunchConfiguration('plugin_config_file')}.items()
-        )
-    ]
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node, SetParameter
 
 
 def generate_launch_description():
     """Launcher entrypoint."""
-    # TODO(pariaspe): map_server config file
-    # config_file = os.path.join(get_package_share_directory('as2_map_server'),
-    #                            'config/plugin_default.yaml')
-    plugin_config_file = PathJoinSubstitution([
-        get_package_share_directory('as2_map_server'),
-        'plugins', LaunchConfiguration('plugin_name'), 'config/plugin_default.yaml'
-    ])
+    plugin_config_file = os.path.join(get_package_share_directory('as2_map_server'),
+                                      'plugins/depth2occ_grid/config/plugin_default.yaml')
     return LaunchDescription([
         DeclareLaunchArgument('use_sim_time', default_value='false'),
         DeclareLaunchArgument('namespace',
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID'),
                               description='Drone namespace'),
-        DeclareLaunchArgument('plugin_name', description='Plugin name',
-                              choices=get_available_plugins('as2_map_server')),
         DeclareLaunchArgumentsFromConfigFile(
             name='plugin_config_file', source_file=plugin_config_file,
             description='Plugin configuration file'),
-        OpaqueFunction(function=get_launch_file),
+        SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
+        Node(
+            package='depthimage_to_laserscan',
+            executable='depthimage_to_laserscan_node',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            emulate_tty=True,
+            remappings=[
+                ('depth', LaunchConfiguration('depth_topic_in')),
+                ('depth_camera_info', LaunchConfiguration('depth_camera_info_topic_in')),
+                ('scan', LaunchConfiguration('scan_topic_out'))
+            ],
+            parameters=[
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        ),
+        Node(
+            package='as2_map_server',
+            executable='as2_map_server_node',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                {'plugin_name': 'mapping_2d'},
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        )
     ])

--- a/as2_map_server/plugins/mapping_2d/CMakeLists.txt
+++ b/as2_map_server/plugins/mapping_2d/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.5)
+set(PLUGIN_NAME mapping_2d)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# set Release as default
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# find dependencies
+set(PLUGIN_DEPENDENCIES
+  ament_cmake
+  rclcpp
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
+  geometry_msgs
+  nav_msgs
+  sensor_msgs
+  OpenCV
+)
+
+foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
+  find_package(${DEPENDENCY} REQUIRED)
+endforeach()
+
+include_directories(
+  include
+  include/${PLUGIN_NAME}
+)
+
+add_library(${PLUGIN_NAME} SHARED src/${PLUGIN_NAME}.cpp)
+target_link_libraries(${PLUGIN_NAME} as2_map_server_base)
+ament_target_dependencies(${PLUGIN_NAME} ${PLUGIN_DEPENDENCIES})
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PLUGIN_NAME})
+ament_export_targets(export_${PLUGIN_NAME})
+
+install(
+  TARGETS ${PLUGIN_NAME}
+  EXPORT export_${PLUGIN_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# PLUGIN TESTS
+# if(BUILD_TESTING)
+#   add_subdirectory(tests)
+# endif()

--- a/as2_map_server/plugins/mapping_2d/launch/mapping_2d-map_server.launch.py
+++ b/as2_map_server/plugins/mapping_2d/launch/mapping_2d-map_server.launch.py
@@ -28,75 +28,46 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""as2_map_server generic launch file."""
+"""as2_map_server mapping_2d plugin launch file."""
 
 from __future__ import annotations
 
 import os
-from xml.etree import ElementTree
 
 from ament_index_python.packages import get_package_share_directory
 from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
-from launch import LaunchContext, LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
-
-
-def get_available_plugins(package_name: str, plugin_type: str = '') -> list[str]:
-    """Parse plugins.xml file from package and return a list of plugins from a specific type."""
-    plugins_file = os.path.join(
-        get_package_share_directory(package_name),
-        'plugins.xml'
-    )
-    root = ElementTree.parse(plugins_file).getroot()
-    root = root.find('library') if root.tag == 'class_libraries' else root
-
-    available_plugins = []
-    for class_element in root.findall('class'):
-        if plugin_type in class_element.attrib['type']:
-            available_plugins.append(
-                class_element.attrib['type'].split('::')[0])
-    return available_plugins
-
-
-def get_launch_file(context: LaunchContext) -> str:
-    """Return the python launcher for a specific plugin."""
-    plugin_name = LaunchConfiguration('plugin_name').perform(context)
-    return [
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([
-                os.path.join(
-                    get_package_share_directory('as2_map_server'), 'launch/'),
-                plugin_name + '-map_server.launch.py'
-            ]),
-            launch_arguments={
-                'use_sim_time': LaunchConfiguration('use_sim_time'),
-                'namespace': LaunchConfiguration('namespace'),
-                'plugin_config_file': LaunchConfiguration('plugin_config_file')}.items()
-        )
-    ]
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node
 
 
 def generate_launch_description():
     """Launcher entrypoint."""
-    # TODO(pariaspe): map_server config file
-    # config_file = os.path.join(get_package_share_directory('as2_map_server'),
-    #                            'config/plugin_default.yaml')
-    plugin_config_file = PathJoinSubstitution([
-        get_package_share_directory('as2_map_server'),
-        'plugins', LaunchConfiguration('plugin_name'), 'config/plugin_default.yaml'
-    ])
+    plugin_config_file = os.path.join(get_package_share_directory('as2_map_server'),
+                                      'plugins/mapping_2d/config/plugin_default.yaml')
     return LaunchDescription([
         DeclareLaunchArgument('use_sim_time', default_value='false'),
         DeclareLaunchArgument('namespace',
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID'),
                               description='Drone namespace'),
-        DeclareLaunchArgument('plugin_name', description='Plugin name',
-                              choices=get_available_plugins('as2_map_server')),
         DeclareLaunchArgumentsFromConfigFile(
             name='plugin_config_file', source_file=plugin_config_file,
             description='Plugin configuration file'),
-        OpaqueFunction(function=get_launch_file),
+        Node(
+            package='as2_map_server',
+            executable='as2_map_server_node',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                {'use_sim_time': LaunchConfiguration('use_sim_time'),
+                 'plugin_name': 'mapping_2d'},
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        )
     ])

--- a/as2_map_server/plugins/mapping_2d/src/mapping_2d.cpp
+++ b/as2_map_server/plugins/mapping_2d/src/mapping_2d.cpp
@@ -116,6 +116,11 @@ void mapping_2d::Plugin::on_laser_scan(const sensor_msgs::msg::LaserScan::Shared
       msg->ranges[i] = msg->range_max;
     }
 
+    // check if range is nan
+    if (std::isnan(msg->ranges[i])) {
+      msg->ranges[i] = msg->range_max;
+    }
+
     // Clip range to parameter to clean noise
     if (msg->ranges[i] > scan_range_max_) {
       msg->ranges[i] = scan_range_max_;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Added new plugin `depth2occ_grid`. New plugin is a zero-code plugin. It only contains launcher and config file. It consists of an input adaptation (`depthimage_to_laserscan` from `ros-perception`) and the `map_server` running with `mapping_2d` plugin.
* CMakeLists structure changed to build plugin libraries from each plugin CMake.
* Created generic launcher and specific launcher at each plugin. The generic one just includes the launcher of the plugin selected.
* Bug on `mapping_2d` plugin fixed when scan range is NaN.

## Description of documentation updates required from your changes

* New entry in documentation explaining the map server and its plugins

![as2_map_server_plugins](https://github.com/user-attachments/assets/5d9d9b2c-4479-431e-a63b-a3210e35d491)

---

## Future work that may be required in bullet points

* Rename `mapping_2d` plugin to `scan2occ_grid`.