### PR TITLE
[aerostack2] ament_index_cpp changes

### DIFF
--- a/as2_aerial_platforms/as2_platform_gazebo/package.xml
+++ b/as2_aerial_platforms/as2_platform_gazebo/package.xml
@@ -16,10 +16,10 @@
   <depend>as2_gazebo_assets</depend>
   <depend>geometry_msgs</depend>
 
-  <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_aerial_platforms/as2_platform_gazebo/tests/CMakeLists.txt
+++ b/as2_aerial_platforms/as2_platform_gazebo/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
 
   foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/package.xml
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/package.xml
@@ -14,17 +14,16 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_cmake</depend>
-  <depend>ament_index_cpp</depend>
   <depend>rclcpp</depend>
   <depend>as2_core</depend>
   <depend>as2_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
 
-  <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/tests/CMakeLists.txt
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
 
   foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)

--- a/as2_behavior_tree/CMakeLists.txt
+++ b/as2_behavior_tree/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 set(PROJECT_DEPENDENCIES
   ament_cmake
   ament_cmake_ros
-  ament_index_cpp
   behaviortree_cpp
   rclcpp
   rclcpp_action

--- a/as2_behaviors/as2_behavior/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behavior/tests/CMakeLists.txt
@@ -22,6 +22,6 @@ foreach(TEST_SOURCE ${GTEST_SOURCE})
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME})
 endforeach()
 endif()

--- a/as2_behaviors/as2_behavior/tests/as2_behavior_gtest.cpp
+++ b/as2_behaviors/as2_behavior/tests/as2_behavior_gtest.cpp
@@ -40,10 +40,8 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include "as2_behavior/behavior_server.hpp"
-#include <ament_index_cpp/get_package_share_directory.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-// #include "as2_msgs/action/follow_path.hpp"
 #include "as2_msgs/action/takeoff.hpp"
 
 

--- a/as2_behaviors/as2_behaviors_perception/package.xml
+++ b/as2_behaviors/as2_behaviors_perception/package.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-
 <package format="3">
   <name>as2_behaviors_perception</name>
   <version>1.1.3</version>
@@ -20,13 +19,13 @@
   <depend>as2_msgs</depend>
   <depend>as2_behavior</depend>
   <depend>cv_bridge</depend>
-  
   <depend>sensor_msgs</depend>
 
-  <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/as2_behaviors/as2_behaviors_platform/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_platform/tests/CMakeLists.txt
@@ -22,6 +22,6 @@ foreach(TEST_SOURCE ${GTEST_SOURCE})
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME})
 endforeach()
 endif()

--- a/as2_behaviors/as2_behaviors_platform/tests/as2_behaviors_platform_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_platform/tests/as2_behaviors_platform_gtest.cpp
@@ -38,7 +38,6 @@
 */
 
 #include <gtest/gtest.h>
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <as2_behaviors_platform/set_offboard_mode_behavior.hpp>
 #include <as2_behaviors_platform/set_arming_state_behavior.hpp>
 

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)

--- a/as2_behaviors/as2_behaviors_trajectory_generation/package.xml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/package.xml
@@ -26,10 +26,10 @@
   <depend>eigen</depend>
   <depend>rclcpp_components</depend>
 
-  <!-- linting test dependencies -->
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_hardware_drivers/as2_realsense_interface/package.xml
+++ b/as2_hardware_drivers/as2_realsense_interface/package.xml
@@ -26,6 +26,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_hardware_drivers/as2_realsense_interface/tests/CMakeLists.txt
+++ b/as2_hardware_drivers/as2_realsense_interface/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
 
   foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)

