### PR TITLE
[aerostack2] Convert trajectory references into an array of references

### DIFF
--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_platform_multirotor_simulator.cpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_platform_multirotor_simulator.cpp
@@ -258,15 +258,15 @@ bool MultirotorSimulatorPlatform::ownSendCommand()
     case as2_msgs::msg::ControlMode::TRAJECTORY:
       {
         Eigen::Vector3d position, velocity, acceleration;
-        position.x() = command_trajectory_msg_.position.x;
-        position.y() = command_trajectory_msg_.position.y;
-        position.z() = command_trajectory_msg_.position.z;
-        velocity.x() = command_trajectory_msg_.twist.x;
-        velocity.y() = command_trajectory_msg_.twist.y;
-        velocity.z() = command_trajectory_msg_.twist.z;
-        acceleration.x() = command_trajectory_msg_.acceleration.x;
-        acceleration.y() = command_trajectory_msg_.acceleration.y;
-        acceleration.z() = command_trajectory_msg_.acceleration.z;
+        position.x() = command_trajectory_msg_.setpoints[0].position.x;
+        position.y() = command_trajectory_msg_.setpoints[0].position.y;
+        position.z() = command_trajectory_msg_.setpoints[0].position.z;
+        velocity.x() = command_trajectory_msg_.setpoints[0].twist.x;
+        velocity.y() = command_trajectory_msg_.setpoints[0].twist.y;
+        velocity.z() = command_trajectory_msg_.setpoints[0].twist.z;
+        acceleration.x() = command_trajectory_msg_.setpoints[0].acceleration.x;
+        acceleration.y() = command_trajectory_msg_.setpoints[0].acceleration.y;
+        acceleration.z() = command_trajectory_msg_.setpoints[0].acceleration.z;
 
         simulator_.set_reference_trajectory(
           position, velocity, acceleration);
@@ -305,7 +305,7 @@ bool MultirotorSimulatorPlatform::ownSendCommand()
         if (current_control_mode.control_mode ==
           as2_msgs::msg::ControlMode::TRAJECTORY)
         {
-          yaw = command_trajectory_msg_.yaw_angle;
+          yaw = command_trajectory_msg_.setpoints[0].yaw_angle;
         } else {
           as2::frame::quaternionToEuler(command_pose_msg_.pose.orientation, roll, pitch, yaw);
         }

--- a/as2_core/include/as2_core/aerial_platform.hpp
+++ b/as2_core/include/as2_core/aerial_platform.hpp
@@ -52,7 +52,7 @@
 #include "as2_msgs/msg/platform_info.hpp"
 #include "as2_msgs/msg/platform_status.hpp"
 #include "as2_msgs/msg/thrust.hpp"
-#include "as2_msgs/msg/trajectory_point.hpp"
+#include "as2_msgs/msg/trajectory_setpoints.hpp"
 #include "as2_msgs/srv/list_control_modes.hpp"
 #include "as2_msgs/srv/set_control_mode.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -90,7 +90,7 @@ protected:
   float cmd_freq_;
   float info_freq_;
 
-  as2_msgs::msg::TrajectoryPoint command_trajectory_msg_;
+  as2_msgs::msg::TrajectorySetpoints command_trajectory_msg_;
   geometry_msgs::msg::PoseStamped command_pose_msg_;
   geometry_msgs::msg::TwistStamped command_twist_msg_;
   as2_msgs::msg::Thrust command_thrust_msg_;
@@ -307,7 +307,7 @@ protected:
 private:
   rclcpp::Publisher<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_pub_;
 
-  rclcpp::Subscription<as2_msgs::msg::TrajectoryPoint>::SharedPtr trajectory_command_sub_;
+  rclcpp::Subscription<as2_msgs::msg::TrajectorySetpoints>::SharedPtr trajectory_command_sub_;
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_command_sub_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_command_sub_;
   rclcpp::Subscription<as2_msgs::msg::Thrust>::SharedPtr thrust_command_sub_;

--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -67,10 +67,10 @@ void AerialPlatform::initialize()
 
     this->loadControlModes(control_modes_file);
 
-    trajectory_command_sub_ = this->create_subscription<as2_msgs::msg::TrajectoryPoint>(
+    trajectory_command_sub_ = this->create_subscription<as2_msgs::msg::TrajectorySetpoints>(
       this->generate_global_name(as2_names::topics::actuator_command::trajectory),
       as2_names::topics::actuator_command::qos,
-      [this](const as2_msgs::msg::TrajectoryPoint::ConstSharedPtr msg) {
+      [this](const as2_msgs::msg::TrajectorySetpoints::ConstSharedPtr msg) {
         this->command_trajectory_msg_ = *msg.get();
         has_new_references_ = true;
       });

--- a/as2_core/tests/mocks/aerial_platform/mock_aerial_platform.cpp
+++ b/as2_core/tests/mocks/aerial_platform/mock_aerial_platform.cpp
@@ -103,7 +103,7 @@ PlatformMockNode::PlatformMockNode(
     });
 
   // Publishers
-  trajectory_command_pub_ = this->create_publisher<as2_msgs::msg::TrajectoryPoint>(
+  trajectory_command_pub_ = this->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
     as2_names::topics::actuator_command::trajectory,
     as2_names::topics::actuator_command::qos);
 
@@ -339,7 +339,7 @@ const sensor_msgs::msg::NavSatFix & PlatformMockNode::getGps() const
 }
 
 void PlatformMockNode::setCommandTrajectoryPoint(
-  const as2_msgs::msg::TrajectoryPoint & trajectory_point)
+  const as2_msgs::msg::TrajectorySetpoints & trajectory_point)
 {
   trajectory_command_ = trajectory_point;
 }

