### PR TITLE
[fix] add as2_core to dependencies in mock lib

### DIFF
--- a/as2_core/tests/mocks/CMakeLists.txt
+++ b/as2_core/tests/mocks/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MOCK_SOURCES
 
 add_library(${MOCKS_LIBRARY_NAME} SHARED ${MOCK_SOURCES})
 ament_target_dependencies(${MOCKS_LIBRARY_NAME} ${PROJECT_DEPENDENCIES})
+target_link_libraries(${MOCKS_LIBRARY_NAME} ${PROJECT_NAME})
 
 install(
   DIRECTORY tests/mocks/


### PR DESCRIPTION
Error when linking using clang
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | (add issues here #749 ) |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---


See #749 
