### PR TITLE
Update Jazzy workflow

### DIFF
--- a/.github/workflows/build-jazzy.yaml
+++ b/.github/workflows/build-jazzy.yaml
@@ -5,9 +5,6 @@ on:
     types: [review_requested, ready_for_review]
     branches:
       - main
-  # push:
-  #   branches:
-  #     - main
 
 jobs:
   build-and-test-jazzy:
@@ -17,7 +14,7 @@ jobs:
       image: osrf/ros:jazzy-desktop
     steps:
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions python3-empy
+        run: sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions python3-empy libgeographiclib-dev
       - name: Setup ros
         uses: ros-tooling/setup-ros@v0.7
         with:
@@ -26,36 +23,11 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: >
-            aerostack2
-            as2_alphanumeric_viewer
-            as2_behavior
-            as2_behaviors_motion
-            as2_behaviors_path_planning
-            as2_behaviors_perception
-            as2_behaviors_platform
-            as2_behaviors_trajectory_generation
-            as2_behavior_tree
-            as2_cli
-            as2_core
-            as2_external_object_to_tf
-            as2_gazebo_assets
-            as2_geozones
-            as2_keyboard_teleoperation
-            as2_map_server
-            as2_motion_controller
-            as2_motion_reference_handlers
             as2_msgs
-            as2_platform_gazebo
-            as2_platform_multirotor_simulator
-            as2_python_api
-            as2_realsense_interface
-            as2_rviz_plugins
-            as2_state_estimator
-            as2_usb_camera_interface
-            as2_visualization
+            as2_cli
           target-ros2-distro: jazzy
           colcon-defaults: |
-            { 
+            {
               "build": {
                 "mixin": ["coverage-gcc"]
               },
@@ -74,35 +46,66 @@ jobs:
           # yml: ./codecov.yml
           fail_ci_if_error: false
 
-  build-platforms:
-    runs-on: ubuntu-latest
-    container:
-      image: osrf/ros:jazzy-desktop
-    strategy:
-      matrix:
-        repos: [as2_platform_crazyflie, as2_platform_tello, as2_platform_dji_osdk, as2_platform_pixhawk, as2_platform_dji_psdk]
-      fail-fast: false
-    steps:
-      - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions python3-empy
-      - name: Setup ros
-        uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
-      - name: Checkout Aerostack2 and platforms
-        run : |
-          set +e
-          export PLATFORM=${{ matrix.repos }}
-          export REPOS_URL="https://raw.githubusercontent.com/aerostack2/$PLATFORM/main/dependencies.repos"
-          export REPOS_PATH=/tmp/dependencies.repos
-          wget -S --spider $REPOS_URL  2>&1 | grep 'HTTP/1.1 200 OK'
-          if [ $? -eq 0 ]; then wget $REPOS_URL -O $REPOS_PATH; else echo "repositories:" > $REPOS_PATH; fi 
-          echo "  $PLATFORM:\n    type: git\n    url: https://github.com/aerostack2/$PLATFORM.git\n    version:  main " >> $REPOS_PATH
-          cat $REPOS_PATH
-      - name: build and test ${{ matrix.repos }}
-        uses: ros-tooling/action-ros-ci@v0.3
-        with:
-          package-name: >
-            ${{ matrix.repos }}
-          target-ros2-distro: jazzy
-          vcs-repo-file-url: /tmp/dependencies.repos
+# ---
+# TODO: we must add these packages iteratively with
+# fixes for each package in a dedicated branch
+# https://github.com/aerostack2/aerostack2/issues/852
+# ---
+# aerostack2
+# as2_alphanumeric_viewer
+# as2_behavior
+# as2_behaviors_motion
+# as2_behaviors_path_planning
+# as2_behaviors_perception
+# as2_behaviors_platform
+# as2_behaviors_trajectory_generation
+# as2_behavior_tree
+# as2_core
+# as2_external_object_to_tf
+# as2_gazebo_assets
+# as2_geozones
+# as2_keyboard_teleoperation
+# as2_map_server
+# as2_motion_controller
+# as2_motion_reference_handlers
+# as2_platform_gazebo
+# as2_platform_multirotor_simulator
+# as2_python_api
+# as2_realsense_interface
+# as2_rviz_plugins
+# as2_state_estimator
+# as2_usb_camera_interface
+# as2_visualization
+
+  # build-platforms:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: osrf/ros:jazzy-desktop
+  #   strategy:
+  #     matrix:
+  #       repos: [as2_platform_crazyflie, as2_platform_tello, as2_platform_dji_osdk, as2_platform_pixhawk, as2_platform_dji_psdk]
+  #     fail-fast: false
+  #   steps:
+  #     - name: Install deps
+  #       run: sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions python3-empy
+  #     - name: Setup ros
+  #       uses: ros-tooling/setup-ros@v0.7
+  #       with:
+  #         required-ros-distributions: jazzy
+  #     - name: Checkout Aerostack2 and platforms
+  #       run : |
+  #         set +e
+  #         export PLATFORM=${{ matrix.repos }}
+  #         export REPOS_URL="https://raw.githubusercontent.com/aerostack2/$PLATFORM/main/dependencies.repos"
+  #         export REPOS_PATH=/tmp/dependencies.repos
+  #         wget -S --spider $REPOS_URL  2>&1 | grep 'HTTP/1.1 200 OK'
+  #         if [ $? -eq 0 ]; then wget $REPOS_URL -O $REPOS_PATH; else echo "repositories:" > $REPOS_PATH; fi
+  #         echo "  $PLATFORM:\n    type: git\n    url: https://github.com/aerostack2/$PLATFORM.git\n    version:  main " >> $REPOS_PATH
+  #         cat $REPOS_PATH
+  #     - name: build and test ${{ matrix.repos }}
+  #       uses: ros-tooling/action-ros-ci@v0.4
+  #       with:
+  #         package-name: >
+  #           ${{ matrix.repos }}
+  #         target-ros2-distro: jazzy
+  #         vcs-repo-file-url: /tmp/dependencies.repos


### PR DESCRIPTION
We are reducing the scope of the Jazzy build workflow to iteratively fix packages and enable them one by one until aerostack2 is compatible with Jazzy.

## Things this PR addresses

- Comment out platforms
- Just build as2_cli and as2_msgs
- Add libgeographiclib-dev

## Future work that may be required in bullet points

We must add these packages iteratively with fixes for each package in a dedicated branch. Addressing the Jazzy issue: https://github.com/aerostack2/aerostack2/issues/852