--- a/as2_core/tests/mocks/aerial_platform/mock_aerial_platform.hpp
+++ b/as2_core/tests/mocks/aerial_platform/mock_aerial_platform.hpp
@@ -49,7 +49,7 @@
 #include "as2_msgs/srv/set_platform_state_machine_event.hpp"
 #include "as2_msgs/srv/set_control_mode.hpp"
 #include "as2_msgs/msg/thrust.hpp"
-#include "as2_msgs/msg/trajectory_point.hpp"
+#include "as2_msgs/msg/trajectory_setpoints.hpp"
 #include "as2_msgs/msg/alert_event.hpp"
 #include "as2_msgs/msg/platform_info.hpp"
 #include "as2_core/names/topics.hpp"
@@ -257,7 +257,7 @@ public:
    *
    * @param trajectory_point trajectory point to publish
    */
-  void setCommandTrajectoryPoint(const as2_msgs::msg::TrajectoryPoint & trajectory_point);
+  void setCommandTrajectoryPoint(const as2_msgs::msg::TrajectorySetpoints & trajectory_point);
 
   /**
    * @brief Set a command pose
@@ -348,7 +348,7 @@ private:
   rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr land_srv_cli_;
 
   // Publisher
-  rclcpp::Publisher<as2_msgs::msg::TrajectoryPoint>::SharedPtr trajectory_command_pub_;
+  rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr trajectory_command_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_command_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_command_pub_;
   rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr thrust_command_pub_;
@@ -369,7 +369,7 @@ private:
   sensor_msgs::msg::NavSatFix gps_;
 
   // Publishers data
-  as2_msgs::msg::TrajectoryPoint trajectory_command_;
+  as2_msgs::msg::TrajectorySetpoints trajectory_command_;
   geometry_msgs::msg::PoseStamped pose_command_;
   geometry_msgs::msg::TwistStamped twist_command_;
   as2_msgs::msg::Thrust thrust_command_;

--- a/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
@@ -46,7 +46,7 @@
 #include "as2_core/node.hpp"
 #include "as2_msgs/msg/control_mode.hpp"
 #include "as2_msgs/msg/thrust.hpp"
-#include "as2_msgs/msg/trajectory_point.hpp"
+#include "as2_msgs/msg/trajectory_setpoints.hpp"
 
 namespace as2_motion_controller_plugin_base
 {
@@ -101,10 +101,10 @@ public:
   virtual void updateReference(const geometry_msgs::msg::TwistStamped & ref) {}
   /*
    * @brief Update the reference to be used by the controller plugin
-   * @param ref as2_msgs::msg::TrajectoryPoint message with the current reference of
+   * @param ref as2_msgs::msg::TrajectorySetpoints message with the current reference of
    * the robot in the "odom" frame
    */
