### PR TITLE
Add ObjectPerception messages and DetectObjects action

### DIFF
--- a/as2_msgs/action/DetectObjects.action
+++ b/as2_msgs/action/DetectObjects.action
@@ -1,0 +1,6 @@
+float32 threshold
+string[] target_classes
+---
+as2_msgs/ObjectPerceptionArray perceptions
+---
+as2_msgs/ObjectPerceptionArray perceptions

--- a/as2_msgs/msg/ObjectPerception.msg
+++ b/as2_msgs/msg/ObjectPerception.msg
@@ -1,0 +1,11 @@
+string id
+string class_name
+float32 confidence
+geometry_msgs/PoseStamped pose
+bool pose_valid
+geometry_msgs/Point[] keypoints
+string[] keypoint_names
+float32[] keypoint_scores
+geometry_msgs/Point bbox_min
+geometry_msgs/Point bbox_max
+uint32 flags

--- a/as2_msgs/msg/ObjectPerceptionArray.msg
+++ b/as2_msgs/msg/ObjectPerceptionArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+as2_msgs/ObjectPerception[] perceptions


### PR DESCRIPTION
## Summary

  This PR adds three new message/action types to `as2_msgs` to support the new
  object perception behavior pipeline (see  discussion #919):

  - `msg/ObjectPerception.msg` — represents a single detected object, including:
    - `id` and `class_name` for identification
    - `confidence` score
    - `pose` (PoseStamped) with a `pose_valid` flag (valid when 3D estimation is available)
    - `keypoints` (3D points in pixel space, z=0), `keypoint_names`, and `keypoint_scores`
    - `bbox_min` / `bbox_max` as 2D bounding box corners
    - `flags` (reserved for future use)

  - `msg/ObjectPerceptionArray.msg` — groups detections with a shared `std_msgs/Header`
    (timestamp + frame_id) and an array of `ObjectPerception`.

  - `action/DetectObjects.action` — replaces the old `Detect` action. It uses
    `ObjectPerceptionArray` in both feedback (streaming detections per cycle) and
    result (final detections). The goal carries:
    - `threshold` (float32): confidence threshold [0, 1]
    - `target_classes` (string[]): class names to filter for (empty = detect all)

  ## Motivation

  The previous `Detect` action and its associated messages did not support rich
  per-detection metadata (keypoints, per-keypoint scores, validity flags for pose).
  These new types unify the output format across all detection plugins and lay the
  foundation for the classification and pose estimation stages planned in  #919.
