### PR TITLE
[as2_aerial_platform] Reset actuator command messages when resetting the platform

### DIFF
--- a/as2_core/include/as2_core/aerial_platform.hpp
+++ b/as2_core/include/as2_core/aerial_platform.hpp
@@ -309,6 +309,8 @@ public:
 protected:
   bool has_new_references_ = false;
 
+  void resetActuatorCommandMsgs();
+
   // ROS publishers & subscribers
 
 private:

--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -181,6 +181,17 @@ void AerialPlatform::resetPlatform()
   // TODO(miferco97): won't work if current control mode dismatches takeoff control mode
   // platform_info_msg_.current_control_mode.control_mode = as2_msgs::msg::ControlMode::UNSET;
   state_machine_.setState(as2_msgs::msg::PlatformStatus::DISARMED);
+
+  resetActuatorCommandMsgs();
+}
+
+void AerialPlatform::resetActuatorCommandMsgs()
+{
+  command_trajectory_msg_ = as2_msgs::msg::TrajectorySetpoints();
+  command_pose_msg_ = geometry_msgs::msg::PoseStamped();
+  command_twist_msg_ = geometry_msgs::msg::TwistStamped();
+  command_thrust_msg_ = as2_msgs::msg::Thrust();
+  has_new_references_ = true;
 }
 
 bool AerialPlatform::setArmingState(bool state)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #706 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Reset actuator command messages when resetting the platform