### PR TITLE
[as2_python_api] Allow for extra models from downstream packages when evaluating drone jinja template

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -203,7 +203,11 @@ class Drone(Entity):
             paths += [Path(p) for p in resource_path.split(':')]
 
         # Define the filename to look for
-        filename = f'{self.model_type.value}/{self.model_type.value}.sdf.jinja'
+        if isinstance(self.model_type, DroneTypeEnum):
+            model_type_str = self.model_type.value
+        else:
+            model_type_str = self.model_type
+        filename = f'{model_type_str}/{model_type_str}.sdf.jinja'
 
         # Loop through each directory and check if the file exists
         for path in paths:


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #844 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Added support for specifying custom drone models in simulation config files. Previously, an error was raised if the model type was not defined in DroneTypeEnum.

Thanks @robin-mueller ! Sorry for not merging #844, we are trying to keep git tree history as cleaner as possible. 
