### PR TITLE
[as2_behaviors_trajectory_generator] Modify a set of waypoints due to frame offsets

### DIFF
--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
@@ -4,9 +4,9 @@
     sampling_n: 1 # Number of sampling of the trajectory
     sampling_dt: 0.01 # Time between each sampling
     path_lenght: 0 # Lenght of the waypoints given to the trajectory generator. 0 is full trajectory
-    yaw_threshold: 0.1 # Threshold to compute the yaw angle
-    transform_threshold: 1.0 # Threshold to compute the transform between frames
-    yaw_speed_threshold: 2.0 # Threshold to compute the yaw speed
+    yaw_threshold: 0.1 # Threshold to compute the yaw angle. 0 always face the next waypoint. A high value fix the yaw to the initial current_yaw
+    transform_threshold: 1.0 # Threshold to limit the maximum distance between the last transform between map to odom and the current transform
+    yaw_speed_threshold: 2.0 # Threshold to limit the yaw speed to update the current yaw
     debug:
       path_topic: "debug/traj_generated" # Topic to publish the debug path. Empty to disable
       reference_setpoint: "debug/ref_traj_point" # Topic to publish the reference waypoint. Empty to disable

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
@@ -4,7 +4,9 @@
     sampling_n: 1 # Number of sampling of the trajectory
     sampling_dt: 0.01 # Time between each sampling
     path_lenght: 0 # Lenght of the waypoints given to the trajectory generator. 0 is full trajectory
-    yaw_threshold: 0.1 # Threshold to cocompute the yaw angle
+    yaw_threshold: 0.1 # Threshold to compute the yaw angle
+    transform_threshold: 1.0 # Threshold to compute the transform between frames
+    yaw_speed_threshold: 2.0 # Threshold to compute the yaw speed
     debug:
       path_topic: "debug/traj_generated" # Topic to publish the debug path. Empty to disable
       reference_setpoint: "debug/ref_traj_point" # Topic to publish the reference waypoint. Empty to disable

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
@@ -6,6 +6,7 @@
     path_lenght: 0 # Lenght of the waypoints given to the trajectory generator. 0 is full trajectory
     yaw_threshold: 0.1 # Threshold to compute the yaw angle. 0 always face the next waypoint. A high value fix the yaw to the initial current_yaw
     transform_threshold: 1.0 # Threshold to limit the maximum distance between the last transform between map to odom and the current transform
+    frequency_update_frame: 0.0 # Frequency to check the transform between map to odom and update the waypoint of the trajectory.0 disable the update
     yaw_speed_threshold: 2.0 # Threshold to limit the yaw speed to update the current yaw
     debug:
       path_topic: "debug/traj_generated" # Topic to publish the debug path. Empty to disable

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -109,10 +109,13 @@ private:
   // Parameters
   std::string base_link_frame_id_;
   std::string desired_frame_id_;
+  std::string map_frame_id_;
   int sampling_n_ = 1;
   double sampling_dt_ = 0.0;
   int path_lenght_ = 0;
   float yaw_threshold_ = 0;
+  float transform_threshold_ = 1.0;
+  double yaw_speed_threshold_ = 2.0;
 
   // Behavior action parameters
   as2_msgs::msg::YawMode yaw_mode_;
@@ -129,6 +132,8 @@ private:
 
   // State
   Eigen::Vector3d current_position_;
+  geometry_msgs::msg::TransformStamped current_transform_;
+  geometry_msgs::msg::TransformStamped last_transform_;
   double current_yaw_;
 
   // Command
@@ -195,8 +200,12 @@ private:
   bool evaluateSetpoint(
     double eval_time,
     as2_msgs::msg::TrajectoryPoint & trajectory_command);
+  bool updateFrame(
+    const as2_msgs::action::GeneratePolynomialTrajectory::Goal &
+    goal);
   double computeYawAnglePathFacing(double vx, double vy);
   double computeYawFaceReference();
+  bool computeErrorFrames();
 
   /** For debuging **/
 

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -151,6 +151,7 @@ private:
   bool first_run_ = false;
   bool has_odom_ = false;
   dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set_;
+  std::optional<rclcpp::Time> time_debug_;
 
   // Debug
   bool enable_debug_ = false;

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -95,6 +95,10 @@ private:
   rclcpp::Subscription<as2_msgs::msg::PoseStampedWithIDArray>::SharedPtr
     mod_waypoint_sub_;
 
