### PR TITLE
[aerostack2] New launchers to avoid context override

### DIFF
--- a/as2_core/as2_core/log_action.py
+++ b/as2_core/as2_core/log_action.py
@@ -33,16 +33,15 @@ __copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
 
 
-from typing import List
-
-import launch.logging
 import logging
+from typing import List
 
 from launch.action import Action
 from launch.frontend import Entity
 from launch.frontend import expose_action
 from launch.frontend import Parser  # noqa: F401
 from launch.launch_context import LaunchContext
+import launch.logging
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitution import Substitution
 from launch.utilities import normalize_to_list_of_substitutions

--- a/as2_core/as2_core/log_action.py
+++ b/as2_core/as2_core/log_action.py
@@ -1,0 +1,86 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Module for the LogWarn action."""
+
+__authors__ = 'Pedro Arias Pérez'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+
+from typing import List
+
+import launch.logging
+import logging
+
+from launch.action import Action
+from launch.frontend import Entity
+from launch.frontend import expose_action
+from launch.frontend import Parser  # noqa: F401
+from launch.launch_context import LaunchContext
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitution import Substitution
+from launch.utilities import normalize_to_list_of_substitutions
+
+
+@expose_action('as2_log')
+class Log(Action):
+    """Action that warns a message when executed."""
+
+    def __init__(self, *, msg: SomeSubstitutionsType, level: str = 'info',
+                 user: str = 'user', **kwargs):
+        """Create a LogInfo action."""
+        super().__init__(**kwargs)
+
+        self.__msg = normalize_to_list_of_substitutions(msg)
+        self.__level = logging._nameToLevel[level.upper()]
+        self.__logger = launch.logging.get_logger('launch.' + user)
+
+    @classmethod
+    def parse(
+        cls,
+        entity: Entity,
+        parser: 'Parser'
+    ):
+        """Parse `log` tag."""
+        _, kwargs = super().parse(entity, parser)
+        kwargs['msg'] = parser.parse_substitution(entity.get_attr('message'))
+        return cls, kwargs
+
+    @property
+    def msg(self) -> List[Substitution]:
+        """Getter for self.__msg."""
+        return self.__msg
+
+    def execute(self, context: LaunchContext) -> None:
+        """Execute the action."""
+        self.__logger.log(
+            self.__level,
+            ''.join([context.perform_substitution(sub) for sub in self.msg])
+        )
+        return None

--- a/as2_motion_controller/launch/differential_flatness_controller-motion_controller.launch.py
+++ b/as2_motion_controller/launch/differential_flatness_controller-motion_controller.launch.py
@@ -1,0 +1,101 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the motion controller node with differential_flatness_controller plugin."""
+
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Entry point for launch file."""
+    plugin_name = 'differential_flatness_controller'
+    package_folder = get_package_share_directory('as2_motion_controller')
+    config_file = os.path.join(package_folder,
+                               'config/motion_controller_default.yaml')
+    plugin_config_file = os.path.join(package_folder,
+                                      'plugins', plugin_name, 'config/controller_default.yaml')
+    plugin_available_modes_config_file = os.path.join(
+        package_folder, 'plugins', plugin_name, 'config/available_modes.yaml')
+    return LaunchDescription([
+        DeclareLaunchArgument('log_level',
+                              description='Logging level',
+                              default_value='info'),
+        DeclareLaunchArgument('use_sim_time',
+                              description='Use simulation clock if true',
+                              default_value='false'),
+        DeclareLaunchArgument('namespace',
+                              description='Drone namespace',
+                              default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        DeclareLaunchArgument(
+            'plugin_available_modes_config_file',
+            description='Plugin available modes configuration file',
+            default_value=plugin_available_modes_config_file),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file'),
+        Node(
+            package='as2_motion_controller',
+            executable='as2_motion_controller_node',
+            name='controller_manager',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            arguments=['--ros-args', '--log-level',
+                       LaunchConfiguration('log_level')],
+            emulate_tty=True,
+            parameters=[
+                {
+                    'use_sim_time': LaunchConfiguration('use_sim_time'),
+                    'plugin_name': plugin_name,
+                    'plugin_available_modes_config_file': LaunchConfiguration(
+                        'plugin_available_modes_config_file')
+                },
+                LaunchConfigurationFromConfigFile(
+                    'config_file',
+                    default_file=config_file),
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        )
+    ]
+    )

--- a/as2_motion_controller/launch/motion_controller.launch.py
+++ b/as2_motion_controller/launch/motion_controller.launch.py
@@ -1,0 +1,186 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the motion controller node."""
+
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_plugin_utils import get_available_plugins
+from as2_core.log_action import Log
+from launch import LaunchContext, LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, \
+    SetLaunchConfiguration
+from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
+
+import yaml
+
+
+def recursive_search(data_dict, target_key, result=None):
+    """Search for a target key in a nested dictionary or list."""
+    if result is None:
+        result = []
+
+    if isinstance(data_dict, dict):
+        for key, value in data_dict.items():
+            if key == target_key:
+                result.append(value)
+            else:
+                recursive_search(value, target_key, result)
+    elif isinstance(data_dict, list):
+        for item in data_dict:
+            recursive_search(item, target_key, result)
+
+    return result
+
+
+def get_plugin_name(context: LaunchContext):
+    """Override plugin_name in the context from config_file if it is not provided as argument."""
+    plugin_name = LaunchConfiguration('plugin_name').perform(context)
+    if plugin_name == '':
+        config_file = LaunchConfiguration('config_file').perform(context)
+        with open(config_file, 'r') as file:
+            config = yaml.safe_load(file)
+        plugin_names = recursive_search(config, 'plugin_name')
+        # intersection of available plugins and plugins in config file, only one coincidence is expected
+        plugin_name = list(set(plugin_names) & set(get_available_plugins('as2_motion_controller')))
+
+    if not plugin_name:
+        raise RuntimeError('No plugin_name provided or not found in config_file.')
+
+    return plugin_name[0]
+
+
+def get_launch_file(context: LaunchContext) -> list:
+    """Return the python launcher for a specific plugin."""
+    plugin_name = LaunchConfiguration('plugin_name').perform(context)
+    if plugin_name == '':
+        plugin_name = get_plugin_name(context)
+
+    package_folder = get_package_share_directory('as2_motion_controller')
+    plugin_config_file = PathJoinSubstitution([
+        package_folder, 'plugins', plugin_name, 'config/controller_default.yaml'
+    ])
+    plugin_available_modes_config_file = PathJoinSubstitution([
+        package_folder, 'plugins', plugin_name, 'config/available_modes.yaml'
+    ])
+
+    return [
+        SetLaunchConfiguration('plugin_name', plugin_name),
+        Log(condition=LaunchConfigurationNotEquals('plugin_name', ''),
+            msg=['Plugin name found: ', plugin_name],
+            user='motion_controller'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file',
+            condition=LaunchConfigurationNotEquals('plugin_name', '')),
+        DeclareLaunchArgument(
+            'plugin_available_modes_config_file',
+            description='Plugin available modes configuration file',
+            default_value=plugin_available_modes_config_file,
+            condition=LaunchConfigurationNotEquals('plugin_name', '')),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                os.path.join(
+                    get_package_share_directory('as2_motion_controller'), 'launch/'),
+                plugin_name + '-motion_controller.launch.py'
+            ]),
+            launch_arguments={
+                'use_sim_time': LaunchConfiguration('use_sim_time'),
+                'namespace': LaunchConfiguration('namespace'),
+                'config_file': LaunchConfiguration('config_file'),
+                'plugin_available_modes_config_file': LaunchConfiguration(
+                    'plugin_available_modes_config_file'),
+                'plugin_config_file': LaunchConfiguration('plugin_config_file')}.items()
+        )
+    ]
+
+
+def generate_launch_description():
+    """Launcher entrypoint."""
+    plugin_choices = get_available_plugins('as2_motion_controller')
+    plugin_choices.append('')
+
+    package_folder = get_package_share_directory('as2_motion_controller')
+    config_file = os.path.join(package_folder,
+                               'config/motion_controller_default.yaml')
+
+    plugin_config_file = PathJoinSubstitution([
+        package_folder,
+        'plugins', LaunchConfiguration('plugin_name'), 'config/controller_default.yaml'
+    ])
+
+    plugin_available_modes_config_file = PathJoinSubstitution([
+        package_folder,
+        'plugins', LaunchConfiguration('plugin_name'), 'config/available_modes.yaml'
+    ])
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'log_level',
+            description='Logging level',
+            default_value='info'),
+        DeclareLaunchArgument(
+            'use_sim_time',
+            description='Use simulation clock if true',
+            default_value='false'),
+        DeclareLaunchArgument(
+            'namespace',
+            description='Drone namespace',
+            default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgument(
+            'plugin_name',
+            default_value='',
+            description='Plugin name. If empty, it must be declared in config file.',
+            choices=plugin_choices),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        Log(condition=LaunchConfigurationEquals('plugin_name', ''),
+            msg=['Plugin name not set via launch argument. ' +
+                 'If not included in config_file, plugin_config_file will not be found.'],
+            level='warn',
+            user='controller_manager'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file',
+            condition=LaunchConfigurationNotEquals('plugin_name', '')),
+        DeclareLaunchArgument(
+            'plugin_available_modes_config_file',
+            description='Plugin available modes configuration file',
+            default_value=plugin_available_modes_config_file,
+            condition=LaunchConfigurationNotEquals('plugin_name', '')),
+        OpaqueFunction(function=get_launch_file),
+    ])

