### PR TITLE
[as2_core] Fix node_frequency declaration

### DIFF
--- a/as2_core/include/as2_core/node.hpp
+++ b/as2_core/include/as2_core/node.hpp
@@ -77,7 +77,9 @@ class Node : public AS2_NODE_FATHER_TYPE
 private:
   void init()
   {
-    this->declare_parameter<float>("node_frequency", -1.0);
+    if (!this->has_parameter("node_frequency")) {
+      this->declare_parameter<float>("node_frequency", -1.0);
+    }
     this->get_parameter("node_frequency", loop_frequency_);
     RCLCPP_DEBUG(
       this->get_logger(), "node [%s] base frequency= %f", this->get_name(), loop_frequency_);


### PR DESCRIPTION

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | Fixes node_frequency parameter re-declaration error |
| ROS2 version tested on | Humble/Jazzy |
| Aerial platform tested on | n/a |

---

## Description of contribution in a few bullet points

* Fixed node_frequency parameter declaration in as2_core::Node to check if parameter already exists before declaring it
* Prevents rclcpp::exceptions::ParameterAlreadyDeclaredException when the parameter is already declared by a derived class or external configuration

## Description of documentation updates required from your changes

* No documentation updates required. This is an internal bug fix that doesn't change the API or behavior.

---
