### PR TITLE
[aerostack2] Use as2::spingLoop without preset_loop_frequency

### DIFF
--- a/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo_node.cpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo_node.cpp
@@ -40,9 +40,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<gazebo_platform::GazeboPlatform>();
-  node->preset_loop_frequency(60);
   as2::spinLoop(node);
-
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_platform_multirotor_simulator_node.cpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_platform_multirotor_simulator_node.cpp
@@ -43,15 +43,7 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto node = std::make_shared<as2_platform_multirotor_simulator::MultirotorSimulatorPlatform>();
 
-  node->preset_loop_frequency(1000);  // Node frequency for run and
-                                      // callbacks
-
-  // Node with only callbacks
   as2::spinLoop(node);
-
-  // Node with run
-  // as2::spinLoop(node,std::bind(&MultirotorSimulatorPlatform::run, node));
-
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior_node.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior_node.cpp
@@ -43,11 +43,9 @@
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-
   auto node = std::make_shared<DynamicPolynomialTrajectoryGenerator>();
-  node->preset_loop_frequency(50);
-  as2::spinLoop(node);
 
+  as2::spinLoop(node);
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_hardware_drivers/as2_realsense_interface/src/as2_realsense_interface_node.cpp
+++ b/as2_hardware_drivers/as2_realsense_interface/src/as2_realsense_interface_node.cpp
@@ -41,10 +41,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<real_sense_interface::RealsenseInterface>();
-  node->preset_loop_frequency(100);
-
   as2::spinLoop(node, std::bind(&real_sense_interface::RealsenseInterface::run, node));
-
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_hardware_drivers/as2_usb_camera_interface/src/as2_usb_camera_interface_node.cpp
+++ b/as2_hardware_drivers/as2_usb_camera_interface/src/as2_usb_camera_interface_node.cpp
@@ -41,9 +41,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<usb_camera_interface::UsbCameraInterface>();
-  node->preset_loop_frequency(30);
   as2::spinLoop(node);
-
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_motion_controller/src/controller_manager_node.cpp
+++ b/as2_motion_controller/src/controller_manager_node.cpp
@@ -43,9 +43,8 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
 
   auto node = std::make_shared<controller_manager::ControllerManager>();
-  node->preset_loop_frequency(node->cmd_freq_);
-  as2::spinLoop(node);
 
+  as2::spinLoop(node);
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_state_estimator/src/as2_state_estimator_node.cpp
+++ b/as2_state_estimator/src/as2_state_estimator_node.cpp
@@ -38,8 +38,7 @@
 *          Pedro Arias Pérez
 */
 
-#include <rclcpp/executors.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include "as2_core/core_functions.hpp"
 #include "as2_state_estimator.hpp"
 
 int main(int argc, char ** argv)

--- a/as2_state_estimator/src/as2_state_estimator_node.cpp
+++ b/as2_state_estimator/src/as2_state_estimator_node.cpp
@@ -46,7 +46,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<as2_state_estimator::StateEstimator>();
-  rclcpp::spin(node);
+  as2::spinLoop(node);
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* By default, ROS 2 set the node frequency.
* User can set one by using the `node_frequency` param
* Set this change in:

1. as2_platform_gazebo
2. as2_platform_multirotor_simulator
3. as2_motion_controller
4. as2_state_estimator
5. as2_behaviors_trajectory_generation

## Future work that may be required in bullet points

* Add and test this on rest of packages