--- a/as2_motion_controller/launch/motion_controller.launch.py
+++ b/as2_motion_controller/launch/motion_controller.launch.py
@@ -74,7 +74,8 @@ def get_plugin_name(context: LaunchContext):
         with open(config_file, 'r') as file:
             config = yaml.safe_load(file)
         plugin_names = recursive_search(config, 'plugin_name')
-        # intersection of available plugins and plugins in config file, only one coincidence is expected
+        # intersection of available plugins and plugins in config file, only one coincidence
+        # is expected
         plugin_name = list(set(plugin_names) & set(get_available_plugins('as2_motion_controller')))
 
     if not plugin_name:

--- a/as2_motion_controller/launch/pid_speed_controller-motion_controller.launch.py
+++ b/as2_motion_controller/launch/pid_speed_controller-motion_controller.launch.py
@@ -1,0 +1,101 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the motion controller node with pid_speed_controller plugin."""
+
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Entry point for launch file."""
+    plugin_name = 'pid_speed_controller'
+    package_folder = get_package_share_directory('as2_motion_controller')
+    config_file = os.path.join(package_folder,
+                               'config/motion_controller_default.yaml')
+    plugin_config_file = os.path.join(package_folder,
+                                      'plugins', plugin_name, 'config/controller_default.yaml')
+    plugin_available_modes_config_file = os.path.join(
+        package_folder, 'plugins', plugin_name, 'config/available_modes.yaml')
+    return LaunchDescription([
+        DeclareLaunchArgument('log_level',
+                              description='Logging level',
+                              default_value='info'),
+        DeclareLaunchArgument('use_sim_time',
+                              description='Use simulation clock if true',
+                              default_value='false'),
+        DeclareLaunchArgument('namespace',
+                              description='Drone namespace',
+                              default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        DeclareLaunchArgument(
+            'plugin_available_modes_config_file',
+            description='Plugin available modes configuration file',
+            default_value=plugin_available_modes_config_file),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file'),
+        Node(
+            package='as2_motion_controller',
+            executable='as2_motion_controller_node',
+            name='controller_manager',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            arguments=['--ros-args', '--log-level',
+                       LaunchConfiguration('log_level')],
+            emulate_tty=True,
+            parameters=[
+                {
+                    'use_sim_time': LaunchConfiguration('use_sim_time'),
+                    'plugin_name': plugin_name,
+                    'plugin_available_modes_config_file': LaunchConfiguration(
+                        'plugin_available_modes_config_file')
+                },
+                LaunchConfigurationFromConfigFile(
+                    'config_file',
+                    default_file=config_file),
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        )
+    ]
+    )

--- a/as2_state_estimator/launch/ground_truth-state_estimator.launch.py
+++ b/as2_state_estimator/launch/ground_truth-state_estimator.launch.py
@@ -1,0 +1,93 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the state estimator node with ground_truth plugin."""
+
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Entry point for launch file."""
+    plugin_name = 'ground_truth'
+    package_folder = get_package_share_directory('as2_state_estimator')
+    config_file = os.path.join(package_folder,
+                               'config/state_estimator_default.yaml')
+    plugin_config_file = os.path.join(package_folder,
+                                      'plugins', plugin_name, 'config/plugin_default.yaml')
+    return LaunchDescription([
+        DeclareLaunchArgument('log_level',
+                              description='Logging level',
+                              default_value='info'),
+        DeclareLaunchArgument('use_sim_time',
+                              description='Use simulation clock if true',
+                              default_value='false'),
+        DeclareLaunchArgument('namespace',
+                              description='Drone namespace',
+                              default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file'),
+        Node(
+            package='as2_state_estimator',
+            executable='as2_state_estimator_node',
+            name='state_estimator',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            arguments=['--ros-args', '--log-level',
+                       LaunchConfiguration('log_level')],
+            emulate_tty=True,
+            parameters=[
+                {
+                    'use_sim_time': LaunchConfiguration('use_sim_time'),
+                    'plugin_name': plugin_name,
+                },
+                LaunchConfigurationFromConfigFile(
+                    'config_file',
+                    default_file=config_file),
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        )
+    ]
+    )

--- a/as2_state_estimator/launch/mocap_pose-state_estimator.launch.py
+++ b/as2_state_estimator/launch/mocap_pose-state_estimator.launch.py
@@ -1,0 +1,93 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the state estimator node with ground_truth plugin."""
+
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Entry point for launch file."""
+    plugin_name = 'mocap_pose'
+    package_folder = get_package_share_directory('as2_state_estimator')
+    config_file = os.path.join(package_folder,
+                               'config/state_estimator_default.yaml')
+    plugin_config_file = os.path.join(package_folder,
+                                      'plugins', plugin_name, 'config/plugin_default.yaml')
+    return LaunchDescription([
+        DeclareLaunchArgument('log_level',
+                              description='Logging level',
+                              default_value='info'),
+        DeclareLaunchArgument('use_sim_time',
+                              description='Use simulation clock if true',
+                              default_value='false'),
+        DeclareLaunchArgument('namespace',
+                              description='Drone namespace',
+                              default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file'),
+        Node(
+            package='as2_state_estimator',
+            executable='as2_state_estimator_node',
+            name='state_estimator',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            arguments=['--ros-args', '--log-level',
+                       LaunchConfiguration('log_level')],
+            emulate_tty=True,
+            parameters=[
+                {
+                    'use_sim_time': LaunchConfiguration('use_sim_time'),
+                    'plugin_name': plugin_name,
+                },
+                LaunchConfigurationFromConfigFile(
+                    'config_file',
+                    default_file=config_file),
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        )
+    ]
+    )

--- a/as2_state_estimator/launch/raw_odometry-state_estimator.launch.py
+++ b/as2_state_estimator/launch/raw_odometry-state_estimator.launch.py
@@ -1,0 +1,93 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the state estimator node with ground_truth plugin."""
+
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Entry point for launch file."""
+    plugin_name = 'raw_odometry'
+    package_folder = get_package_share_directory('as2_state_estimator')
+    config_file = os.path.join(package_folder,
+                               'config/state_estimator_default.yaml')
+    plugin_config_file = os.path.join(package_folder,
+                                      'plugins', plugin_name, 'config/plugin_default.yaml')
+    return LaunchDescription([
+        DeclareLaunchArgument('log_level',
+                              description='Logging level',
+                              default_value='info'),
+        DeclareLaunchArgument('use_sim_time',
+                              description='Use simulation clock if true',
+                              default_value='false'),
+        DeclareLaunchArgument('namespace',
+                              description='Drone namespace',
+                              default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file'),
+        Node(
+            package='as2_state_estimator',
+            executable='as2_state_estimator_node',
+            name='state_estimator',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            arguments=['--ros-args', '--log-level',
+                       LaunchConfiguration('log_level')],
+            emulate_tty=True,
+            parameters=[
+                {
+                    'use_sim_time': LaunchConfiguration('use_sim_time'),
+                    'plugin_name': plugin_name,
+                },
+                LaunchConfigurationFromConfigFile(
+                    'config_file',
+                    default_file=config_file),
+                LaunchConfigurationFromConfigFile(
+                    'plugin_config_file',
+                    default_file=plugin_config_file),
+            ]
+        )
+    ]
+    )

--- a/as2_state_estimator/launch/state_estimator.launch.py
+++ b/as2_state_estimator/launch/state_estimator.launch.py
@@ -1,0 +1,166 @@
+# Copyright 2024 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the state estimator node."""
+
+__authors__ = 'Pedro Arias Pérez, Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_plugin_utils import get_available_plugins
+from as2_core.log_action import Log
+from launch import LaunchContext, LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, \
+    SetLaunchConfiguration
+from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
+
+import yaml
+
+
+def recursive_search(data_dict, target_key, result=None):
+    """Search for a target key in a nested dictionary or list."""
+    if result is None:
+        result = []
+
+    if isinstance(data_dict, dict):
+        for key, value in data_dict.items():
+            if key == target_key:
+                result.append(value)
+            else:
+                recursive_search(value, target_key, result)
+    elif isinstance(data_dict, list):
+        for item in data_dict:
+            recursive_search(item, target_key, result)
+
+    return result
+
+
+def get_plugin_name(context: LaunchContext):
+    """Override plugin_name in the context from config_file if it is not provided as argument."""
+    plugin_name = LaunchConfiguration('plugin_name').perform(context)
+    if plugin_name == '':
+        config_file = LaunchConfiguration('config_file').perform(context)
+        with open(config_file, 'r') as file:
+            config = yaml.safe_load(file)
+        plugin_names = recursive_search(config, 'plugin_name')
+        # intersection of available plugins and plugins in config file, only one coincidence is expected
+        plugin_name = list(set(plugin_names) & set(get_available_plugins('as2_state_estimator')))
+
+    if not plugin_name:
+        raise RuntimeError('No plugin_name provided or not found in config_file.')
+
+    return plugin_name[0]
+
+
+def get_launch_file(context: LaunchContext) -> list:
+    """Return the python launcher for a specific plugin."""
+    plugin_name = LaunchConfiguration('plugin_name').perform(context)
+    if plugin_name == '':
+        plugin_name = get_plugin_name(context)
+
+    package_folder = get_package_share_directory('as2_state_estimator')
+    plugin_config_file = PathJoinSubstitution([
+        package_folder, 'plugins', plugin_name, 'config/plugin_default.yaml'
+    ])
+
+    return [
+        SetLaunchConfiguration('plugin_name', plugin_name),
+        Log(condition=LaunchConfigurationNotEquals('plugin_name', ''),
+            msg=['Plugin name found: ', plugin_name],
+            user='state_estimator'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file',
+            condition=LaunchConfigurationNotEquals('plugin_name', '')),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                os.path.join(
+                    get_package_share_directory('as2_state_estimator'), 'launch/'),
+                plugin_name + '-state_estimator.launch.py'
+            ]),
+            launch_arguments={
+                'use_sim_time': LaunchConfiguration('use_sim_time'),
+                'namespace': LaunchConfiguration('namespace'),
+                'config_file': LaunchConfiguration('config_file'),
+                'plugin_config_file': LaunchConfiguration('plugin_config_file')}.items()
+        )
+
+    ]
+
+
+def generate_launch_description():
+    """Launcher entrypoint."""
+    plugin_choices = get_available_plugins('as2_state_estimator')
+    plugin_choices.append('')
+
+    package_folder = get_package_share_directory('as2_state_estimator')
+    config_file = os.path.join(package_folder,
+                               'config/state_estimator_default.yaml')
+
+    plugin_config_file = PathJoinSubstitution([
+        package_folder, 'plugins', LaunchConfiguration('plugin_name'), 'config/plugin_default.yaml'
+    ])
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'log_level',
+            description='Logging level',
+            default_value='info'),
+        DeclareLaunchArgument(
+            'use_sim_time',
+            description='Use simulation clock if true',
+            default_value='false'),
+        DeclareLaunchArgument(
+            'namespace',
+            description='Drone namespace',
+            default_value=EnvironmentVariable('AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgument(
+            'plugin_name',
+            default_value='',
+            description='Plugin name. If empty, it must be declared in config file.',
+            choices=plugin_choices),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=config_file,
+            description='Configuration file'),
+        Log(condition=LaunchConfigurationEquals('plugin_name', ''),
+            msg=['Plugin name not set via launch argument. ' +
+                 'If not included in config_file, plugin_config_file will not be found.'],
+            level='warn',
+            user='state_estimator'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='plugin_config_file', source_file=plugin_config_file,
+            description='Plugin configuration file',
+            condition=LaunchConfigurationNotEquals('plugin_name', '')),
+        OpaqueFunction(function=get_launch_file),
+    ])

--- a/as2_state_estimator/launch/state_estimator.launch.py
+++ b/as2_state_estimator/launch/state_estimator.launch.py
@@ -74,7 +74,8 @@ def get_plugin_name(context: LaunchContext):
         with open(config_file, 'r') as file:
             config = yaml.safe_load(file)
         plugin_names = recursive_search(config, 'plugin_name')
-        # intersection of available plugins and plugins in config file, only one coincidence is expected
+        # intersection of available plugins and plugins in config file, only one coincidence
+        # is expected
         plugin_name = list(set(plugin_names) & set(get_available_plugins('as2_state_estimator')))
 
     if not plugin_name:


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #733 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* New Log launch_action added. Similar to ros.launch.LogInfo but with choosable user and severity level
* Launchers refactored to avoid context override

## Description of documentation updates required from your changes

-
<!--
* Added new parameter, so need to add that to default configs and documentation page
* Added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

* Context override still happens when using generic launcher. 
* Refactor might be improved reusing code from generic launch to specific one (or the other way around)
