### PR TITLE
[as2_behaviors_swarm_flocking] ROS buildfarm dependency fix

### DIFF
--- a/as2_behaviors/as2_behaviors_swarm_flocking/package.xml
+++ b/as2_behaviors/as2_behaviors_swarm_flocking/package.xml
@@ -4,8 +4,8 @@
   <name>as2_behaviors_swarm_flocking</name>
   <version>0.0.0</version>
   <description>AS2 behavior swarm flocking</description>
-  <maintainer email="c.derojas@alumnos.upm.es">carmendrpr</maintainer>
- <license>BSD-3-Clause</license>
+  <maintainer email="cvar.upm3@gmail.com">CVAR-UPM</maintainer>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/as2_behaviors/as2_behaviors_swarm_flocking/package.xml
+++ b/as2_behaviors/as2_behaviors_swarm_flocking/package.xml
@@ -22,7 +22,7 @@
   <depend>tf2_ros</depend>
   <depend>trajectory_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>Eigen3</depend>
+  <depend>eigen</depend>
   <depend>rclcpp_components</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #813 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* `eigen` dependency
* Change to cvar-upm maintainer
