### PR TITLE
[as2_behaviors_motion] In follow reference, remove rclcpp info of yaw mode in each iteration

### DIFF
--- a/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/src/follow_reference_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/src/follow_reference_behavior.cpp
@@ -306,14 +306,14 @@ bool FollowReferenceBehavior::computeYaw(
       yaw = yaw + (yaw > 0 ? -M_PI : M_PI);
       break;
     case as2_msgs::msg::YawMode::FIXED_YAW:
-      RCLCPP_INFO(this->get_logger(), "Yaw mode FIXED_YAW");
+      RCLCPP_DEBUG(this->get_logger(), "Yaw mode FIXED_YAW");
       break;
     case as2_msgs::msg::YawMode::KEEP_YAW:
-      RCLCPP_INFO(this->get_logger(), "Yaw mode KEEP_YAW");
+      RCLCPP_DEBUG(this->get_logger(), "Yaw mode KEEP_YAW");
       yaw = getActualYaw();
       break;
     case as2_msgs::msg::YawMode::YAW_FROM_TOPIC:
-      RCLCPP_INFO(this->get_logger(), "Yaw mode YAW_FROM_TOPIC, not supported");
+      RCLCPP_ERROR(this->get_logger(), "Yaw mode YAW_FROM_TOPIC, not supported");
       return false;
       break;
     default:

--- a/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/src/follow_reference_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/src/follow_reference_behavior.cpp
@@ -306,10 +306,12 @@ bool FollowReferenceBehavior::computeYaw(
       yaw = yaw + (yaw > 0 ? -M_PI : M_PI);
       break;
     case as2_msgs::msg::YawMode::FIXED_YAW:
-      RCLCPP_DEBUG(this->get_logger(), "Yaw mode FIXED_YAW");
+      RCLCPP_DEBUG_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000, "Yaw mode FIXED_YAW");
       break;
     case as2_msgs::msg::YawMode::KEEP_YAW:
-      RCLCPP_DEBUG(this->get_logger(), "Yaw mode KEEP_YAW");
+      RCLCPP_DEBUG_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000, "Yaw mode KEEP_YAW");
       yaw = getActualYaw();
       break;
     case as2_msgs::msg::YawMode::YAW_FROM_TOPIC:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Remove rclcpp info of yaw mode in each iteration
