### PR TITLE
[as2_state_estimator] Use tf_handler instead of tf2_ros directly

### DIFF
--- a/as2_state_estimator/include/as2_state_estimator/as2_state_estimator.hpp
+++ b/as2_state_estimator/include/as2_state_estimator/as2_state_estimator.hpp
@@ -76,8 +76,7 @@ private:
   std::shared_ptr<as2_state_estimator_plugin_base::StateEstimatorBase> plugin_ptr_;
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tfstatic_broadcaster_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
+  std::shared_ptr<as2::tf::TfHandler> tf_handler_;
 
 private:
   /**

--- a/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
+++ b/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
@@ -77,12 +77,12 @@ public:
   StateEstimatorBase() {}
   void setup(
     as2::Node * node,
-    std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+    std::shared_ptr<as2::tf::TfHandler> tf_handler_,
     std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster,
     std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster)
   {
     node_ptr_ = node;
-    tf_buffer_ = tf_buffer;
+    tf_handler_ = tf_handler_;
     tf_broadcaster_ = tf_broadcaster;
     static_tf_broadcaster_ = static_tf_broadcaster;
 
@@ -118,8 +118,8 @@ public:
     return true;
   }
 
-private:
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+protected:
+  std::shared_ptr<as2::tf::TfHandler> tf_handler_;
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
@@ -140,7 +140,6 @@ private:
     }
   }
 
-protected:
   inline void publish_transform(const geometry_msgs::msg::TransformStamped & transform)
   {
     tf_broadcaster_->sendTransform(transform);

--- a/as2_state_estimator/src/as2_state_estimator.cpp
+++ b/as2_state_estimator/src/as2_state_estimator.cpp
@@ -45,7 +45,7 @@ namespace as2_state_estimator
 StateEstimator::StateEstimator(const rclcpp::NodeOptions & options)
 : as2::Node("state_estimator", get_modified_options(options))
 {
-  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+  tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
   tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
   tfstatic_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
   try {
@@ -62,7 +62,7 @@ StateEstimator::StateEstimator(const rclcpp::NodeOptions & options)
     "as2_state_estimator", "as2_state_estimator_plugin_base::StateEstimatorBase");
   try {
     plugin_ptr_ = loader_->createSharedInstance(plugin_name_);
-    plugin_ptr_->setup(this, tf_buffer_, tf_broadcaster_, tfstatic_broadcaster_);
+    plugin_ptr_->setup(this, tf_handler_, tf_broadcaster_, tfstatic_broadcaster_);
   } catch (const pluginlib::PluginlibException & e) {
     RCLCPP_FATAL(this->get_logger(), "Failed to load plugin: %s", e.what());
     this->~StateEstimator();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Use `tf_handler` instead of `tf2_ros` directly
