### PR TITLE
[as2_platform_gazebo] Reset FSM

### DIFF
--- a/as2_aerial_platforms/as2_platform_gazebo/include/as2_platform_gazebo/as2_platform_gazebo.hpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/include/as2_platform_gazebo/as2_platform_gazebo.hpp
@@ -42,6 +42,7 @@
 #include <rclcpp/logging.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
+#include <std_srvs/srv/trigger.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 
@@ -78,6 +79,9 @@ public:
   // Subscribers
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_state_sub_;
 
+  // Servers
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reset_srv_;
+
 private:
   as2_msgs::msg::ControlMode control_in_;
   double yaw_rate_limit_ = M_PI_2;
@@ -92,6 +96,9 @@ private:
 private:
   void resetCommandTwistMsg();
   void state_callback(const geometry_msgs::msg::TwistStamped::SharedPtr _twist_msg);
+  void reset_callback(
+    const std_srvs::srv::Trigger::Request::SharedPtr request,
+    std_srvs::srv::Trigger::Response::SharedPtr response);
 };
 }  // namespace gazebo_platform
 

--- a/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
@@ -71,7 +71,7 @@ GazeboPlatform::GazeboPlatform(const rclcpp::NodeOptions & options)
 
   arm_pub_ =
     this->create_publisher<std_msgs::msg::Bool>(arm_topic_param, rclcpp::QoS(1));
-  
+
   reset_srv_ = this->create_service<std_srvs::srv::Trigger>(
     "platform/state_machine/_reset",
     std::bind(&GazeboPlatform::reset_callback, this, std::placeholders::_1, std::placeholders::_2));

--- a/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
@@ -66,7 +66,7 @@ GazeboPlatform::GazeboPlatform(const rclcpp::NodeOptions & options)
   arm_pub_ = this->create_publisher<std_msgs::msg::Bool>(arm_topic_param, rclcpp::QoS(1));
 
   reset_srv_ = this->create_service<std_srvs::srv::Trigger>(
-    "platform/state_machine/reset",
+    "platform/state_machine/_reset",
     std::bind(&GazeboPlatform::reset_callback, this, std::placeholders::_1, std::placeholders::_2));
 }
 

--- a/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
@@ -338,6 +338,7 @@ void GazeboPlatform::reset_callback(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
   std_srvs::srv::Trigger::Response::SharedPtr response)
 {
+  ownSetArmingState(false);
   this->resetPlatform();
   response->success = true;
 }

--- a/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
@@ -338,21 +338,7 @@ void GazeboPlatform::reset_callback(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
   std_srvs::srv::Trigger::Response::SharedPtr response)
 {
-  // Reset the platform state machine manually since attribute is private
-  // state_machine_.resetStateMachine();
-  as2_msgs::msg::PlatformStateMachineEvent event;
-  event.event = as2_msgs::msg::PlatformStateMachineEvent::LAND;
-  handleStateMachineEvent(event);
-
-  event.event = as2_msgs::msg::PlatformStateMachineEvent::LANDED;
-  handleStateMachineEvent(event);
-
-  ownSetArmingState(false);
-  platform_info_msg_.armed = false;
-  platform_info_msg_.offboard = false;
-
-  event.event = as2_msgs::msg::PlatformStateMachineEvent::DISARM;
-  handleStateMachineEvent(event);
+  this->resetPlatform();
   response->success = true;
 }
 

--- a/as2_core/include/as2_core/aerial_platform.hpp
+++ b/as2_core/include/as2_core/aerial_platform.hpp
@@ -238,6 +238,13 @@ protected:
    */
   virtual void sendCommand();
 
+  /**
+   * @brief Reset the platform to its initial state.
+   * This is primarily used for reseting simulation environments.
+   * or at the initialization of the platform.
+   */
+  void resetPlatform();
+
 private:
   void loadControlModes(const std::string & filename);
 

--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -178,7 +178,8 @@ void AerialPlatform::resetPlatform()
   platform_info_msg_.armed = false;
   platform_info_msg_.offboard = false;
   platform_info_msg_.connected = true;  // TODO(miferco97): Check if connected
-  platform_info_msg_.current_control_mode.control_mode = as2_msgs::msg::ControlMode::UNSET;
+  // TODO(miferco97): won't work if current control mode dismatches takeoff control mode
+  // platform_info_msg_.current_control_mode.control_mode = as2_msgs::msg::ControlMode::UNSET;
   state_machine_.setState(as2_msgs::msg::PlatformStatus::DISARMED);
 }
 

--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -39,14 +39,12 @@
 
 namespace as2
 {
+
+
 void AerialPlatform::initialize()
 {
   {
-    platform_info_msg_.armed = false;
-    platform_info_msg_.offboard = false;
-    platform_info_msg_.connected = true;  // TODO(miferco97): Check if connected
-    platform_info_msg_.current_control_mode.control_mode = as2_msgs::msg::ControlMode::UNSET;
-
+    resetPlatform();
     this->declare_parameter<float>("cmd_freq", 100.0);
     this->declare_parameter<float>("info_freq", 10.0);
 
@@ -173,6 +171,15 @@ AerialPlatform::AerialPlatform(const std::string & ns, const rclcpp::NodeOptions
 : as2::Node(std::string("platform"), ns, options), state_machine_(as2::PlatformStateMachine(this))
 {
   initialize();
+}
+
+void AerialPlatform::resetPlatform()
+{
+  platform_info_msg_.armed = false;
+  platform_info_msg_.offboard = false;
+  platform_info_msg_.connected = true;  // TODO(miferco97): Check if connected
+  platform_info_msg_.current_control_mode.control_mode = as2_msgs::msg::ControlMode::UNSET;
+  state_machine_.setState(as2_msgs::msg::PlatformStatus::DISARMED);
 }
 
 bool AerialPlatform::setArmingState(bool state)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #706 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* FSM in Gazebo platform can be reset.
* Reset implementation follows these steps:
  * FSM --> LAND
  * FSM --> LANDED
  * disarm()
  * armed --> false
  * offboard --> false
  * FSM --> DISARMED