+  /** Timer**/
+  rclcpp::TimerBase::SharedPtr timer_update_frame_;
+  double frequency_update_frame_ = 0.0;
+
   /** Dynamic trajectory generator library */
   // dynamic_traj_generator::DynamicTrajectory trajectory_generator_;
   std::shared_ptr<dynamic_traj_generator::DynamicTrajectory>
@@ -181,6 +185,11 @@ private:
   void on_execution_end(const as2_behavior::ExecutionStatus & state) override;
 
 private:
+  /**
+  * @brief Callback to check the errors between frames and update the frame offset
+  */
+  void timerUpdateFrameCallback();
+
   /** Topic Callbacks **/
   void stateCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
   void yawCallback(const std_msgs::msg::Float32::SharedPtr _msg);

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -132,8 +132,8 @@ private:
 
   // State
   Eigen::Vector3d current_position_;
-  geometry_msgs::msg::TransformStamped current_transform_;
-  geometry_msgs::msg::TransformStamped last_transform_;
+  geometry_msgs::msg::TransformStamped current_map_to_odom_transform_;
+  geometry_msgs::msg::TransformStamped last_map_to_odom_transform_;
   double current_yaw_;
 
   // Command
@@ -200,11 +200,28 @@ private:
   bool evaluateSetpoint(
     double eval_time,
     as2_msgs::msg::TrajectoryPoint & trajectory_command);
+
+  /**
+   * @brief update the trajectory waypoint and waypoint_to_set_queue with the frame offset
+   * @param goal the goal of the action
+   * @return bool Return false if the transform between the map and the desired frame is not available and true otherwise
+   */
   bool updateFrame(
     const as2_msgs::action::GeneratePolynomialTrajectory::Goal &
     goal);
+
   double computeYawAnglePathFacing(double vx, double vy);
+
+  /**
+  * @brief Compute the Yaw angle to face the next reference point
+  * @return double Current yaw angle if the distance to the next reference point is less than the yaw_threshold_ or the angle to face the next reference point otherwise
+  */
   double computeYawFaceReference();
+
+  /**
+* @brief Compute the error frames between the map and the desired frame
+* @return bool Return true if the frame offset is bigger than the transform_threshold_ and false otherwise
+*/
   bool computeErrorFrames();
 
   /** For debuging **/

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
@@ -86,6 +86,7 @@ DynamicPolynomialTrajectoryGenerator::DynamicPolynomialTrajectoryGenerator(
   yaw_threshold_ = this->declare_parameter<float>("yaw_threshold", 0.1);
   transform_threshold_ = this->declare_parameter<float>("transform_threshold", 1.0);
   yaw_speed_threshold_ = this->declare_parameter<double>("yaw_speed_threshold", 2.0);
+  frequency_update_frame_ = this->declare_parameter<double>("frequency_update_frame", 0.0);
 
   if (sampling_n_ < 1) {
     RCLCPP_ERROR(this->get_logger(), "Sampling n must be greater than 0");
@@ -127,9 +128,28 @@ DynamicPolynomialTrajectoryGenerator::DynamicPolynomialTrajectoryGenerator(
   {
     enable_debug_ = true;
   }
+  if (frequency_update_frame_ > 0) {
+    /** Calback to check the transform between frames */
+    timer_update_frame_ = this->create_wall_timer(
+      std::chrono::milliseconds(static_cast<int>(1000 / frequency_update_frame_)),
+      std::bind(
+        &DynamicPolynomialTrajectoryGenerator::timerUpdateFrameCallback,
+        this));
+  }
   return;
 }
-
+void DynamicPolynomialTrajectoryGenerator::timerUpdateFrameCallback()
+{
+  RCLCPP_INFO(this->get_logger(), " Check error");
+  if (computeErrorFrames()) {
+    RCLCPP_INFO(this->get_logger(), " Update frames");
+    if (!updateFrame(goal_)) {
+      RCLCPP_ERROR(
+        this->get_logger(), "Could not update transform between %s and %s",
+        map_frame_id_.c_str(), desired_frame_id_.c_str());
+    }
+  }
+}
 void DynamicPolynomialTrajectoryGenerator::stateCallback(
   const geometry_msgs::msg::TwistStamped::SharedPtr _twist_msg)
 {
@@ -155,13 +175,6 @@ void DynamicPolynomialTrajectoryGenerator::stateCallback(
         pose_msg.pose.position.z));
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(this->get_logger(), "Could not get transform: %s", ex.what());
-  }
-  if (computeErrorFrames()) {
-    if (!updateFrame(goal_)) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Could not update transform between %s and %s",
-        map_frame_id_.c_str(), desired_frame_id_.c_str());
-    }
   }
   return;
 }
