### PR TITLE
[as2_behavior] Add support for behaviors to pause themselves

### DIFF
--- a/as2_behaviors/as2_behavior/include/as2_behavior/__impl/behavior_server__impl.hpp
+++ b/as2_behaviors/as2_behavior/include/as2_behavior/__impl/behavior_server__impl.hpp
@@ -308,6 +308,11 @@ void BehaviorServer<actionT>::run(
         goal_handle_action->publish_feedback(feedback);
         behavior_status_.status = BehaviorStatus::RUNNING;
       } break;
+    case ExecutionStatus::PAUSED: {
+        RCLCPP_INFO(this->get_logger(), "PAUSED");
+        goal_handle_action->publish_feedback(feedback);
+        behavior_status_.status = BehaviorStatus::PAUSED;
+      } break;
     case ExecutionStatus::FAILURE: {
         RCLCPP_INFO(this->get_logger(), "FAILURE");
         behavior_status_.status = BehaviorStatus::IDLE;
@@ -320,7 +325,9 @@ void BehaviorServer<actionT>::run(
       } break;
   }
 
-  if (behavior_status_.status != BehaviorStatus::RUNNING) {
+  if (behavior_status_.status != BehaviorStatus::RUNNING &&
+    behavior_status_.status != BehaviorStatus::PAUSED)
+  {
     cleanup_run_timer(status);
   }
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

Add support for behaviors to pause themselves by returning `ExecutionStatus::PAUSED` from `on_run` (or any other lifecycle hook). The base `BehaviorServer` now propagates this transition to the action client and keeps the run timer alive while paused, so the behavior can be resumed later via the `resume` service.

- `as2_behaviors/as2_behavior/include/as2_behavior/__impl/behavior_server__impl.hpp` (`BehaviorServer<actionT>::run`)
  - New `case ExecutionStatus::PAUSED`: logs the transition, publishes feedback to the action client, and sets `behavior_status_.status = BehaviorStatus::PAUSED`.
  - Run-timer cleanup is now gated on `status != RUNNING && status != PAUSED`, so the timer survives a pause and the next `resume` request can drive the behavior back to `RUNNING` without having to re-activate.