### PR TITLE
[as2_core] Support nested plugins.xml in launch utils

### DIFF
--- a/as2_core/as2_core/launch_plugin_utils.py
+++ b/as2_core/as2_core/launch_plugin_utils.py
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Launch as2_multirotor_simulator node."""
+"""Launch utils for plugin based packages."""
 
 __authors__ = 'Rafael Pérez Seguí, Pedro Arias Pérez'
 __copyright__ = 'Copyright (c) 2022 Universidad Politécnica de Madrid'
@@ -42,21 +42,33 @@ from xml.etree import ElementTree
 from ament_index_python.packages import get_package_share_directory
 
 
-def get_available_plugins(package_name: str, plugin_type: str = None) -> List[str]:
+def get_available_plugins(
+    package_name: str,
+    plugin_type: str = None,
+    plugins_file: str = 'plugins.xml',
+) -> List[str]:
     """
     Parse plugins.xml file from package and return a list of plugins from a specific type.
 
     :param package_name: Name of the package where the plugins.xml file is located.
-    :type file_path: str
+    :type package_name: str
     :param plugin_type: Type of plugin to filter the list. If None, all plugins are returned.
     :type plugin_type: str
+    :param plugins_file: Path to the plugins.xml file, relative to the package share
+        directory. Defaults to 'plugins.xml' (the file is at the share root, which is
+        the layout produced by ``pluginlib_export_plugin_description_file(<pkg> plugins.xml)``).
+        Packages whose plugin description lives in a subdirectory must pass the matching
+        relative path (e.g. ``'my_behavior/plugins.xml'``) so it matches the install
+        layout produced by ``pluginlib_export_plugin_description_file``, which preserves
+        the relative directory of its argument under ``share/<pkg>/``.
+    :type plugins_file: str
     :return: List of available plugins from the plugins.xml file.
     """
-    plugins_file = os.path.join(
+    plugins_file_abs = os.path.join(
         get_package_share_directory(package_name),
-        'plugins.xml'
+        plugins_file
     )
-    root = ElementTree.parse(plugins_file).getroot()
+    root = ElementTree.parse(plugins_file_abs).getroot()
 
     available_plugins = []
     # Check if the root element is a <class_libraries> or <library> tag


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

- Add an optional `plugins_file` parameter to `as2_core.launch_plugin_utils.get_available_plugins()` so packages whose pluginlib description is installed under a subdirectory of `share/<pkg>/` can locate it. Default value `'plugins.xml'` preserves the current behavior.

## Motivation

`pluginlib_export_plugin_description_file(<pkg> <relative-path>/plugins.xml)` preserves the relative directory of its argument under `share/<pkg>/`. Previously `get_available_plugins()` hard-coded the lookup at `share/<pkg>/plugins.xml`, so packages whose description lives in a subdirectory (e.g. `share/<pkg>/<behavior>/plugins.xml`) could not use this helper. Exposing the path as a parameter generalizes the helper without forcing any change to the default install layout.

## Changes

- `as2_core/as2_core/launch_plugin_utils.py`
  - `get_available_plugins(package_name, plugin_type=None, plugins_file='plugins.xml')`: new keyword argument for the pluginlib description file path, **relative to the package share directory**. Documented in the docstring (including the `pluginlib_export_plugin_description_file` install-layout caveat).
  - Renamed the local variable `plugins_file` to `plugins_file_abs` to avoid shadowing the new argument.