### PR TITLE
[as2_gazebo_assets] Fix jinja env dir when model comes from outside aerostack2

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -190,11 +190,13 @@ class Drone(Entity):
         :raises RuntimeError: if jinja fails
         :return: python3 jinja command and path to model_sdf generated
         """
-        # Concatenate the model directory and the GZ_SIM_RESOURCE_PATH environment variable
-        model_dir = Path(get_package_share_directory(
-            'as2_gazebo_assets'), 'models')
         jinja_script = os.path.join(
             get_package_share_directory('as2_gazebo_assets'), 'scripts')
+
+        filename = self.get_model_jinja_template()
+        # Ensure that the environment directory is the parent of the model directory
+        # For instance: /path/to/models/drone_base/drone_base.sdf.jinja
+        env_dir = filename.parent.parent
 
         payload = ''
         for pld in self.payload:
@@ -223,8 +225,8 @@ class Drone(Entity):
         command = [
             'python3',
             f'{jinja_script}/jinja_gen.py',
-            self.get_model_jinja_template(),
-            model_dir.parent,
+            filename,
+            env_dir,
             '--namespace',
             f'{self.model_name}',
             '--sensors',

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -66,7 +66,7 @@ class DroneTypeEnum(str, Enum):
     PX4 = 'px4vision'
 
     @classmethod
-    def list(cls) -> List[str]:
+    def list_models(cls) -> List[str]:
         """Return a list of valid model types."""
         return [model.value for model in cls]
 
@@ -82,7 +82,7 @@ class DroneTypeEnum(str, Enum):
     @classmethod
     def list_all(cls) -> List[str]:
         """Return a list of all valid model types."""
-        return cls.list() + cls.extra_models()
+        return cls.list_models() + cls.extra_models()
 
 
 class Drone(Entity):
@@ -94,10 +94,10 @@ class Drone(Entity):
     payload: List[Payload] = []
     enable_velocity_control: bool = True
 
-    @validator("model_type")
+    @validator('model_type')
     def model_type_exist(cls, v: str) -> str:
         if v not in DroneTypeEnum.list_all():
-            raise ValueError(f"Invalid drone model type; permitted: {DroneTypeEnum.list_all()}")
+            raise ValueError(f'Invalid drone model type; permitted: {DroneTypeEnum.list_all()}')
         return v
 
     @root_validator

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -39,7 +39,7 @@ from enum import Enum
 import os
 from pathlib import Path
 import subprocess
-from typing import List
+from typing import List, Union
 
 from ament_index_python.packages import get_package_share_directory
 
@@ -88,7 +88,7 @@ class DroneTypeEnum(str, Enum):
 class Drone(Entity):
     """Gz Drone Entity."""
 
-    model_type: DroneTypeEnum | str
+    model_type: Union[DroneTypeEnum, str]
     flight_time: int = 0  # in minutes
     battery_capacity: float = 0  # Ah
     payload: List[Payload] = []


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #698, #689 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Fix jinja env dir when model comes from outside aerostack2
* Jinja2 env dir is now grandparent from model
* Valid drone model_type can be extended with AS2_EXTRA_DRONE_MODELS environment variable

## Description of documentation updates required from your changes

* Update documentation on how to add a new drone model

---

## Future work that may be required in bullet points

-