@@ -652,36 +665,36 @@ bool DynamicPolynomialTrajectoryGenerator::updateFrame(
   const as2_msgs::action::GeneratePolynomialTrajectory::Goal &
   goal)
 {
+  std::vector<std::pair<std::string, Eigen::Vector3d>> waypoints_to_set_vector;
   // Update the frame
   for (as2_msgs::msg::PoseStampedWithID waypoint : goal.path) {
-    if (waypoint.pose.header.frame_id != desired_frame_id_) {
-      geometry_msgs::msg::PoseStamped pose_stamped;
-      if (!tf_handler_.tryConvert(waypoint.pose, desired_frame_id_)) {return false;}
-      // Update the waypoint in the trajectory generator
-      for (auto traj_waypoint : trajectory_generator_->getNextTrajectoryWaypoints()) {
-        if (traj_waypoint.getName() == waypoint.id) {
-          waypoint.pose.header.stamp = this->now();
-          Eigen::Vector3d position;
-          position.x() = waypoint.pose.pose.position.x;
-          position.y() = waypoint.pose.pose.position.y;
-          position.z() = waypoint.pose.pose.position.z;
-          trajectory_generator_->modifyWaypoint(waypoint.id, position);
-        }
+    if (!tf_handler_.tryConvert(waypoint.pose, desired_frame_id_)) {return false;}
+    // Update the waypoint in the trajectory generator
+    for (auto traj_waypoint : trajectory_generator_->getNextTrajectoryWaypoints()) {
+      if (traj_waypoint.getName() == waypoint.id) {
+        waypoint.pose.header.stamp = this->now();
+        Eigen::Vector3d position;
+        position.x() = waypoint.pose.pose.position.x;
+        position.y() = waypoint.pose.pose.position.y;
+        position.z() = waypoint.pose.pose.position.z;
+        waypoints_to_set_vector.emplace_back(waypoint.id, position);
       }
-      // Update the waypoints in the queue
-      dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set;
-      for (auto waypoints_queue : waypoints_to_set_) {
-        if (waypoints_queue.getName() == waypoint.id) {
-          waypoints_to_set.emplace_back(waypoints_queue);
-        }
-      }
-      waypoints_to_set_.clear();
-      waypoints_to_set_ = waypoints_to_set;
     }
+    // Update the waypoints in the queue
+    dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set_queue;
+    for (auto waypoints_queue : waypoints_to_set_) {
+      if (waypoints_queue.getName() == waypoint.id) {
+        waypoints_to_set_queue.emplace_back(waypoints_queue);
+      }
+    }
+    waypoints_to_set_.clear();
+    waypoints_to_set_ = waypoints_to_set_queue;
   }
   last_map_to_odom_transform_ = tf_handler_.getTransform(
     map_frame_id_, desired_frame_id_,
     tf2::TimePointZero);
+  trajectory_generator_->modifyWaypoints(waypoints_to_set_vector);
+  waypoints_to_set_vector.clear();
   return true;
 }
 

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
@@ -267,7 +267,9 @@ bool DynamicPolynomialTrajectoryGenerator::on_activate(
   }
   // Set waypoints to trajectory generator
   trajectory_generator_->setWaypoints(waypoints_to_set);
-  last_transform_ = tf_handler_.getTransform(map_frame_id_, desired_frame_id_, tf2::TimePointZero);
+  last_map_to_odom_transform_ = tf_handler_.getTransform(
+    map_frame_id_, desired_frame_id_,
+    tf2::TimePointZero);
   yaw_mode_ = goal->yaw;
   goal_ = *goal;
 
@@ -677,7 +679,9 @@ bool DynamicPolynomialTrajectoryGenerator::updateFrame(
       waypoints_to_set_ = waypoints_to_set;
     }
   }
-  last_transform_ = tf_handler_.getTransform(map_frame_id_, desired_frame_id_, tf2::TimePointZero);
+  last_map_to_odom_transform_ = tf_handler_.getTransform(
+    map_frame_id_, desired_frame_id_,
+    tf2::TimePointZero);
   return true;
 }
 
