### PR TITLE
[as2_gazebo_assets] Fixed image depth generation and tf tree for rgbd sensor

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/bridges/bridges.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/bridges/bridges.py
@@ -206,7 +206,7 @@ def image(world_name, drone_model_name, sensor_model_name,
     """Image bridge."""
     sensor_prefix = prefix(world_name, drone_model_name, sensor_model_name, sensor_model_type)
     return Bridge(
-        gz_topic=f'{sensor_prefix}/camera/image',
+        gz_topic=f'{sensor_prefix}/{sensor_model_type}/image',
         ros_topic=f'sensor_measurements/{sensor_model_prefix}/image_raw',
         gz_type='ignition.msgs.Image',
         ros_type='sensor_msgs/msg/Image',
@@ -218,7 +218,7 @@ def depth_image(world_name, model_name, sensor_name, sensor_type, model_prefix='
     """Depth image bridge."""
     sensor_prefix = prefix(world_name, model_name, sensor_name, sensor_type)
     return Bridge(
-        gz_topic=f'{sensor_prefix}/rgbd_camera/depth_image',
+        gz_topic=f'{sensor_prefix}/{sensor_type}/depth_image',
         ros_topic=f'sensor_measurements/{model_prefix}/depth',
         gz_type='ignition.msgs.Image',
         ros_type='sensor_msgs/msg/Image',

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/bridges/custom_bridges.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/bridges/custom_bridges.py
@@ -175,14 +175,14 @@ def static_tf_node(drone_model_name: str, sensor_model_name: str,
     This static tf fixes camera optical frames.
     """
     if not gimbaled:
-        parent_frame = f'/{drone_model_name}/{sensor_model_name}/{sensor_model_type}/camera',
+        parent_frame = f'/{drone_model_name}/{sensor_model_name}/{sensor_model_type}',
         child_frame = f'/{drone_model_name}/{sensor_model_name}/' + \
-            f'{sensor_model_type}/camera/optical_frame'
+            f'{sensor_model_type}/optical_frame'
     else:
         parent_frame = f'/{drone_model_name}/{gimbal_name}/_0/_1/_2/{sensor_model_name}/' + \
-            f'{sensor_model_type}/camera'
+            f'{sensor_model_type}'
         child_frame = f'/{drone_model_name}/{gimbal_name}/_0/_1/_2/{sensor_model_name}/' + \
-            f'{sensor_model_type}/camera/optical_frame'
+            f'{sensor_model_type}/optical_frame'
 
     return Node(
         package='tf2_ros',


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #824 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Rgbd sensor now publishes depth + image
<img width="2563" height="1322" alt="Screenshot from 2025-09-11 17-12-34" src="https://github.com/user-attachments/assets/78696326-5dd6-459f-a86f-3f99ab46ff22" />

* Rgbd sensor tf tree fixed
<img width="2563" height="1322" alt="Screenshot from 2025-09-11 17-38-39" src="https://github.com/user-attachments/assets/0b4ae118-0890-44ab-8950-ec3262d493f0" />

---

## Future work that may be required in bullet points

* Somehow separate camera_info from depth and rgb image, right now they use the same one.
