### PR TITLE
[as2_core] Fix incorrect bitmask for yaw mode detection in control_mode_utils

### DIFF
--- a/as2_core/src/utils/control_mode_utils.cpp
+++ b/as2_core/src/utils/control_mode_utils.cpp
@@ -192,9 +192,9 @@ as2_msgs::msg::ControlMode convertUint8tToAS2ControlMode(uint8_t control_mode_ui
 
   if ((control_mode_uint8t & 0b00001100) == 0b00000100) {
     mode.yaw_mode = as2_msgs::msg::ControlMode::YAW_SPEED;
-  } else if ((control_mode_uint8t & 0b00000110) == 0b00000000) {
+  } else if ((control_mode_uint8t & 0b00001100) == 0b00000000) {
     mode.yaw_mode = as2_msgs::msg::ControlMode::YAW_ANGLE;
-  } else if ((control_mode_uint8t & 0b00000110) == 0b00001000) {
+  } else if ((control_mode_uint8t & 0b00001100) == 0b00001000) {
     mode.yaw_mode = as2_msgs::msg::ControlMode::NONE;
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("as2_mode"), "Yaw mode not recognized");


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   |  N/A  |
| ROS2 version tested on | ALL |
| Aerial platform tested on | N/A |

## Description of contribution in a few bullet points

The yaw mode detection was using mask 0x06 (bits 2,1) instead of 0x0C (bits 3,2), causing NONE yaw mode to never be detected. This fix aligns the mask with the actual bit encoding where yaw modes use bits [3:2].

- Line 195: Change mask from 0b00000110 to 0b00001100 for YAW_ANGLE
- Line 197: Change mask from 0b00000110 to 0b00001100 for NONE

Fixes the warning: "bitwise comparison always evaluates to false"

## Description of documentation updates required from your changes

N/A

## Future work that may be required in bullet points

N/A