### PR TITLE
[as2_gazebo_assets] parse params for gimbal joint limits

### DIFF
--- a/as2_simulation_assets/as2_gazebo_assets/models/gimbal/position_gimbal.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/gimbal/position_gimbal.sdf.jinja
@@ -112,6 +112,12 @@
     <child>{{ sensor.name }}::_0::yaw_pitch_link</child>
     <axis>
         <xyz>0 0 1</xyz>
+        <limit>
+            <effort>{{ sensor.joint_limits_yaw_eff }}</effort>
+            <velocity>{{ sensor.joint_limits_yaw_vel }}</velocity>
+            <upper>{{ sensor.joint_limits_yaw_up }}</upper>
+            <lower>{{ sensor.joint_limits_yaw_low }}</lower>
+        </limit>
     </axis>
 </joint>
 
@@ -121,6 +127,12 @@
     <child>{{ sensor.name }}::_0::_1::pitch_roll_link</child>
     <axis>
         <xyz>0 1 0</xyz>
+        <limit>
+            <effort>{{ sensor.joint_limits_pitch_eff }}</effort>
+            <velocity>{{ sensor.joint_limits_pitch_vel }}</velocity>
+            <upper>{{ sensor.joint_limits_pitch_up }}</upper>
+            <lower>{{ sensor.joint_limits_pitch_low }}</lower>
+        </limit>
     </axis>
 </joint>
 
@@ -130,6 +142,12 @@
     <child>{{ sensor.name }}::_0::_1::_2::{{ sensor.sensor_attached }}_enu_link</child>
     <axis>
         <xyz>1 0 0</xyz>
+        <limit>
+            <effort>{{ sensor.joint_limits_roll_eff }}</effort>
+            <velocity>{{ sensor.joint_limits_roll_vel }}</velocity>
+            <upper>{{ sensor.joint_limits_roll_up }}</upper>
+            <lower>{{ sensor.joint_limits_roll_low }}</lower>
+        </limit>
     </axis>
 </joint>
 

--- a/as2_simulation_assets/as2_gazebo_assets/models/gimbal/speed_gimbal.sdf.jinja
+++ b/as2_simulation_assets/as2_gazebo_assets/models/gimbal/speed_gimbal.sdf.jinja
@@ -112,6 +112,12 @@
     <child>{{ sensor.name }}::_0::yaw_pitch_link</child>
     <axis>
         <xyz>0 0 1</xyz>
+        <limit>
+            <effort>{{ sensor.joint_limits_yaw_eff }}</effort>
+            <velocity>{{ sensor.joint_limits_yaw_vel }}</velocity>
+            <upper>{{ sensor.joint_limits_yaw_up }}</upper>
+            <lower>{{ sensor.joint_limits_yaw_low }}</lower>
+        </limit>
     </axis>
 </joint>
 
@@ -121,6 +127,12 @@
     <child>{{ sensor.name }}::_0::_1::pitch_roll_link</child>
     <axis>
         <xyz>0 1 0</xyz>
+        <limit>
+            <effort>{{ sensor.joint_limits_pitch_eff }}</effort>
+            <velocity>{{ sensor.joint_limits_pitch_vel }}</velocity>
+            <upper>{{ sensor.joint_limits_pitch_up }}</upper>
+            <lower>{{ sensor.joint_limits_pitch_low }}</lower>
+        </limit>
     </axis>
 </joint>
 
@@ -130,6 +142,12 @@
     <child>{{ sensor.name }}::_0::_1::_2::{{ sensor.sensor_attached }}_enu_link</child>
     <axis>
         <xyz>1 0 0</xyz>
+        <limit>
+            <effort>{{ sensor.joint_limits_roll_eff }}</effort>
+            <velocity>{{ sensor.joint_limits_roll_vel }}</velocity>
+            <upper>{{ sensor.joint_limits_roll_up }}</upper>
+            <lower>{{ sensor.joint_limits_roll_low }}</lower>
+        </limit>
     </axis>
 </joint>
 