@@ -725,18 +729,20 @@ double DynamicPolynomialTrajectoryGenerator::computeYawFaceReference()
 }
 bool DynamicPolynomialTrajectoryGenerator::computeErrorFrames()
 {
-  current_transform_ =
+  current_map_to_odom_transform_ =
     tf_handler_.getTransform(map_frame_id_, desired_frame_id_, tf2::TimePointZero);
   Eigen::Vector3d current_traslation = Eigen::Vector3d(
-    current_transform_.transform.translation.x,
-    current_transform_.transform.translation.y,
-    current_transform_.transform.translation.z);
+    current_map_to_odom_transform_.transform.translation.x,
+    current_map_to_odom_transform_.transform.translation.y,
+    current_map_to_odom_transform_.transform.translation.z);
   Eigen::Vector3d last_traslation = Eigen::Vector3d(
-    last_transform_.transform.translation.x,
-    last_transform_.transform.translation.y,
-    last_transform_.transform.translation.z);
-  double current_yaw = as2::frame::getYawFromQuaternion(current_transform_.transform.rotation);
-  double last_yaw = as2::frame::getYawFromQuaternion(last_transform_.transform.rotation);
+    last_map_to_odom_transform_.transform.translation.x,
+    last_map_to_odom_transform_.transform.translation.y,
+    last_map_to_odom_transform_.transform.translation.z);
+  double current_yaw = as2::frame::getYawFromQuaternion(
+    current_map_to_odom_transform_.transform.rotation);
+  double last_yaw =
+    as2::frame::getYawFromQuaternion(last_map_to_odom_transform_.transform.rotation);
   Eigen::Vector3d traslation_error =
     Eigen::Vector3d(
     current_traslation[0] - last_traslation[0],

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
@@ -140,9 +140,7 @@ DynamicPolynomialTrajectoryGenerator::DynamicPolynomialTrajectoryGenerator(
 }
 void DynamicPolynomialTrajectoryGenerator::timerUpdateFrameCallback()
 {
-  RCLCPP_INFO(this->get_logger(), " Check error");
   if (computeErrorFrames()) {
-    RCLCPP_INFO(this->get_logger(), " Update frames");
     if (!updateFrame(goal_)) {
       RCLCPP_ERROR(
         this->get_logger(), "Could not update transform between %s and %s",
@@ -708,6 +706,7 @@ bool DynamicPolynomialTrajectoryGenerator::updateFrame(
     map_frame_id_, desired_frame_id_,
     tf2::TimePointZero);
   trajectory_generator_->modifyWaypoints(waypoints_to_set_vector);
+  time_debug_ = this->now();
   waypoints_to_set_vector.clear();
   return true;
 }
@@ -798,7 +797,13 @@ void DynamicPolynomialTrajectoryGenerator::plotTrajectory()
 
 void DynamicPolynomialTrajectoryGenerator::plotTrajectoryThread()
 {
-  auto time_stamp = this->now();
+  rclcpp::Time time_stamp;
+  if (time_debug_.has_value()) {
+    time_stamp = time_debug_.value();
+  } else {
+    time_stamp = this->now();
+  }
+
   if (debug_path_pub_ != nullptr) {
     nav_msgs::msg::Path path_msg;
     const float step = 0.2;

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
@@ -49,6 +49,7 @@ DynamicPolynomialTrajectoryGenerator::DynamicPolynomialTrajectoryGenerator(
   tf_handler_(this)
 {
   desired_frame_id_ = as2::tf::generateTfName(this, "odom");
+  map_frame_id_ = as2::tf::generateTfName(this, "map");
   base_link_frame_id_ = as2::tf::generateTfName(this, "base_link");
 
   trajectory_generator_ =
@@ -83,6 +84,8 @@ DynamicPolynomialTrajectoryGenerator::DynamicPolynomialTrajectoryGenerator(
   sampling_dt_ = this->get_parameter("sampling_dt").as_double();
   path_lenght_ = this->declare_parameter<int>("path_lenght", 0);
   yaw_threshold_ = this->declare_parameter<float>("yaw_threshold", 0.1);
+  transform_threshold_ = this->declare_parameter<float>("transform_threshold", 1.0);
+  yaw_speed_threshold_ = this->declare_parameter<double>("yaw_speed_threshold", 2.0);
 
   if (sampling_n_ < 1) {
     RCLCPP_ERROR(this->get_logger(), "Sampling n must be greater than 0");
@@ -152,6 +155,13 @@ void DynamicPolynomialTrajectoryGenerator::stateCallback(
         pose_msg.pose.position.z));
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(this->get_logger(), "Could not get transform: %s", ex.what());
+  }
+  if (computeErrorFrames()) {
+    if (!updateFrame(goal_)) {
+      RCLCPP_ERROR(
+        this->get_logger(), "Could not update transform between %s and %s",
+        map_frame_id_.c_str(), desired_frame_id_.c_str());
+    }
   }
   return;
 }
@@ -257,6 +267,7 @@ bool DynamicPolynomialTrajectoryGenerator::on_activate(
   }
   // Set waypoints to trajectory generator
   trajectory_generator_->setWaypoints(waypoints_to_set);
+  last_transform_ = tf_handler_.getTransform(map_frame_id_, desired_frame_id_, tf2::TimePointZero);
   yaw_mode_ = goal->yaw;
   goal_ = *goal;
 
@@ -635,11 +646,45 @@ bool DynamicPolynomialTrajectoryGenerator::evaluateSetpoint(
 
   return succes_eval;
 }
+bool DynamicPolynomialTrajectoryGenerator::updateFrame(
+  const as2_msgs::action::GeneratePolynomialTrajectory::Goal &
+  goal)
+{
+  // Update the frame
+  for (as2_msgs::msg::PoseStampedWithID waypoint : goal.path) {
+    if (waypoint.pose.header.frame_id != desired_frame_id_) {
+      geometry_msgs::msg::PoseStamped pose_stamped;
+      if (!tf_handler_.tryConvert(waypoint.pose, desired_frame_id_)) {return false;}
+      // Update the waypoint in the trajectory generator
+      for (auto traj_waypoint : trajectory_generator_->getNextTrajectoryWaypoints()) {
+        if (traj_waypoint.getName() == waypoint.id) {
+          waypoint.pose.header.stamp = this->now();
+          Eigen::Vector3d position;
+          position.x() = waypoint.pose.pose.position.x;
+          position.y() = waypoint.pose.pose.position.y;
+          position.z() = waypoint.pose.pose.position.z;
+          trajectory_generator_->modifyWaypoint(waypoint.id, position);
+        }
+      }
+      // Update the waypoints in the queue
+      dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set;
+      for (auto waypoints_queue : waypoints_to_set_) {
+        if (waypoints_queue.getName() == waypoint.id) {
+          waypoints_to_set.emplace_back(waypoints_queue);
+        }
+      }
+      waypoints_to_set_.clear();
+      waypoints_to_set_ = waypoints_to_set;
+    }
+  }
+  last_transform_ = tf_handler_.getTransform(map_frame_id_, desired_frame_id_, tf2::TimePointZero);
+  return true;
+}
 
 double DynamicPolynomialTrajectoryGenerator::computeYawAnglePathFacing(
   double vx, double vy)
 {
-  if (sqrt(vx * vx + vy * vy) > 0.1) {
+  if (sqrt(vx * vx + vy * vy) > yaw_threshold_) {
     return as2::frame::getVector2DAngle(vx, vy);
   }
   return current_yaw_;
@@ -647,42 +692,63 @@ double DynamicPolynomialTrajectoryGenerator::computeYawAnglePathFacing(
 double DynamicPolynomialTrajectoryGenerator::computeYawFaceReference()
 {
   eval_time_yaw_ = rclcpp::Duration(0, 0);
-  if (trajectory_generator_->getRemainingWaypoints() > 0) {
-    dynamic_traj_generator::DynamicWaypoint::Vector next_trajectory_waypoint =
-      trajectory_generator_->getNextTrajectoryWaypoints();
-    Eigen::Vector3d next_position = next_trajectory_waypoint.begin()->getOriginalPosition();
-    Eigen::Vector2d diff(next_position[0] - current_position_[0],
-      next_position[1] - current_position_[1]);
-
-    if (diff.norm() < yaw_threshold_) {
-      RCLCPP_WARN(
-        this->get_logger(),
-        "Reference is too close to the current position in the plane, setting yaw_mode to "
-        "KEEP_YAW");
-
-      // Store the time when the yaw is set
-      time_zero_yaw_ = this->now();
-      return current_yaw_;
-    } else {
-      // Error from the current yaw to the desired yaw
-      double yaw_error =
-        as2::frame::angleMinError(
-        as2::frame::getVector2DAngle(diff.x(), diff.y()), current_yaw_);
-      eval_time_yaw_ = this->now() - time_zero_yaw_;
-      // Compute the speed to reach the desired yaw
-      double yaw_speed = yaw_error / eval_time_yaw_.seconds();
-      // Limit the yaw speed
-      yaw_speed = std::clamp(yaw_speed, -2.0, 2.0);
-      // Store the time when the yaw is set
-      time_zero_yaw_ = this->now();
-      return current_yaw_ + yaw_speed * eval_time_yaw_.seconds();
-    }
-  } else {
-    // If there are no more waypoints, keep the current yaw
-    // Store the time when the yaw is set
+  if (trajectory_generator_->getRemainingWaypoints() < 1) {
     time_zero_yaw_ = this->now();
     return current_yaw_;
   }
+
+  dynamic_traj_generator::DynamicWaypoint::Vector next_trajectory_waypoint =
+    trajectory_generator_->getNextTrajectoryWaypoints();
+  Eigen::Vector3d next_position = next_trajectory_waypoint.begin()->getOriginalPosition();
+  Eigen::Vector2d diff(next_position[0] - current_position_[0],
+    next_position[1] - current_position_[1]);
+
+  if (diff.norm() > yaw_threshold_) {
+    // Error from the current yaw to the desired yaw
+    double yaw_error =
+      as2::frame::angleMinError(
+      as2::frame::getVector2DAngle(diff.x(), diff.y()), current_yaw_);
+    eval_time_yaw_ = this->now() - time_zero_yaw_;
+    // Compute the speed to reach the desired yaw
+    double yaw_speed = yaw_error / eval_time_yaw_.seconds();
+    // Limit the yaw speed
+    yaw_speed = std::clamp(yaw_speed, (-yaw_speed_threshold_), yaw_speed_threshold_);
+    // Store the time when the yaw is set
+    time_zero_yaw_ = this->now();
+    return current_yaw_ + yaw_speed * eval_time_yaw_.seconds();
+  } else {
+    // Store the time when the yaw is set
+    time_zero_yaw_ = this->now();
+    // If there are no more waypoints, keep the current yaw
+    return current_yaw_;
+  }
+}
+bool DynamicPolynomialTrajectoryGenerator::computeErrorFrames()
+{
+  current_transform_ =
+    tf_handler_.getTransform(map_frame_id_, desired_frame_id_, tf2::TimePointZero);
+  Eigen::Vector3d current_traslation = Eigen::Vector3d(
+    current_transform_.transform.translation.x,
+    current_transform_.transform.translation.y,
+    current_transform_.transform.translation.z);
+  Eigen::Vector3d last_traslation = Eigen::Vector3d(
+    last_transform_.transform.translation.x,
+    last_transform_.transform.translation.y,
+    last_transform_.transform.translation.z);
+  double current_yaw = as2::frame::getYawFromQuaternion(current_transform_.transform.rotation);
+  double last_yaw = as2::frame::getYawFromQuaternion(last_transform_.transform.rotation);
+  Eigen::Vector3d traslation_error =
+    Eigen::Vector3d(
+    current_traslation[0] - last_traslation[0],
+    current_traslation[1] - last_traslation[1],
+    current_traslation[2] - last_traslation[2]);
+  if (traslation_error.norm() > transform_threshold_) {
+    return true;
+  }
+  // if (as2::frame::angleMinError(current_yaw, last_yaw) > 0.5) {
+  //   return true;
+  // }
+  return false;
 }
 
 /** Debug functions **/


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | -|
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Update the updateFrame method to use the new method from the dynamic_trajectory_generator library, which allows modifying a set of waypoints with a single call.
* The computeErrorFrames method, which calls the updateFrame, is invoked by a new timer outside of the stateCallback.


## Description of documentation updates required from your changes


* The frequency of the new timer is a parameter set via the config file.
*The default value of the frequency is 0, which disables the timer callback.
*Synchronize the plotTrajectoryThread with the updateFrame
