### PR TITLE
[as2_behavior_swarm_flocking] Remove ros_backward from dependencies

### DIFF
--- a/as2_behaviors/as2_behaviors_swarm_flocking/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_swarm_flocking/CMakeLists.txt
@@ -32,7 +32,6 @@ endif()
 # Set commons dependencies
 set(PROJECT_DEPENDENCIES
   ament_cmake
-  backward_ros
   ament_cmake_ros
   rclcpp
   rclcpp_action
@@ -60,7 +59,6 @@ endforeach()
 set (SUBPROJECT_NAME
 swarm_flocking_behavior_node
   )
-find_package(backward_ros REQUIRED)
 
 
 # Include directories


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | https://github.com/aerostack2/aerostack2/actions/runs/15443260810/job/43466040995 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* Fix docker nightly build by removing backward_ros unmet dependency from CMakeLists

```
#28 779.2 CMake Error at CMakeLists.txt:55 (find_package):
#28 779.2   By not providing "Findbackward_ros.cmake" in CMAKE_MODULE_PATH this project
#28 779.2   has asked CMake to find a package configuration file provided by
#28 779.2   "backward_ros", but CMake did not find one.
#28 779.2 
#28 779.2   Could not find a package configuration file provided by "backward_ros" with
#28 779.2   any of the following names:
#28 779.2 
#28 779.2     backward_rosConfig.cmake
#28 779.2     backward_ros-config.cmake
#28 779.2 
#28 779.2   Add the installation prefix of "backward_ros" to CMAKE_PREFIX_PATH or set
#28 779.2   "backward_ros_DIR" to a directory containing one of the above files.  If
#28 779.2   "backward_ros" provides a separate development package or SDK, be sure it
#28 779.2   has been installed.
```