### PR TITLE
[as2_state_estimator] Enable gazebo TFs for all plugins

### DIFF
--- a/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
+++ b/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
@@ -163,6 +163,11 @@ protected:
   inline const std::string & get_odom_frame() const {return odom_frame_id_;}
   inline const std::string & get_base_frame() const {return base_frame_id_;}
 
+  inline void set_earth_frame(const std::string & frame) {earth_frame_id_ = frame;}
+  inline void set_map_frame(const std::string & frame) {map_frame_id_ = frame;}
+  inline void set_odom_frame(const std::string & frame) {odom_frame_id_ = frame;}
+  inline void set_base_frame(const std::string & frame) {base_frame_id_ = frame;}
+
   tf2::Transform odom_to_baselink;
   tf2::Transform earth_to_map;
   tf2::Transform map_to_odom;

--- a/as2_state_estimator/plugins/ground_truth/config/plugin_default.yaml
+++ b/as2_state_estimator/plugins/ground_truth/config/plugin_default.yaml
@@ -6,4 +6,4 @@
     #   lat: 0.0  # Set manually origin latitude
     #   lon: 0.0  # Set manually origin latitude
     #   alt: 0.0  # Set manually origin altitude in meters
-    use_gazebo_tf: False  # Use the gazebo tf tree
+    use_gazebo_tf: false  # Use the gazebo tf tree

--- a/as2_state_estimator/plugins/raw_odometry/include/raw_odometry.hpp
+++ b/as2_state_estimator/plugins/raw_odometry/include/raw_odometry.hpp
@@ -208,15 +208,13 @@ private:
         node_ptr_->get_logger(), "Received odom in frame %s, expected %s. "
         "frame_id changed to expected one",
         msg->header.frame_id.c_str(), get_odom_frame().c_str());
-      return;
     }
     if (msg->child_frame_id != get_base_frame()) {
       RCLCPP_WARN_ONCE(
         node_ptr_->get_logger(),
-        "Received odom child_frame_id  in frame %s, expected %s. "
+        "Received odom child_frame_id in frame %s, expected %s. "
         "child_frame_id changed to expected one",
         msg->child_frame_id.c_str(), get_base_frame().c_str());
-      return;
     }
 
     auto transform = geometry_msgs::msg::TransformStamped();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

- When using Gazebo, the `base_frame` must be `/namespace`.
- Also, the `use_gazebo_tf` parameter is kept for backward compatibility.