-  virtual void updateReference(const as2_msgs::msg::TrajectoryPoint & ref) {}
+  virtual void updateReference(const as2_msgs::msg::TrajectorySetpoints & ref) {}
 
   /*
    * @brief Update the thrust reference to be used by the controller plugin

--- a/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
@@ -65,7 +65,7 @@
 #include "as2_msgs/msg/control_mode.hpp"
 #include "as2_msgs/msg/platform_info.hpp"
 #include "as2_msgs/msg/thrust.hpp"
-#include "as2_msgs/msg/trajectory_point.hpp"
+#include "as2_msgs/msg/trajectory_setpoints.hpp"
 #include "as2_msgs/srv/list_control_modes.hpp"
 #include "as2_msgs/srv/set_control_mode.hpp"
 
@@ -126,12 +126,12 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_sub_;
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr ref_pose_sub_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr ref_twist_sub_;
+  rclcpp::Subscription<as2_msgs::msg::TrajectorySetpoints>::SharedPtr ref_traj_sub_;
   rclcpp::Subscription<as2_msgs::msg::Thrust>::SharedPtr ref_thrust_sub_;
   rclcpp::Subscription<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_sub_;
-  rclcpp::Subscription<as2_msgs::msg::TrajectoryPoint>::SharedPtr ref_traj_sub_;
 
   // Publishers
-  rclcpp::Publisher<as2_msgs::msg::TrajectoryPoint>::SharedPtr trajectory_pub_;
+  rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr trajectory_pub_;
   rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr thrust_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
@@ -168,8 +168,8 @@ private:
   geometry_msgs::msg::TwistStamped state_twist_;
   geometry_msgs::msg::PoseStamped ref_pose_;
   geometry_msgs::msg::TwistStamped ref_twist_;
+  as2_msgs::msg::TrajectorySetpoints ref_traj_;
   as2_msgs::msg::Thrust ref_thrust_;
-  as2_msgs::msg::TrajectoryPoint ref_traj_;
   geometry_msgs::msg::PoseStamped command_pose_;
   geometry_msgs::msg::TwistStamped command_twist_;
   as2_msgs::msg::Thrust command_thrust_;
@@ -182,8 +182,8 @@ private:
   void stateCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
   void refPoseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
   void refTwistCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
+  void refTrajCallback(const as2_msgs::msg::TrajectorySetpoints::SharedPtr msg);
   void refThrustCallback(const as2_msgs::msg::Thrust::SharedPtr msg);
-  void refTrajCallback(const as2_msgs::msg::TrajectoryPoint::SharedPtr msg);
   void platformInfoCallback(const as2_msgs::msg::PlatformInfo::SharedPtr msg);
 
   // Services servers callbacks

--- a/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
@@ -48,7 +48,7 @@
 #include "as2_core/utils/frame_utils.hpp"
 #include "as2_core/utils/tf_utils.hpp"
 #include "as2_msgs/msg/thrust.hpp"
-#include "as2_msgs/msg/trajectory_point.hpp"
+#include "as2_msgs/msg/trajectory_setpoints.hpp"
 
 #include "as2_motion_controller/controller_base.hpp"
 
@@ -137,7 +137,7 @@ public:
     const geometry_msgs::msg::PoseStamped & pose_msg,
     const geometry_msgs::msg::TwistStamped & twist_msg) override;
 
-  void updateReference(const as2_msgs::msg::TrajectoryPoint & ref) override;
+  void updateReference(const as2_msgs::msg::TrajectorySetpoints & ref) override;
 
   bool setMode(
     const as2_msgs::msg::ControlMode & mode_in,
@@ -152,7 +152,8 @@ public:
   bool updateParams(const std::vector<rclcpp::Parameter> & _params_list) override;
   void reset() override;
 
-  // IMPORTANT: this is the frame_id of the desired pose and twist
+  // IMPORTANT: this is the frame_id of the desired pose and twist,
+  // both reference and state
   std::string getDesiredPoseFrameId() override {return odom_frame_id_;}
   std::string getDesiredTwistFrameId() override {return odom_frame_id_;}
 

--- a/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
@@ -169,11 +169,13 @@ void Plugin::updateState(
   return;
 }
 
-void Plugin::updateReference(const as2_msgs::msg::TrajectoryPoint & traj_msg)
+void Plugin::updateReference(const as2_msgs::msg::TrajectorySetpoints & trajectory_setpoints_msg)
 {
   if (control_mode_in_.control_mode != as2_msgs::msg::ControlMode::TRAJECTORY) {
     return;
   }
+
+  as2_msgs::msg::TrajectoryPoint traj_msg = trajectory_setpoints_msg.setpoints[0];
 
   control_ref_.position =
     Eigen::Vector3d(traj_msg.position.x, traj_msg.position.y, traj_msg.position.z);

--- a/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
@@ -49,7 +49,7 @@
 #include "as2_core/utils/frame_utils.hpp"
 #include "as2_core/utils/tf_utils.hpp"
 #include "as2_msgs/msg/thrust.hpp"
-#include "as2_msgs/msg/trajectory_point.hpp"
+#include "as2_msgs/msg/trajectory_setpoints.hpp"
 
 #include "as2_motion_controller/controller_base.hpp"
 #include "pid_controller/pid.hpp"
@@ -100,7 +100,7 @@ public:
 
   void updateReference(const geometry_msgs::msg::PoseStamped & ref) override;
   void updateReference(const geometry_msgs::msg::TwistStamped & ref) override;
-  void updateReference(const as2_msgs::msg::TrajectoryPoint & ref) override;
+  void updateReference(const as2_msgs::msg::TrajectorySetpoints & ref) override;
 
   bool setMode(
     const as2_msgs::msg::ControlMode & mode_in,

--- a/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
@@ -396,11 +396,13 @@ void Plugin::updateReference(const geometry_msgs::msg::TwistStamped & twist_msg)
   return;
 }
 
-void Plugin::updateReference(const as2_msgs::msg::TrajectoryPoint & traj_msg)
+void Plugin::updateReference(const as2_msgs::msg::TrajectorySetpoints & traj_setpoints_msg)
 {
   if (control_mode_in_.control_mode != as2_msgs::msg::ControlMode::TRAJECTORY) {
     return;
   }
+
+  as2_msgs::msg::TrajectoryPoint traj_msg = traj_setpoints_msg.setpoints[0];
 
   control_ref_.position =
     Eigen::Vector3d(traj_msg.position.x, traj_msg.position.y, traj_msg.position.z);

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -100,7 +100,7 @@ ControllerHandler::ControllerHandler(
   ref_twist_sub_ = node_ptr_->create_subscription<geometry_msgs::msg::TwistStamped>(
     as2_names::topics::motion_reference::twist, as2_names::topics::motion_reference::qos,
     std::bind(&ControllerHandler::refTwistCallback, this, std::placeholders::_1));
-  ref_traj_sub_ = node_ptr_->create_subscription<as2_msgs::msg::TrajectoryPoint>(
+  ref_traj_sub_ = node_ptr_->create_subscription<as2_msgs::msg::TrajectorySetpoints>(
     as2_names::topics::motion_reference::trajectory, as2_names::topics::motion_reference::qos,
     std::bind(&ControllerHandler::refTrajCallback, this, std::placeholders::_1));
   ref_thrust_sub_ = node_ptr_->create_subscription<as2_msgs::msg::Thrust>(
@@ -114,7 +114,7 @@ ControllerHandler::ControllerHandler(
     std::bind(&ControllerHandler::stateCallback, this, std::placeholders::_1));
 
   // Publishers
-  trajectory_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectoryPoint>(
+  trajectory_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
     as2_names::topics::actuator_command::trajectory, as2_names::topics::actuator_command::qos);
   pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
     as2_names::topics::actuator_command::pose, as2_names::topics::actuator_command::qos);
@@ -270,7 +270,7 @@ void ControllerHandler::refTwistCallback(const geometry_msgs::msg::TwistStamped:
   if (!bypass_controller_) {controller_ptr_->updateReference(ref_twist_);}
 }
 
-void ControllerHandler::refTrajCallback(const as2_msgs::msg::TrajectoryPoint::SharedPtr msg)
+void ControllerHandler::refTrajCallback(const as2_msgs::msg::TrajectorySetpoints::SharedPtr msg)
 {
   if ((!control_mode_established_ && !bypass_controller_) ||
     control_mode_in_.control_mode == as2_msgs::msg::ControlMode::HOVER ||
@@ -742,6 +742,9 @@ void ControllerHandler::publishCommand()
       thrust_pub_->publish(command_thrust_);
       break;
     case as2_msgs::msg::ControlMode::ACRO:
+      std::cout << "T: " << command_thrust_.thrust << std::endl;
+      std::cout << "W: " << command_twist_.twist.angular.x << " " <<
+        command_twist_.twist.angular.y << " " << command_twist_.twist.angular.z << std::endl;
       command_thrust_.header = command_pose_.header;
       twist_pub_->publish(command_twist_);
       thrust_pub_->publish(command_thrust_);

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -44,7 +44,7 @@
 #include <as2_msgs/msg/control_mode.hpp>
 #include <as2_msgs/msg/thrust.hpp>
 #include <as2_msgs/msg/controller_info.hpp>
-#include <as2_msgs/msg/trajectory_point.hpp>
+#include <as2_msgs/msg/trajectory_setpoints.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 
@@ -64,7 +64,7 @@ protected:
   as2::Node * node_ptr_;
   std::string namespace_;
 
-  as2_msgs::msg::TrajectoryPoint command_trajectory_msg_;
+  as2_msgs::msg::TrajectorySetpoints command_trajectory_msg_;
   geometry_msgs::msg::PoseStamped command_pose_msg_;
   geometry_msgs::msg::TwistStamped command_twist_msg_;
   as2_msgs::msg::Thrust command_thrust_msg_;
@@ -84,7 +84,7 @@ private:
   ::SharedPtr controller_info_sub_;
   static as2_msgs::msg::ControlMode current_mode_;
 
-  static rclcpp::Publisher<as2_msgs::msg::TrajectoryPoint>::SharedPtr command_traj_pub_;
+  static rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr command_traj_pub_;
   static rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr command_pose_pub_;
   static rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
   static rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/trajectory_motion.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/trajectory_motion.hpp
@@ -129,6 +129,13 @@ public:
     const Eigen::Vector3d & positions,
     const Eigen::Vector3d & velocities,
     const Eigen::Vector3d & accelerations);
+
+  /**
+   * @brief sendTrajectorySetpoints sends a trajectory setpoints message to the robot.
+   * @param trajectory_setpoints trajectory setpoints message.
+   * @return true if the command was sent successfully, false otherwise.
+   */
+  bool sendTrajectorySetpoints(const as2_msgs::msg::TrajectorySetpoints & trajectory_setpoints);
 };
 }    // namespace motionReferenceHandlers
 }  // namespace as2

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -56,7 +56,7 @@ BasicMotionReferenceHandler::BasicMotionReferenceHandler(
     namespace_ = ns == "" ? ns : "/" + ns + "/";
 
     // Publisher
-    command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectoryPoint>(
+    command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
       namespace_ + as2_names::topics::motion_reference::trajectory,
       as2_names::topics::motion_reference::qos);
 
@@ -197,7 +197,7 @@ BasicMotionReferenceHandler::controller_info_sub_ = nullptr;
 as2_msgs::msg::ControlMode BasicMotionReferenceHandler::current_mode_ =
   as2_msgs::msg::ControlMode();
 
-rclcpp::Publisher<as2_msgs::msg::TrajectoryPoint>::SharedPtr
+rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr
 BasicMotionReferenceHandler::command_traj_pub_ = nullptr;
 rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr
 BasicMotionReferenceHandler::command_pose_pub_ = nullptr;

--- a/as2_motion_reference_handlers/src/trajectory_motion.cpp
+++ b/as2_motion_reference_handlers/src/trajectory_motion.cpp
@@ -71,19 +71,23 @@ bool TrajectoryMotion::sendTrajectoryCommandWithYawAngle(
   this->command_trajectory_msg_.header.frame_id = frame_id;
   this->command_trajectory_msg_.header.stamp = this->node_ptr_->now();
 
-  this->command_trajectory_msg_.yaw_angle = yaw_angle;
+  if (this->command_trajectory_msg_.setpoints.size() == 0) {
+    this->command_trajectory_msg_.setpoints.push_back(as2_msgs::msg::TrajectoryPoint());
+  }
 
-  this->command_trajectory_msg_.position.x = x;
-  this->command_trajectory_msg_.position.y = y;
-  this->command_trajectory_msg_.position.z = z;
+  this->command_trajectory_msg_.setpoints[0].yaw_angle = yaw_angle;
 
-  this->command_trajectory_msg_.twist.x = vx;
-  this->command_trajectory_msg_.twist.y = vy;
-  this->command_trajectory_msg_.twist.z = vz;
+  this->command_trajectory_msg_.setpoints[0].position.x = x;
+  this->command_trajectory_msg_.setpoints[0].position.y = y;
+  this->command_trajectory_msg_.setpoints[0].position.z = z;
 
-  this->command_trajectory_msg_.acceleration.x = ax;
-  this->command_trajectory_msg_.acceleration.y = ay;
-  this->command_trajectory_msg_.acceleration.z = az;
+  this->command_trajectory_msg_.setpoints[0].twist.x = vx;
+  this->command_trajectory_msg_.setpoints[0].twist.y = vy;
+  this->command_trajectory_msg_.setpoints[0].twist.z = vz;
+
+  this->command_trajectory_msg_.setpoints[0].acceleration.x = ax;
+  this->command_trajectory_msg_.setpoints[0].acceleration.y = ay;
+  this->command_trajectory_msg_.setpoints[0].acceleration.z = az;
 
   return this->sendTrajectoryCommand();
 }
@@ -112,5 +116,12 @@ bool TrajectoryMotion::sendTrajectoryCommandWithYawAngle(
     velocities.y(), velocities.z(), accelerations.x(), accelerations.y(), accelerations.z());
 }
 