--- a/as2_simulation_assets/as2_gazebo_assets/scripts/jinja_gen.py
+++ b/as2_simulation_assets/as2_gazebo_assets/scripts/jinja_gen.py
@@ -92,6 +92,25 @@ def get_sensors(sensors_array: list[str]) -> dict[str, str]:
                         'gimbal_name': gimbal_name,
                         'drone_model_name': drone_model_name,
                         'gimbaled': str2bool(gimbaled)})
+
+        if model=="gimbal_position" or model=="gimbal_speed":
+            joint_limits_yaw, joint_limits_pitch, joint_limits_roll, sensors_array = \
+                sensors_array[:4], sensors_array[4:8], sensors_array[8:12], sensors_array[12:]
+            sensors[-1].update({
+                'joint_limits_yaw_eff': f'{joint_limits_yaw[0]}',
+                'joint_limits_yaw_vel': f'{joint_limits_yaw[1]}',
+                'joint_limits_yaw_up': f'{joint_limits_yaw[2]}',
+                'joint_limits_yaw_low': f'{joint_limits_yaw[3]}',
+                'joint_limits_pitch_eff': f'{joint_limits_pitch[0]}',
+                'joint_limits_pitch_vel': f'{joint_limits_pitch[1]}',
+                'joint_limits_pitch_up': f'{joint_limits_pitch[2]}',
+                'joint_limits_pitch_low': f'{joint_limits_pitch[3]}',
+                'joint_limits_roll_eff': f'{joint_limits_roll[0]}',
+                'joint_limits_roll_vel': f'{joint_limits_roll[1]}',
+                'joint_limits_roll_up': f'{joint_limits_roll[2]}',
+                'joint_limits_roll_low': f'{joint_limits_roll[3]}',
+            })
+
         print(sensors)
     return sensors
 

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -256,11 +256,11 @@ class Drone(Entity):
             payload += f'{self.model_name} '
             payload += f'{pld.gimbaled} '
             if isinstance(pld.model_type, GimbalTypeEnum):
-                payload += f'{pld.joint_limits_yaw["effort"]} {pld.joint_limits_yaw["velocity"]}'
-                payload += f'{pld.joint_limits_yaw["upper"]} {pld.joint_limits_yaw["lower"]}'
-                payload += f'{pld.joint_limits_pitch["effort"]} {pld.joint_limits_pitch["velocity"]}'
-                payload += f'{pld.joint_limits_pitch["upper"]} {pld.joint_limits_pitch["lower"]}'
-                payload += f'{pld.joint_limits_roll["effort"]} {pld.joint_limits_roll["velocity"]}'
+                payload += f'{pld.joint_limits_yaw["effort"]} {pld.joint_limits_yaw["velocity"]} '
+                payload += f'{pld.joint_limits_yaw["upper"]} {pld.joint_limits_yaw["lower"]} '
+                payload += f'{pld.joint_limits_pitch["effort"]} {pld.joint_limits_pitch["velocity"]} '
+                payload += f'{pld.joint_limits_pitch["upper"]} {pld.joint_limits_pitch["lower"]} '
+                payload += f'{pld.joint_limits_roll["effort"]} {pld.joint_limits_roll["velocity"]} '
                 payload += f'{pld.joint_limits_roll["upper"]} {pld.joint_limits_roll["lower"]} '
 
         if isinstance(self.model_type, DroneTypeEnum):

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -46,7 +46,7 @@ from as2_gazebo_assets.bridges import bridges as gz_bridges
 from as2_gazebo_assets.bridges import custom_bridges as gz_custom_bridges
 from as2_gazebo_assets.bridges.bridge import Bridge
 from as2_gazebo_assets.models.entity import Entity
-from as2_gazebo_assets.models.payload import Payload
+from as2_gazebo_assets.models.payload import Payload, GimbalTypeEnum
 from launch_ros.actions import Node
 
 try:
@@ -233,7 +233,6 @@ class Drone(Entity):
         # Ensure that the environment directory is the parent of the model directory
         # For instance: /path/to/models/drone_base/drone_base.sdf.jinja
         env_dir = filename.parent.parent
-
         payload = ''
         for pld in self.payload:
             if pld.payload is not None:  # Gimbal payload
@@ -256,6 +255,13 @@ class Drone(Entity):
             payload += f'{pld.gimbal_name} '
             payload += f'{self.model_name} '
             payload += f'{pld.gimbaled} '