--- a/as2_hardware_drivers/as2_usb_camera_interface/CMakeLists.txt
+++ b/as2_hardware_drivers/as2_usb_camera_interface/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 # find dependencies
 set(PROJECT_DEPENDENCIES
   ament_cmake
-  ament_index_cpp
   rclcpp
   as2_core
   as2_msgs
@@ -55,7 +54,7 @@ target_link_libraries(${PROJECT_NAME}_node yaml-cpp)
 # Create the library
 add_library(${PROJECT_NAME} STATIC ${SOURCE_CPP_FILES})
 ament_target_dependencies(${PROJECT_NAME} ${PROJECT_DEPENDENCIES})
-target_link_libraries(${PROJECT_NAME} ament_index_cpp::ament_index_cpp ${realsense2_LIBRARY})
+target_link_libraries(${PROJECT_NAME} ${realsense2_LIBRARY})
 
 # Install the headers
 install(

--- a/as2_hardware_drivers/as2_usb_camera_interface/package.xml
+++ b/as2_hardware_drivers/as2_usb_camera_interface/package.xml
@@ -17,12 +17,12 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>sensor_msgs</depend>
-
   <depend>cv_bridge</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_hardware_drivers/as2_usb_camera_interface/tests/CMakeLists.txt
+++ b/as2_hardware_drivers/as2_usb_camera_interface/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
 
   foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)

--- a/as2_motion_controller/package.xml
+++ b/as2_motion_controller/package.xml
@@ -11,7 +11,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>pluginlib</depend>
   <depend>yaml-cpp</depend>
@@ -22,9 +21,10 @@
   <depend>eigen</depend>
   <depend>benchmark</depend>
 
-  <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_motion_controller/plugins/differential_flatness_controller/tests/CMakeLists.txt
+++ b/as2_motion_controller/plugins/differential_flatness_controller/tests/CMakeLists.txt
@@ -16,13 +16,14 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME} ${PLUGIN_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME} ${PLUGIN_NAME})
 endforeach()
 endif()
 

--- a/as2_motion_controller/plugins/pid_speed_controller/tests/CMakeLists.txt
+++ b/as2_motion_controller/plugins/pid_speed_controller/tests/CMakeLists.txt
@@ -16,13 +16,14 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME} ${PLUGIN_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME} ${PLUGIN_NAME})
 endforeach()
 endif()
 

--- a/as2_motion_controller/tests/CMakeLists.txt
+++ b/as2_motion_controller/tests/CMakeLists.txt
@@ -16,13 +16,14 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
 endforeach()
 endif()
 

--- a/as2_state_estimator/package.xml
+++ b/as2_state_estimator/package.xml
@@ -2,10 +2,8 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>as2_state_estimator</name>
-  
   <version>1.1.3</version>
-  <description>Basic state estimator for AeroStack2</description>
-
+  <description>State estimator for Aerostack2</description>
 
   <maintainer email="cvar.upm3@gmail.com">CVAR-UPM</maintainer>
   
@@ -22,11 +20,11 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
-  <!-- linting test dependencies -->
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  
+  <test_depend>ament_index_cpp</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/as2_state_estimator/plugins/mocap_pose/tests/CMakeLists.txt
+++ b/as2_state_estimator/plugins/mocap_pose/tests/CMakeLists.txt
@@ -16,13 +16,14 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME} ${PLUGIN_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME} ${PLUGIN_NAME})
 endforeach()
 endif()
 

--- a/as2_state_estimator/tests/CMakeLists.txt
+++ b/as2_state_estimator/tests/CMakeLists.txt
@@ -16,13 +16,14 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
 endforeach()
 endif()
 

--- a/as2_utilities/as2_external_object_to_tf/tests/CMakeLists.txt
+++ b/as2_utilities/as2_external_object_to_tf/tests/CMakeLists.txt
@@ -22,6 +22,6 @@ foreach(TEST_SOURCE ${GTEST_SOURCE})
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME})
 endforeach()
 endif()

--- a/as2_utilities/as2_external_object_to_tf/tests/as2_external_object_to_tf_gtest.cpp
+++ b/as2_utilities/as2_external_object_to_tf/tests/as2_external_object_to_tf_gtest.cpp
@@ -35,7 +35,6 @@
 */
 
 #include <gtest/gtest.h>
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <as2_external_object_to_tf/as2_external_object_to_tf.hpp>
 
 TEST(As2ExternalObjectToTf, test_constructor) {

--- a/as2_utilities/as2_geozones/tests/CMakeLists.txt
+++ b/as2_utilities/as2_geozones/tests/CMakeLists.txt
@@ -22,6 +22,6 @@ foreach(TEST_SOURCE ${GTEST_SOURCE})
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME})
 endforeach()
 endif()

--- a/as2_utilities/as2_geozones/tests/as2_geozones_gtest.cpp
+++ b/as2_utilities/as2_geozones/tests/as2_geozones_gtest.cpp
@@ -35,7 +35,6 @@
 */
 
 #include <gtest/gtest.h>
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <as2_geozones/as2_geozones.hpp>
 
 TEST(Geozones, test_constructor) {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble, Jazzy |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Added `ament_index_cpp` to xml in packages when used
* Added `find_package` dependency in CMakeLists when used
* Removed header and dependencies when not needed


Inspired by #784 changes, thanks @dvdmc!