### PR TITLE
[as2_aerial_platforms] Enable gazebo and multirotor simulator platform in Jazzy

### DIFF
--- a/.github/workflows/build-jazzy.yaml
+++ b/.github/workflows/build-jazzy.yaml
@@ -26,6 +26,8 @@ jobs:
             as2_msgs
             as2_cli
             as2_core
+            as2_platform_gazebo
+            as2_platform_multirotor_simulator
             as2_motion_reference_handlers
             as2_map_server
             as2_behavior_tree


### PR DESCRIPTION
Resolves #873 
Resolves #874 