-}         // namespace motionReferenceHandlers
+bool TrajectoryMotion::sendTrajectorySetpoints(
+  const as2_msgs::msg::TrajectorySetpoints & trajectory_setpoints)
+{
+  this->command_trajectory_msg_ = trajectory_setpoints;
+  return this->sendTrajectoryCommand();
+}
+
+}  // namespace motionReferenceHandlers
 }  // namespace as2

--- a/as2_msgs/msg/TrajectoryPoint.msg
+++ b/as2_msgs/msg/TrajectoryPoint.msg
@@ -1,7 +1,5 @@
 # Definition of a point of a trajectory
 
-std_msgs/Header header              # Message header with the frame_id of the point
-
 geometry_msgs/Vector3 position      # Position of the vehicle in the frame_id frame
 geometry_msgs/Vector3 twist         # Twist of the vehicle in the frame_id frame
 geometry_msgs/Vector3 acceleration  # Acceleration of the vehicle in the frame_id frame

--- a/as2_msgs/msg/TrajectorySetpoints.msg
+++ b/as2_msgs/msg/TrajectorySetpoints.msg
@@ -1,0 +1,5 @@
+# Definition of a point of a trajectory
+
+std_msgs/Header header              # Message header with the frame_id of the point
+
+as2_msgs/TrajectoryPoint[] setpoints # Array of setpoints of the vehicle in the frame_id frame


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Motion references and actuators command use TrajectorySetpoints.msg, with an array of TrajectoryPoint.msg
