### PR TITLE
[as2_gazebo_assets] Fix path to gimbals and camera sensors

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/crazyflie/crazyflie.sdf.jinja
@@ -203,28 +203,28 @@
           {% if sensor.model == 'gimbal_position' -%}
 
               {# Gimbal position - include or basic render  #}
-              {% include 'models/gimbal/position_gimbal.sdf.jinja' with context %}
+              {% include 'gimbal/position_gimbal.sdf.jinja' with context %}
 
           {% elif sensor.model == 'gimbal_speed' -%}
 
               {# Gimbal speed - include or basic render  #}
-              {% include 'models/gimbal/speed_gimbal.sdf.jinja' with context %}
+              {% include 'gimbal/speed_gimbal.sdf.jinja' with context %}
 
           {% elif sensor.model == 'hd_camera' and not sensor.gimbaled -%}
 
-              {% include 'models/hd_camera/hd_camera.sdf.jinja' with context %}
+              {% include 'hd_camera/hd_camera.sdf.jinja' with context %}
 
           {% elif sensor.model == 'vga_camera' and not sensor.gimbaled -%}
 
-              {% include 'models/vga_camera/vga_camera.sdf.jinja' with context %}
+              {% include 'vga_camera/vga_camera.sdf.jinja' with context %}
 
           {% elif sensor.model == 'semantic_camera' and not sensor.gimbaled -%}
 
-              {% include 'models/semantic_camera/semantic_camera.sdf.jinja' with context %}
+              {% include 'semantic_camera/semantic_camera.sdf.jinja' with context %}
 
           {% elif sensor.model == 'rgbd_camera' and not sensor.gimbaled -%}
 
-              {% include 'models/rgbd_camera/rgbd_camera.sdf.jinja' with context %}
+              {% include 'rgbd_camera/rgbd_camera.sdf.jinja' with context %}
 
           {% elif sensor.gimbaled -%}
 

--- a/as2_simulation_assets/as2_gazebo_assets/models/gimbal/position_gimbal.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/gimbal/position_gimbal.sdf.jinja
@@ -63,19 +63,19 @@
                 </link>
                 {% if sensor.sensor_attached_type == 'hd_camera' -%}
 
-                    {% include 'models/hd_camera/hd_camera.sdf.jinja' with context -%}
+                    {% include 'hd_camera/hd_camera.sdf.jinja' with context -%}
 
                 {% elif sensor.sensor_attached_type == 'vga_camera' -%}
 
-                    {% include 'models/vga_camera/vga_camera.sdf.jinja' with context -%}
+                    {% include 'vga_camera/vga_camera.sdf.jinja' with context -%}
 
                 {% elif sensor.sensor_attached_type == 'semantic_camera' -%}
 
-                    {% include 'models/semantic_camera/semantic_camera.sdf.jinja' with context -%}
+                    {% include 'semantic_camera/semantic_camera.sdf.jinja' with context -%}
 
                 {% elif sensor.sensor_attached_type == 'rgbd_camera' -%}
 
-                    {% include 'models/rgbd_camera/rgbd_camera.sdf.jinja' with context -%}
+                    {% include 'rgbd_camera/rgbd_camera.sdf.jinja' with context -%}
 
                 {% else -%}
 

--- a/as2_simulation_assets/as2_gazebo_assets/models/gimbal/speed_gimbal.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/gimbal/speed_gimbal.sdf.jinja
@@ -63,19 +63,19 @@
                 </link>
                 {% if sensor.sensor_attached_type == 'hd_camera' -%}
 
-                    {% include 'models/hd_camera/hd_camera.sdf.jinja' with context -%}
+                    {% include 'hd_camera/hd_camera.sdf.jinja' with context -%}
 
                 {% elif sensor.sensor_attached_type == 'vga_camera' -%}
 
-                    {% include 'models/vga_camera/vga_camera.sdf.jinja' with context -%}
+                    {% include 'vga_camera/vga_camera.sdf.jinja' with context -%}
 
                 {% elif sensor.sensor_attached_type == 'semantic_camera' -%}
 
-                    {% include 'models/semantic_camera/semantic_camera.sdf.jinja' with context -%}
+                    {% include 'semantic_camera/semantic_camera.sdf.jinja' with context -%}
 
                 {% elif sensor.sensor_attached_type == 'rgbd_camera' -%}
 
-                    {% include 'models/rgbd_camera/rgbd_camera.sdf.jinja' with context -%}
+                    {% include 'rgbd_camera/rgbd_camera.sdf.jinja' with context -%}
 
                 {% else -%}
 

--- a/as2_simulation_assets/as2_gazebo_assets/models/px4vision/px4vision.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/px4vision/px4vision.sdf.jinja
@@ -203,28 +203,28 @@
             {% if sensor.model == 'gimbal_position' -%}
 
                 {# Gimbal position - include or basic render  #}
-                {% include 'models/gimbal/position_gimbal.sdf.jinja' with context %}
+                {% include 'gimbal/position_gimbal.sdf.jinja' with context %}
 
             {% elif sensor.model == 'gimbal_speed' -%}
 
                 {# Gimbal speed - include or basic render  #}
-                {% include 'models/gimbal/speed_gimbal.sdf.jinja' with context %}
+                {% include 'gimbal/speed_gimbal.sdf.jinja' with context %}
 
             {% elif sensor.model == 'hd_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/hd_camera/hd_camera.sdf.jinja' with context %}
+                {% include 'hd_camera/hd_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'vga_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/vga_camera/vga_camera.sdf.jinja' with context %}
+                {% include 'vga_camera/vga_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'semantic_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/semantic_camera/semantic_camera.sdf.jinja' with context %}
+                {% include 'semantic_camera/semantic_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'rgbd_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/rgbd_camera/rgbd_camera.sdf.jinja' with context %}
+                {% include 'rgbd_camera/rgbd_camera.sdf.jinja' with context %}
 
             {% elif sensor.gimbaled -%}
 

--- a/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/quadrotor_base/quadrotor_base.sdf.jinja
@@ -204,28 +204,28 @@
             {% if sensor.model == 'gimbal_position' -%}
 
                 {# Gimbal position - include or basic render  #}
-                {% include 'models/gimbal/position_gimbal.sdf.jinja' with context %}
+                {% include 'gimbal/position_gimbal.sdf.jinja' with context %}
 
             {% elif sensor.model == 'gimbal_speed' -%}
 
                 {# Gimbal speed - include or basic render  #}
-                {% include 'models/gimbal/speed_gimbal.sdf.jinja' with context %}
+                {% include 'gimbal/speed_gimbal.sdf.jinja' with context %}
 
             {% elif sensor.model == 'hd_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/hd_camera/hd_camera.sdf.jinja' with context %}
+                {% include 'hd_camera/hd_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'vga_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/vga_camera/vga_camera.sdf.jinja' with context %}
+                {% include 'vga_camera/vga_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'semantic_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/semantic_camera/semantic_camera.sdf.jinja' with context %}
+                {% include 'semantic_camera/semantic_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'rgbd_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/rgbd_camera/rgbd_camera.sdf.jinja' with context %}
+                {% include 'rgbd_camera/rgbd_camera.sdf.jinja' with context %}
 
             {% elif sensor.gimbaled -%}
 

--- a/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/x500/x500.sdf.jinja
@@ -192,28 +192,28 @@
             {% if sensor.model == 'gimbal_position' -%}
 
                 {# Gimbal position - include or basic render  #}
-                {% include 'models/gimbal/position_gimbal.sdf.jinja' with context %}
+                {% include 'gimbal/position_gimbal.sdf.jinja' with context %}
 
             {% elif sensor.model == 'gimbal_speed' -%}
 
                 {# Gimbal speed - include or basic render  #}
-                {% include 'models/gimbal/speed_gimbal.sdf.jinja' with context %}
+                {% include 'gimbal/speed_gimbal.sdf.jinja' with context %}
 
             {% elif sensor.model == 'hd_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/hd_camera/hd_camera.sdf.jinja' with context %}
+                {% include 'hd_camera/hd_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'vga_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/vga_camera/vga_camera.sdf.jinja' with context %}
+                {% include 'vga_camera/vga_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'semantic_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/semantic_camera/semantic_camera.sdf.jinja' with context %}
+                {% include 'semantic_camera/semantic_camera.sdf.jinja' with context %}
 
             {% elif sensor.model == 'rgbd_camera' and not sensor.gimbaled -%}
 
-                {% include 'models/rgbd_camera/rgbd_camera.sdf.jinja' with context %}
+                {% include 'rgbd_camera/rgbd_camera.sdf.jinja' with context %}
 
             {% elif sensor.gimbaled -%}
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Jinja environment path was changed in #699, so hardcoded path in gimbals couldn't find model files for gimbals and cameras

## Description of documentation updates required from your changes

* Models attached to gimbals are hardcoded in jinja templates. This have to be documented somewhere

---

## Future work that may be required in bullet points


* Models attached to gimbals are hardcoded in jinja templates. This is a really bad idea, we should think in a better way of doing this.
