### PR TITLE
[as2_behaviors_trajectory_generation] Generate partial trajectory and new yaw to face the next refernce

### DIFF
--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
@@ -3,6 +3,7 @@
     tf_timeout_threshold: 0.05 # tf timeout (50ms)
     sampling_n: 1 # Number of sampling of the trajectory
     sampling_dt: 0.01 # Time between each sampling
+    path_lenght: 6 # Lenght of the waypoints given to the trajectory generator
     debug:
       path_topic: "debug/traj_generated" # Topic to publish the debug path. Empty to disable
       reference_setpoint: "debug/ref_traj_point" # Topic to publish the reference waypoint. Empty to disable

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
@@ -3,7 +3,7 @@
     tf_timeout_threshold: 0.05 # tf timeout (50ms)
     sampling_n: 1 # Number of sampling of the trajectory
     sampling_dt: 0.01 # Time between each sampling
-    path_lenght: 6 # Lenght of the waypoints given to the trajectory generator
+    path_lenght: 0 # Lenght of the waypoints given to the trajectory generator
     debug:
       path_topic: "debug/traj_generated" # Topic to publish the debug path. Empty to disable
       reference_setpoint: "debug/ref_traj_point" # Topic to publish the reference waypoint. Empty to disable

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
@@ -3,7 +3,8 @@
     tf_timeout_threshold: 0.05 # tf timeout (50ms)
     sampling_n: 1 # Number of sampling of the trajectory
     sampling_dt: 0.01 # Time between each sampling
-    path_lenght: 0 # Lenght of the waypoints given to the trajectory generator
+    path_lenght: 0 # Lenght of the waypoints given to the trajectory generator. 0 is full trajectory
+    yaw_threshold: 0.1 # Threshold to cocompute the yaw angle
     debug:
       path_topic: "debug/traj_generated" # Topic to publish the debug path. Empty to disable
       reference_setpoint: "debug/ref_traj_point" # Topic to publish the reference waypoint. Empty to disable

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -112,6 +112,7 @@ private:
   int sampling_n_ = 1;
   double sampling_dt_ = 0.0;
   int path_lenght_ = 0;
+  float yaw_threshold_ = 0;
 
   // Behavior action parameters
   as2_msgs::msg::YawMode yaw_mode_;
@@ -135,7 +136,9 @@ private:
 
   // Trajectory generator
   rclcpp::Duration eval_time_ = rclcpp::Duration(0, 0);
+  rclcpp::Duration eval_time_yaw_ = rclcpp::Duration(0, 0);
   rclcpp::Time time_zero_;
+  rclcpp::Time time_zero_yaw_;
   bool first_run_ = false;
   bool has_odom_ = false;
   dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set_;
@@ -193,6 +196,7 @@ private:
     double eval_time,
     as2_msgs::msg::TrajectoryPoint & trajectory_command);
   double computeYawAnglePathFacing(double vx, double vy);
+  double computeYawFaceReference();
 
   /** For debuging **/
 

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -111,6 +111,7 @@ private:
   std::string desired_frame_id_;
   int sampling_n_ = 1;
   double sampling_dt_ = 0.0;
+  int path_lenght_ = 0;
 
   // Behavior action parameters
   as2_msgs::msg::YawMode yaw_mode_;
@@ -137,6 +138,7 @@ private:
   rclcpp::Time time_zero_;
   bool first_run_ = false;
   bool has_odom_ = false;
+  dynamic_traj_generator::DynamicWaypoint::Vector waypoints_left_;
 
   // Debug
   bool enable_debug_ = false;

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -138,7 +138,7 @@ private:
   rclcpp::Time time_zero_;
   bool first_run_ = false;
   bool has_odom_ = false;
-  dynamic_traj_generator::DynamicWaypoint::Vector waypoints_left_;
+  dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set_;
 
   // Debug
   bool enable_debug_ = false;
@@ -187,7 +187,7 @@ private:
     std::shared_ptr<
       const as2_msgs::action::GeneratePolynomialTrajectory::Goal>
     goal,
-    dynamic_traj_generator::DynamicWaypoint::Vector & waypoints);
+    dynamic_traj_generator::DynamicWaypoint::Deque & waypoints);
   bool evaluateTrajectory(double eval_time);
   bool evaluateSetpoint(
     double eval_time,

--- a/as2_msgs/msg/YawMode.msg
+++ b/as2_msgs/msg/YawMode.msg
@@ -6,6 +6,7 @@ uint8 FIXED_YAW            = 2 # Yaw angle is fixed to a given angle
 uint8 YAW_FROM_TOPIC       = 3 # Yaw angle is set by a topic
 uint8 YAW_FROM_ORIENTATION = 4 # Yaw angle is set by pose orientation
 uint8 YAW_TO_FRAME         = 5 # Yaw angle is set to face the used frame
+uint8 FACE_REFERENCE       = 6 # Yaw angle is set to face the next reference
 
 uint8 mode      # Yaw mode
 float32 angle   # Fixed yaw (rad)

--- a/as2_python_api/as2_python_api/modules/trajectory_generation_module.py
+++ b/as2_python_api/as2_python_api/modules/trajectory_generation_module.py
@@ -152,3 +152,20 @@ class TrajectoryGenerationModule(ModuleBase, TrajectoryGenerationBehavior):
         """
         return self.__traj_generation(path, speed, yaw_mode=YawMode.PATH_FACING, yaw_angle=0.0,
                                       frame_id=frame_id)
+
+    def traj_generation_with_face_reference(self, path: Path, speed: float,
+                                            frame_id: str = 'earth') -> bool:
+        """
+        Trajectory generation. With path facing yaw mode. Blocking call.
+
+        :param path: path to follow
+        :type path: Path
+        :param speed: speed (m/s) limit
+        :type speed: float
+        :param frame_id: reference frame of the coordinates, defaults to "earth"
+        :type frame_id: str, optional
+        :return: True if was accepted, False otherwise
+        :rtype: bool
+        """
+        return self.__traj_generation(path, speed, yaw_mode=YawMode.FACE_REFERENCE, yaw_angle=0.0,
+                                      frame_id=frame_id)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on |  Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Parameter path_lenght to generate the trajectory in partial trajectory. ( 0 is full trajectory)
* Change the method goalToDynamicWaypoint to work with queues instead of vectors
* New mode FACE_REFERENCE add in the YawMode message
* New method computeYawReference to face the next reference during trajectory
* New method traj_generation_with_face_reference in the module trajectory_generation_module from the modules of the as2_python_api to access to the new yaw mode from the mission



## Future work that may be required in bullet points

*Fixed exception when there are still waypoints to reach but the trajectory generator has finished