+            if isinstance(pld.model_type, GimbalTypeEnum):
+                payload += f'{pld.joint_limits_yaw["effort"]} {pld.joint_limits_yaw["velocity"]}'
+                payload += f'{pld.joint_limits_yaw["upper"]} {pld.joint_limits_yaw["lower"]}'
+                payload += f'{pld.joint_limits_pitch["effort"]} {pld.joint_limits_pitch["velocity"]}'
+                payload += f'{pld.joint_limits_pitch["upper"]} {pld.joint_limits_pitch["lower"]}'
+                payload += f'{pld.joint_limits_roll["effort"]} {pld.joint_limits_roll["velocity"]}'
+                payload += f'{pld.joint_limits_roll["upper"]} {pld.joint_limits_roll["lower"]} '
 
         if isinstance(self.model_type, DroneTypeEnum):
             model_type_str = self.model_type.value

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -429,7 +429,25 @@ class Payload(Entity):  # noqa: F811
     payload: Payload = None
     gimbaled: bool = False
     gimbal_name: str = 'None'
-
+    joint_limits_yaw = {
+        "effort": float('inf'),
+        "velocity": float('inf'),
+        "upper": float('inf'),
+        "lower": float('-inf')
+    }
+    joint_limits_pitch = {
+        "effort": float('inf'),
+        "velocity": float('inf'),
+        "upper": float('inf'),
+        "lower": float('-inf')
+    }
+    joint_limits_roll = {
+        "effort": float('inf'),
+        "velocity": float('inf'),
+        "upper": float('inf'),
+        "lower": float('-inf')
+    }
+    
     @validator('payload', always=True)
     def set_gimbaled_default(cls, v, values):
         if 'model_type' in values and isinstance(values['model_type'], GimbalTypeEnum):

--- a/as2_simulation_assets/as2_gazebo_assets/test/gimbal_test_limits.json
+++ b/as2_simulation_assets/as2_gazebo_assets/test/gimbal_test_limits.json
@@ -1,0 +1,40 @@
+{
+    "world_name": "empty",
+    "origin": {"latitude": 100.0, "longitude": 100.0, "altitude": 100.0},
+    "drones": [
+        {
+          "model_type": "quadrotor_base",
+          "model_name": "drone0",
+          "xyz": [ 1.0, 1.0, 0.3 ],
+          "rpy": [ 0.0, 0.0, 0.0 ],
+          "payload": [
+              {
+                "model_name": "gimbal",
+                "model_type": "gimbal_position",
+                "joint_limits_pitch": {
+                  "effort": "99.0",
+                  "velocity": "20.0",
+                  "upper": 1.48,
+                  "lower": -0.5
+                },
+                "joint_limits_yaw": {
+                  "effort": "99.0",
+                  "velocity": "20.0",
+                  "upper": 1.3,
+                  "lower": -1.3
+                },
+                "joint_limits_roll": {
+                  "effort": "99.0",
+                  "velocity": "20.0",
+                  "upper": 0.0,
+                  "lower": 0.0
+                },
+                "payload": {
+                    "model_name": "rgbd_camera",
+                    "model_type": "rgbd_camera"
+                }
+              }
+          ]
+        }
+    ]
+  }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | #930  |
| ROS2 version tested on | Jazzy |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

I added the possibilities to set the joint limits in the sdf for the gimbal joint from the config file

## Description of documentation updates required from your changes

In the world config file, now it is possible to do something like:
~~~yaml
    payload:
      - model_type: "gps"
        model_name: "gps"
      - model_name: "lidar_3d"
        model_type: "lidar_3d"
      - model_type: "gimbal_speed"
        model_name: "gimbal"
        joint_limits_yaw:
          "effort": "float('inf')"
          "velocity": "float('inf')"
          "upper": 0.5
          "lower": -0.5
~~~
joint_limits_pitch and joint_limits_roll can be added too. Just be sure to add the full map (effort, velocity, upper, lower). 
When a limit for an axis is not present, the sdf is generated with the default SDF values (infinite).
This is valid for both position and speed gimbal (I tested both)


---

## Future work that may be required in bullet points

Simplify the parsing instead of relying on positional arguments
