### PR TITLE
[as2_behavior_tree] Add wait_for_service_timeout parameter

### DIFF
--- a/as2_behavior_tree/src/as2_behavior_tree_node.cpp
+++ b/as2_behavior_tree/src/as2_behavior_tree_node.cpp
@@ -74,7 +74,7 @@ int main(int argc, char * argv[])
   node->declare_parameter<int>("groot_server_port", 1667);
   node->declare_parameter<int>("server_timeout", 10000);  // miliseconds
   node->declare_parameter<int>("bt_loop_duration", 10);  // miliseconds
-  node->declare_parameter<int>("wait_for_service_timeout", 5000); // miliseconds
+  node->declare_parameter<int>("wait_for_service_timeout", 5000);  // miliseconds
   std::string tree_description = node->get_parameter("tree").as_string();
   bool groot_logger = node->get_parameter("use_groot").as_bool();
   int groot_client_port = node->get_parameter("groot_client_port").as_int();

--- a/as2_behavior_tree/src/as2_behavior_tree_node.cpp
+++ b/as2_behavior_tree/src/as2_behavior_tree_node.cpp
@@ -74,12 +74,14 @@ int main(int argc, char * argv[])
   node->declare_parameter<int>("groot_server_port", 1667);
   node->declare_parameter<int>("server_timeout", 10000);  // miliseconds
   node->declare_parameter<int>("bt_loop_duration", 10);  // miliseconds
+  node->declare_parameter<int>("wait_for_service_timeout", 5000); // miliseconds
   std::string tree_description = node->get_parameter("tree").as_string();
   bool groot_logger = node->get_parameter("use_groot").as_bool();
   int groot_client_port = node->get_parameter("groot_client_port").as_int();
   int groot_server_port = node->get_parameter("groot_server_port").as_int();
   int server_timeout = node->get_parameter("server_timeout").as_int();
   int bt_loop_duration = node->get_parameter("bt_loop_duration").as_int();
+  int wait_for_service_timeout = node->get_parameter("wait_for_service_timeout").as_int();
 
   BT::BehaviorTreeFactory factory;
 
@@ -109,7 +111,8 @@ int main(int argc, char * argv[])
     "server_timeout", std::chrono::milliseconds(server_timeout));
   config->blackboard->set<std::chrono::milliseconds>(
     "bt_loop_duration", std::chrono::milliseconds(bt_loop_duration));
-
+  config->blackboard->set<std::chrono::milliseconds>(
+    "wait_for_service_timeout", std::chrono::milliseconds(wait_for_service_timeout));
   auto tree = factory.createTreeFromFile(tree_description, config->blackboard);
 
   // LOGGERS


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | ([#14](https://github.com/aerostack2/project_gazebo/issues/14)) |
| ROS2 version tested on | (Humble) |
| Aerial platform tested on | (Gazebo) |

---

## Description of contribution in a few bullet points

<!--
* Added this neat new feature
* Also fixed a typo in a parameter name in as2_motion_controller_manager
-->

Introduced a new parameter wait_for_service_timeout with a default value of 5000 milliseconds.

This prevents the crashing:
[as2_behavior_tree_node-1] terminate called after throwing an instance of 'BT::RuntimeError'
[as2_behavior_tree_node-1]   what():  Blackboard::get() error. Missing key [wait_for_service_timeout]

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* Added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* There might be some optimizations to be made in ...
* A lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
-->
