### PR TITLE
[as2_platform_multirotor_simulator] Use as2 interface to convert commands and states

### DIFF
--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/CMakeLists.txt
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories(
 # Set source files
 set(SOURCE_CPP_FILES
   src/${PROJECT_NAME}.cpp
+  src/as2_interface.cpp
 )
 
 # Create the node executable

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/config/world_config.yaml
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/config/world_config.yaml
@@ -10,5 +10,5 @@
       y: 0.0 # Initial y position of the vehicle in odometry frame. Meters (default: 0.0)
       z: 0.0 # Initial z position of the vehicle in odometry frame. Meters (default: 0.0)
       roll: 0.0 # Initial roll orientation of the vehicle in ENU frame. Radians (default: 0.0)
-      pitch: 0.0 # Initial ptich orientation of the vehicle in ENU frame. Radians (default: 0.0)
-      yaw: 0.0 # # Initial yaw orientation of the vehicle in ENU frame. Radians (default: 0.0)
+      pitch: 0.0 # Initial pitch orientation of the vehicle in ENU frame. Radians (default: 0.0)
+      yaw: 0.0 # Initial yaw orientation of the vehicle in ENU frame. Radians (default: 0.0)

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_interface.hpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_interface.hpp
@@ -1,0 +1,154 @@
+// Copyright 2025 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+* @file as2_interface.hpp
+*
+* As2MultirotorSimulatorInterface class definition
+*
+* @authors Rafael Pérez Seguí
+*/
+
+#ifndef AS2_PLATFORM_MULTIROTOR_SIMULATOR__AS2_INTERFACE_HPP_
+#define AS2_PLATFORM_MULTIROTOR_SIMULATOR__AS2_INTERFACE_HPP_
+
+#include <string>
+#include <vector>
+
+#include "multirotor_simulator.hpp"
+#include "as2_core/aerial_platform.hpp"
+#include "as2_core/utils/tf_utils.hpp"
+#include "as2_core/utils/frame_utils.hpp"
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <as2_msgs/msg/trajectory_setpoints.hpp>
+#include <as2_msgs/msg/trajectory_point.hpp>
+
+namespace as2_platform_multirotor_simulator
+{
+
+class As2MultirotorSimulatorInterface
+{
+  using Simulator = multirotor::Simulator<double, 4>;
+  using SimulatorParams = multirotor::SimulatorParams<double, 4>;
+  using Kinematics = multirotor::state::internal::Kinematics<double>;
+
+public:
+  explicit As2MultirotorSimulatorInterface(
+    as2::Node * node_ptr);
+
+  ~As2MultirotorSimulatorInterface() {}
+
+private:
+  as2::Node * node_ptr_;
+
+  // Tf
+  as2::tf::TfHandler tf_handler_;
+  std::string frame_id_baselink_ = "base_link";
+  std::string frame_id_odom_ = "odom";
+  std::string frame_id_earth_ = "earth";
+
+  Eigen::Vector3d initial_position_;
+  Eigen::Quaterniond initial_orientation_;
+  bool using_odom_for_control_ = false;
+
+public:
+  /**
+    * @brief Get parameter from the parameter server
+    *
+    * @param param_name Name of the parameter
+    * @param param_value Value of the parameter
+    * @param use_default Use default value if parameter is not found
+   */
+  template<typename T>
+  inline void getParam(const std::string & param_name, T & param_value, bool use_default = false)
+  {
+    try {
+      // Declare parameter if not declared
+      if (!node_ptr_->has_parameter(param_name)) {
+        if (use_default) {
+          node_ptr_->declare_parameter<T>(param_name, param_value);
+        } else {
+          node_ptr_->declare_parameter<T>(param_name);
+        }
+      }
+
+      if constexpr (std::is_same<T, std::vector<double>>::value) {
+        param_value = node_ptr_->get_parameter(param_name).as_double_array();
+      } else if constexpr (std::is_same<T, double>::value) {
+        param_value = node_ptr_->get_parameter(param_name).as_double();
+      } else if constexpr (std::is_same<T, std::string>::value) {
+        param_value = node_ptr_->get_parameter(param_name).as_string();
+      } else if constexpr (std::is_same<T, bool>::value) {
+        param_value = node_ptr_->get_parameter(param_name).as_bool();
+      } else {
+        RCLCPP_WARN(node_ptr_->get_logger(), "Parameter type %s not expected", typeid(T).name());
+        param_value = node_ptr_->get_parameter<T>(param_name, param_value);
+      }
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(
+        node_ptr_->get_logger(), "Error getting parameter %s: %s", param_name.c_str(), e.what());
+    }
+  }
+
+  /**
+   * @brief Convert simulator data to odometry message
+   *
+   * @param kinematics Kinematics data
+   * @param odom Return odometry message
+   * @param current_time Current time
+   */
+  void convertToOdom(
+    const Kinematics & kinematics, nav_msgs::msg::Odometry & odom,
+    const builtin_interfaces::msg::Time & current_time);
+
+  /**
+   * @brief Convert simulator data to ground truth message
+   *
+   * @param kinematics Kinematics data
+   * @param ground_truth_pose Return ground truth pose message
+   * @param ground_truth_twist Return ground truth twist message
+   * @param current_time Current time
+   */
+  void convertToGroundTruth(
+    const Kinematics & kinematics, geometry_msgs::msg::PoseStamped & ground_truth_pose,
+    geometry_msgs::msg::TwistStamped & ground_truth_twist,
+    const builtin_interfaces::msg::Time & current_time);
+
+  bool processCommand(
+    geometry_msgs::msg::PoseStamped & pose_command);
+
+  bool processCommand(
+    geometry_msgs::msg::TwistStamped & twist_command);
+
+  bool processCommand(as2_msgs::msg::TrajectorySetpoints trajectory_command);
+};  // class As2MultirotorSimulatorInterface
+}  // namespace as2_platform_multirotor_simulator
+
+#endif  // AS2_PLATFORM_MULTIROTOR_SIMULATOR__AS2_INTERFACE_HPP_

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_platform_multirotor_simulator.hpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_platform_multirotor_simulator.hpp
@@ -57,6 +57,7 @@
 #include "as2_core/utils/gps_utils.hpp"
 #include "as2_msgs/msg/control_mode.hpp"
 #include "as2_msgs/msg/gimbal_control.hpp"
+#include "as2_interface.hpp"
 #include "multirotor_simulator.hpp"
 
 namespace as2_platform_multirotor_simulator
@@ -102,6 +103,8 @@ public:
   void gimbalControlCallback(const as2_msgs::msg::GimbalControl::SharedPtr msg);
 
 private:
+  As2MultirotorSimulatorInterface as2_interface_;
+
   as2::gps::GpsHandler gps_handler_;
   PlatformParams platform_params_;
   Simulator simulator_;
@@ -116,7 +119,6 @@ private:
   rclcpp::TimerBase::SharedPtr simulator_state_pub_timer_;
 
   std::string frame_id_baselink_ = "base_link";
-  std::string frame_id_odom_ = "odom";
   std::string frame_id_earth_ = "earth";
 
   // Gimbal

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_interface.cpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_interface.cpp
@@ -1,0 +1,200 @@
+// Copyright 2025 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file as2_interface.cpp
+ *
+ * As2MultirotorSimulatorInterface class implementation
+ *
+ * @author Rafael Perez-Segui <r.psegui@upm.es>
+ */
+
+#include "as2_platform_multirotor_simulator/as2_interface.hpp"
+
+#include "as2_core/core_functions.hpp"
+#include "as2_core/utils/frame_utils.hpp"
+#include "as2_core/utils/tf_utils.hpp"
+#include "as2_core/utils/control_mode_utils.hpp"
+
+namespace as2_platform_multirotor_simulator
+{
+
+As2MultirotorSimulatorInterface::As2MultirotorSimulatorInterface(
+  as2::Node * node_ptr)
+: node_ptr_(node_ptr), tf_handler_(node_ptr)
+{
+  getParam("global_ref_frame", frame_id_earth_);
+  getParam("odom_frame", frame_id_odom_);
+  getParam("base_frame", frame_id_baselink_);
+  frame_id_odom_ = as2::tf::generateTfName(node_ptr, frame_id_odom_);
+  frame_id_baselink_ = as2::tf::generateTfName(node_ptr, frame_id_baselink_);
+
+  getParam("use_odom_for_control", using_odom_for_control_);
+
+  // Initial position
+  getParam("vehicle_initial_pose.x", initial_position_.x());
+  getParam("vehicle_initial_pose.y", initial_position_.y());
+  getParam("vehicle_initial_pose.z", initial_position_.z());
+
+  // Initial orientation
+  double roll, pitch, yaw;
+  getParam("vehicle_initial_pose.yaw", yaw);
+  getParam("vehicle_initial_pose.pitch", pitch);
+  getParam("vehicle_initial_pose.roll", roll);
+  as2::frame::eulerToQuaternion(roll, pitch, yaw, initial_orientation_);
+  initial_orientation_ = initial_orientation_.normalized();
+}
+
+void As2MultirotorSimulatorInterface::convertToOdom(
+  const Kinematics & kinematics, nav_msgs::msg::Odometry & odometry,
+  const builtin_interfaces::msg::Time & current_time)
+{
+  odometry.header.stamp = current_time;
+  odometry.header.frame_id = frame_id_odom_;
+  odometry.child_frame_id = frame_id_baselink_;
+  odometry.pose.pose.position.x = kinematics.position.x();
+  odometry.pose.pose.position.y = kinematics.position.y();
+  odometry.pose.pose.position.z = kinematics.position.z();
+  odometry.pose.pose.orientation.w = kinematics.orientation.w();
+  odometry.pose.pose.orientation.x = kinematics.orientation.x();
+  odometry.pose.pose.orientation.y = kinematics.orientation.y();
+  odometry.pose.pose.orientation.z = kinematics.orientation.z();
+  Eigen::Vector3d odom_linear_velocity_flu =
+    as2::frame::transform(
+    kinematics.orientation.inverse(), kinematics.linear_velocity);
+  odometry.twist.twist.linear.x = odom_linear_velocity_flu.x();
+  odometry.twist.twist.linear.y = odom_linear_velocity_flu.y();
+  odometry.twist.twist.linear.z = odom_linear_velocity_flu.z();
+  odometry.twist.twist.angular.x = kinematics.angular_velocity.x();
+  odometry.twist.twist.angular.y = kinematics.angular_velocity.y();
+  odometry.twist.twist.angular.z = kinematics.angular_velocity.z();
+  return;
+}
+
+void As2MultirotorSimulatorInterface::convertToGroundTruth(
+  const Kinematics & kinematics, geometry_msgs::msg::PoseStamped & ground_truth_pose,
+  geometry_msgs::msg::TwistStamped & ground_truth_twist,
+  const builtin_interfaces::msg::Time & current_time)
+{
+  // Convert to ground truth
+  Eigen::Vector3d gt_linear_velocity_flu =
+    as2::frame::transform(kinematics.orientation.inverse(), kinematics.linear_velocity);
+
+  // Ground truth pose
+  ground_truth_pose.header.stamp = current_time;
+  ground_truth_pose.header.frame_id = frame_id_earth_;
+  ground_truth_pose.pose.position.x = kinematics.position.x();
+  ground_truth_pose.pose.position.y = kinematics.position.y();
+  ground_truth_pose.pose.position.z = kinematics.position.z();
+  ground_truth_pose.pose.orientation.w = kinematics.orientation.w();
+  ground_truth_pose.pose.orientation.x = kinematics.orientation.x();
+  ground_truth_pose.pose.orientation.y = kinematics.orientation.y();
+  ground_truth_pose.pose.orientation.z = kinematics.orientation.z();
+
+  // Ground truth twist
+  ground_truth_twist.header.stamp = current_time;
+  ground_truth_twist.header.frame_id = frame_id_baselink_;
+  ground_truth_twist.twist.linear.x = gt_linear_velocity_flu.x();
+  ground_truth_twist.twist.linear.y = gt_linear_velocity_flu.y();
+  ground_truth_twist.twist.linear.z = gt_linear_velocity_flu.z();
+  ground_truth_twist.twist.angular.x = kinematics.angular_velocity.x();
+  ground_truth_twist.twist.angular.y = kinematics.angular_velocity.y();
+  ground_truth_twist.twist.angular.z = kinematics.angular_velocity.z();
+  return;
+}
+
+bool As2MultirotorSimulatorInterface::processCommand(
+  geometry_msgs::msg::PoseStamped & pose_command)
+{
+  if (pose_command.header.frame_id != frame_id_earth_ &&
+    !tf_handler_.tryConvert(pose_command, frame_id_earth_))
+  {
+    RCLCPP_ERROR(
+      node_ptr_->get_logger(), "Error converting pose command to %s frame from frame: %s",
+      frame_id_earth_.c_str(), pose_command.header.frame_id.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool As2MultirotorSimulatorInterface::processCommand(
+  geometry_msgs::msg::TwistStamped & twist_command)
+{
+  if (twist_command.header.frame_id != frame_id_earth_ &&
+    !tf_handler_.tryConvert(twist_command, frame_id_earth_))
+  {
+    RCLCPP_ERROR(
+      node_ptr_->get_logger(), "Error converting twist command to %s frame from frame: %s",
+      frame_id_earth_.c_str(), twist_command.header.frame_id.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool As2MultirotorSimulatorInterface::processCommand(
+  as2_msgs::msg::TrajectorySetpoints trajectory_command)
+{
+  // TODO(RPS98): Improve this function for better performance
+  as2_msgs::msg::TrajectoryPoint trajectory_point = trajectory_command.setpoints[0];
+  geometry_msgs::msg::PoseStamped pose_command;
+  pose_command.header = trajectory_command.header;
+  pose_command.pose.position.x = trajectory_point.position.x;
+  pose_command.pose.position.y = trajectory_point.position.y;
+  pose_command.pose.position.z = trajectory_point.position.z;
+
+  as2::frame::eulerToQuaternion(
+    0.0, 0.0, trajectory_point.yaw_angle,
+    pose_command.pose.orientation);
+
+  geometry_msgs::msg::TwistStamped twist_command;
+  twist_command.header = trajectory_command.header;
+  twist_command.twist.linear.x = trajectory_point.twist.x;
+  twist_command.twist.linear.y = trajectory_point.twist.y;
+  twist_command.twist.linear.z = trajectory_point.twist.z;
+  twist_command.twist.angular.x = 0.0;
+  twist_command.twist.angular.y = 0.0;
+  twist_command.twist.angular.z = 0.0;
+
+  if (!processCommand(pose_command)) {
+    return false;
+  }
+  if (!processCommand(twist_command)) {
+    return false;
+  }
+  trajectory_point.position.x = pose_command.pose.position.x;
+  trajectory_point.position.y = pose_command.pose.position.y;
+  trajectory_point.position.z = pose_command.pose.position.z;
+  trajectory_point.yaw_angle = as2::frame::getYawFromQuaternion(pose_command.pose.orientation);
+  trajectory_point.twist.x = twist_command.twist.linear.x;
+  trajectory_point.twist.y = twist_command.twist.linear.y;
+  trajectory_point.twist.z = twist_command.twist.linear.z;
+  trajectory_command.setpoints[0] = trajectory_point;
+  return true;
+}
+
+}   // namespace as2_platform_multirotor_simulator

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/tests/as2_platform_multirotor_simulator_fly_gtest.cpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/tests/as2_platform_multirotor_simulator_fly_gtest.cpp
@@ -140,6 +140,14 @@ TEST_F(MultirotorSimulatorPlatformTest, TakeoffAndLand) {
   double epsilon = 1e-3;
   ASSERT_NEAR(current_pose.pose.position.x, 0.0, epsilon);
 
+  // Publish TF static transform earth and odom
+  static tf2_ros::StaticTransformBroadcaster static_broadcaster(test_node);
+  geometry_msgs::msg::TransformStamped transformStamped;
+  transformStamped.header.stamp = test_node->now();
+  transformStamped.header.frame_id = "earth";
+  transformStamped.child_frame_id = "multirotor_simulator/odom";
+  static_broadcaster.sendTransform(transformStamped);
+
   // Takeoff
   RCLCPP_INFO(test_node->get_logger(), "Taking off");
   EXPECT_TRUE(test_node->takeoffPlatform(false));


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |  |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

Aerostack2 uses: earth_{as2} - map_{as2} - odom_{as2} - base_link_{as2}
MultirotorS uses: earth_{mrs} - map_{mrs} - odom_{mrs} - base_link_{mrs}

We expect: 

- earth_{as2} = earth_{mrs}
- odom_{as2} = odom_{mrs}

So:

- Publish ground truth and odometry reading earth_{mrs} and odom_{mrs}
- Convert commands from odom_{as2} to earth_{mrs} (when using grount_truth for control) or to odom_{mrs} (when using odometry for control)

If the condition is not met, position, velocity and trajectory commands will not work.


## Description of documentation updates required from your changes

* Explain this in documentation

---

## Future work that may be required in bullet points

* Test GPS missions
* Improve simulation frames and aerostack2 frames management
