### PR TITLE
[as2_behaviors_motion] Fix takeoff behavior with trajectory yaw mode to Keep Yaw

### DIFF
--- a/as2_behaviors/as2_behaviors_motion/takeoff_behavior/plugins/takeoff_plugin_trajectory.cpp
+++ b/as2_behaviors/as2_behaviors_motion/takeoff_behavior/plugins/takeoff_plugin_trajectory.cpp
@@ -212,8 +212,7 @@ private:
     traj_generator_goal.header.stamp = node_ptr_->now();
     traj_generator_goal.header.frame_id = "earth";
 
-    traj_generator_goal.yaw.mode = as2_msgs::msg::YawMode::FIXED_YAW;
-    traj_generator_goal.yaw.angle = as2::frame::getYawFromQuaternion(actual_pose_.pose.orientation);
+    traj_generator_goal.yaw.mode = as2_msgs::msg::YawMode::KEEP_YAW;
 
     traj_generator_goal.max_speed = _goal.takeoff_speed;
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Set takeoff behavior with trajectory yaw mode to Keep Yaw
