### PR TITLE
[as2_behaviors_trajectory_generation] Pluginize generate_polynomial_trajectory_behavior

### DIFF
--- a/as2_behaviors/as2_behaviors_trajectory_generation/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/CMakeLists.txt
@@ -18,14 +18,16 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Set commons dependencies
 set(PROJECT_DEPENDENCIES
   ament_cmake
+  pluginlib
   rclcpp
+  rclcpp_action
+  rclcpp_components
   std_msgs
   std_srvs
   as2_core
   as2_msgs
   as2_behavior
   as2_motion_reference_handlers
-  yaml-cpp
 )
 
 # Find dependencies
@@ -43,21 +45,65 @@ foreach(BEHAVIOR ${BEHAVIORS_LIST})
   add_subdirectory(${BEHAVIOR})
 endforeach()
 
-# Register component_node again in main CMakeLists
-# https://robotics.stackexchange.com/questions/97057/ros2-components-registration-from-subdirectory-cmakelists-file/
-rclcpp_components_register_nodes(trajectory_generator_component "DynamicPolynomialTrajectoryGenerator")
+# Pluginlib resource registry
+pluginlib_export_plugin_description_file(${PROJECT_NAME}
+  generate_polynomial_trajectory_behavior/plugins.xml)
 
 ament_export_dependencies(${PROJECT_DEPENDENCIES})
 
 # Build tests if testing is enabled
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  file(GLOB_RECURSE EXCLUDE_FILES
-    build/*
-    install/*
-  )
-  set(AMENT_LINT_AUTO_FILE_EXCLUDE ${EXCLUDE_FILES})
+
+  # Keep ament linters out of generated / vendored trees.
+  #
+  # Two mechanisms are needed because they cover disjoint sets of linters:
+  #   - AMENT_IGNORE markers: honored by cpplint, uncrustify, copyright,
+  #     flake8, cppcheck, lint_cmake, xmllint, clang_format and by colcon
+  #     for package discovery.
+  #   - AMENT_LINT_AUTO_FILE_EXCLUDE: needed for ament_pep257, which does
+  #     NOT honor AMENT_IGNORE but accepts directory paths via --exclude.
+  #
+  # We collect every directory to suppress in LINT_EXCLUDED_DIRS and feed
+  # both mechanisms from that single list.
+  set(LINT_EXCLUDED_DIRS)
+
+  # 1. IDE artefacts left inside the source tree (e.g. VSCode CMake Tools
+  #    with cmake.buildDirectory pointing at <pkg>/build). Plugins do not
+  #    own these paths, so we drop the AMENT_IGNORE marker here.
+  foreach(_DIR build install)
+    set(_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${_DIR})
+    if(IS_DIRECTORY ${_PATH})
+      file(WRITE ${_PATH}/AMENT_IGNORE "")
+      list(APPEND LINT_EXCLUDED_DIRS ${_PATH})
+    endif()
+  endforeach()
+
+  # 2. Vendored upstream sources under each plugin's thirdparties/. Each
+  #    plugin's own CMakeLists already writes the AMENT_IGNORE marker
+  #    inside its thirdparties/ at configure time, so we only need to
+  #    extend the pep257 exclude list here.
+  foreach(BEHAVIOR ${BEHAVIORS_LIST})
+    file(GLOB _PLUGIN_THIRDPARTIES LIST_DIRECTORIES true
+      ${CMAKE_CURRENT_SOURCE_DIR}/${BEHAVIOR}/plugins/*/thirdparties)
+    list(APPEND LINT_EXCLUDED_DIRS ${_PLUGIN_THIRDPARTIES})
+  endforeach()
+
+  set(AMENT_LINT_AUTO_FILE_EXCLUDE ${LINT_EXCLUDED_DIRS})
+
+  # ament_cmake_pep257 does not forward AMENT_LINT_AUTO_FILE_EXCLUDE to the
+  # ament_pep257 binary, so we skip its auto-registration and re-register
+  # the test manually with the explicit --exclude argv.
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_pep257)
   ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_pep257 QUIET)
+  if(ament_cmake_pep257_FOUND)
+    if(AMENT_LINT_AUTO_FILE_EXCLUDE)
+      ament_pep257(. --exclude ${AMENT_LINT_AUTO_FILE_EXCLUDE})
+    else()
+      ament_pep257()
+    endif()
+  endif()
 endif()
 
 ament_package()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/README.md
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/README.md
@@ -1,1 +1,10 @@
 # as2_behaviors_trajectory_generation
+
+## External dependencies
+
+The following upstream libraries are vendored under each plugin's
+`thirdparties/` directory and fetched automatically at CMake configure
+time (`find_package` → local clone → `FetchContent`). The directories
+are gitignored and never committed to this repository.
+
+- Dynamic Trajectory Generator: <https://github.com/miferco97/dynamic_trajectory_generator>, based on <https://github.com/ethz-asl/mav_trajectory_generation>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
@@ -1,108 +1,114 @@
-set(EXECUTABLE_NAME generate_polynomial_trajectory_behavior)
+set(BEHAVIOR_NAME generate_polynomial_trajectory_behavior)
 
-# Download the dynamic_trajectory_generator from github
-find_package(dynamic_trajectory_generator QUIET)
-
-if(${dynamic_trajectory_generator_FOUND})
-  message(STATUS "dynamic_trajectory_generator found")
-else()
-  message(STATUS "dynamic_trajectory_generator not found")
-  include(FetchContent)
-  fetchcontent_declare(
-    dynamic_trajectory_generator
-    GIT_REPOSITORY https://github.com/miferco97/dynamic_trajectory_generator.git
-    GIT_TAG master
-  )
-  fetchcontent_makeavailable(dynamic_trajectory_generator)
-endif()
-
-# Find dependencies
-set(EXECUTABLE_DEPENDENCIES
+# Behavior-level dependencies (in addition to the package-level ones).
+set(BEHAVIOR_DEPENDENCIES
   trajectory_msgs
   geometry_msgs
+  nav_msgs
   visualization_msgs
   Eigen3
   rclcpp_components
 )
-
-foreach(DEPENDENCY ${EXECUTABLE_DEPENDENCIES})
+foreach(DEPENDENCY ${BEHAVIOR_DEPENDENCIES})
   find_package(${DEPENDENCY} REQUIRED)
 endforeach()
 
-# Include directories
 include_directories(
   include
-  include/${EXECUTABLE_NAME}
+  include/${BEHAVIOR_NAME}
   ${EIGEN3_INCLUDE_DIRS}
 )
 
-set(SOURCE_CPP_FILES
-  src/${EXECUTABLE_NAME}.cpp
-  src/${EXECUTABLE_NAME}_node.cpp
-)
+# --- Plugin base library ---------------------------------------------------
+# Holds the abstract interface and the shared implementation (debug
+# publishers, yaw computation, vehicle state, evaluation orchestration).
+add_library(${BEHAVIOR_NAME}_plugin_base SHARED
+  src/generate_polynomial_trajectory_base.cpp)
+target_include_directories(${BEHAVIOR_NAME}_plugin_base PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(${BEHAVIOR_NAME}_plugin_base
+  ${PROJECT_DEPENDENCIES}
+  ${BEHAVIOR_DEPENDENCIES})
 
-add_executable(${EXECUTABLE_NAME}_node ${SOURCE_CPP_FILES})
-target_link_libraries(${EXECUTABLE_NAME}_node dynamic_trajectory_generator)
-ament_target_dependencies(${EXECUTABLE_NAME}_node ${PROJECT_DEPENDENCIES} ${EXECUTABLE_DEPENDENCIES})
+# --- Wrapper server (BehaviorServer + composable component) ---------------
+add_library(${BEHAVIOR_NAME} SHARED src/${BEHAVIOR_NAME}.cpp)
+target_link_libraries(${BEHAVIOR_NAME} ${BEHAVIOR_NAME}_plugin_base)
+ament_target_dependencies(${BEHAVIOR_NAME}
+  ${PROJECT_DEPENDENCIES}
+  ${BEHAVIOR_DEPENDENCIES})
+rclcpp_components_register_nodes(${BEHAVIOR_NAME} "GeneratePolynomialTrajectoryBehavior")
 
-add_library(trajectory_generator_component SHARED
-  src/generate_polynomial_trajectory_behavior.cpp
-)
-target_link_libraries(trajectory_generator_component dynamic_trajectory_generator)
-ament_target_dependencies(trajectory_generator_component ${PROJECT_DEPENDENCIES} ${EXECUTABLE_DEPENDENCIES})
-rclcpp_components_register_nodes(trajectory_generator_component "DynamicPolynomialTrajectoryGenerator")
+# --- Standalone executable -------------------------------------------------
+add_executable(${BEHAVIOR_NAME}_node src/${BEHAVIOR_NAME}_node.cpp)
+target_link_libraries(${BEHAVIOR_NAME}_node ${BEHAVIOR_NAME})
+ament_target_dependencies(${BEHAVIOR_NAME}_node
+  ${PROJECT_DEPENDENCIES}
+  ${BEHAVIOR_DEPENDENCIES})
 
-# Install libraries
+# --- Install ---------------------------------------------------------------
 install(TARGETS
-  trajectory_generator_component
-  EXPORT export_trajectory_generator_component
+    ${BEHAVIOR_NAME}
+    ${BEHAVIOR_NAME}_plugin_base
+  EXPORT export_${BEHAVIOR_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
-
 install(TARGETS
-  dynamic_trajectory_generator
-  EXPORT export_dynamic_trajectory_generator
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+  ${BEHAVIOR_NAME}_node
+  DESTINATION
+  lib/${PROJECT_NAME}
 )
 
-install(TARGETS
-  mav_trajectory_generation
-  EXPORT export_mav_trajectory_generation
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+install(DIRECTORY
+  include/
+  DESTINATION
+  include
 )
 
-# Install launch files
+ament_export_include_directories(include)
+ament_export_libraries(${BEHAVIOR_NAME} ${BEHAVIOR_NAME}_plugin_base)
+ament_export_targets(export_${BEHAVIOR_NAME})
+
+# --- Plugins ---------------------------------------------------------------
+set(PLUGIN_LIST
+  dynamic_mav_trajectory_generator
+)
+
+foreach(PLUGIN ${PLUGIN_LIST})
+  add_subdirectory(plugins/${PLUGIN})
+endforeach()
+
+# Pluginlib registry — must be exported once per package, pointing to the
+# plugins.xml that lists every plugin of this behavior. The actual call lives
+# in the root CMakeLists.txt because pluginlib_export_plugin_description_file
+# accumulates state in a variable that does not propagate from a subdirectory
+# to the project's ament_package() call.
+
+foreach(PLUGIN ${PLUGIN_LIST})
+  install(
+    DIRECTORY plugins/${PLUGIN}/config
+    DESTINATION share/${PROJECT_NAME}/${BEHAVIOR_NAME}/plugins/${PLUGIN}
+  )
+endforeach()
+
+# --- Launch + config -------------------------------------------------------
 install(DIRECTORY
   launch
-  DESTINATION share/${PROJECT_NAME})
+  DESTINATION
+  share/${PROJECT_NAME}/${BEHAVIOR_NAME}
+)
 
-# Install config files
 install(DIRECTORY
   config
-  DESTINATION share/${PROJECT_NAME}/generate_polynomial_trajectory_behavior)
+  DESTINATION
+  share/${PROJECT_NAME}/${BEHAVIOR_NAME}
+)
 
-# Install executables
-install(TARGETS
-  ${EXECUTABLE_NAME}_node
-  DESTINATION lib/${PROJECT_NAME})
 
-ament_export_dependencies(${EXECUTABLE_DEPENDENCIES})
-ament_export_include_directories(include)
-
-# Build tests if testing is enabled
+# --- Tests -----------------------------------------------------------------
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  file(GLOB_RECURSE EXCLUDE_FILES
-    build/*
-    install/*
-  )
-  set(AMENT_LINT_AUTO_FILE_EXCLUDE ${EXCLUDE_FILES})
-  ament_lint_auto_find_test_dependencies()
   add_subdirectory(tests)
 endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/config/config_default.yaml
@@ -1,17 +1,33 @@
 /**:
   ros__parameters:
-    tf_timeout_threshold: 0.05 # TF timeout (50ms)
-    sampling_n: 1 # Number of sampling of the trajectory
-    sampling_dt: 0.01 # Time (s) between each sampling
-    path_length: 0 # Length of the waypoints given to the trajectory generator. Default value = 0, is full trajectory
-    yaw_threshold: 0.1 # Threshold (m) to compute the yaw angle. Less than this value, the yaw keeps the same value
-    yaw_speed_threshold: 0.0 # Threshold (rad/s) to limit the yaw speed. Default value = 0.0, no limit
-    frequency_update_frame: 0.0 # Frequency (Hz) to check the transform between map to odom and update trajectory waypoints. Default value = 0.0, no update
-    transform_threshold: 1.0 # Threshold (m) to limit the minimum distance to update the transform between map to odom.
-    wp_close_threshold: 0.0 # Threshold (s) for which the waypoints within that horizon are not updated. Default value = 0.0, all waypoints are updated
+    # Frame IDs.
+    desired_frame_id: 'odom'  # Frame in which the trajectory is generated
+
+    # Sampling of the prediction horizon emitted by the wrapper on each
+    # control cycle.
+    sampling_n: 1                # Number of samples per cycle (>= 1)
+    sampling_dt: 0.01            # Time (s) between samples
+
+    # Active waypoint window fed to the plugin. The wrapper keeps the rest
+    # in a pending queue and feeds them incrementally via
+    # plugin->updateWaypoints() as the plugin consumes them. Plugins that
+    # do not override updateWaypoints() will regenerate per slide using
+    # the live vehicle pose+twist as boundary conditions.
+    path_length: 0               # 0 = full trajectory loaded up front
+
+    # Yaw computation thresholds (consumed by the plugin base class).
+    yaw_threshold: 0.1           # Min planar distance (m) to recompute yaw
+    yaw_speed_threshold: 0.0     # Max yaw rate (rad/s) for FACE_REFERENCE
+                                 # (0.0 disables the rate limit)
+
+    # Map↔odom drift watchdog.
+    frequency_update_frame: 0.0  # Hz (0 disables the watchdog)
+    transform_threshold: 1.0     # Translation drift (m) that triggers regen
+                                 # (0.0 disables the drift check)
+
+    # Debug topics — leave empty to disable each publisher.
     debug:
-      path_topic: "debug/traj_generated" # Topic to publish the debug path. Empty to disable
-      reference_setpoint: "debug/ref_traj_point" # Topic to publish the reference waypoint. Empty to disable
-      reference_end_waypoint: "debug/ref_traj_end_point" # Topic to publish the last setwaypoint marker in horizon. Empty to disable
-      reference_waypoints: "debug/waypoints" # Topic to publish the path waypoints. Empty to disable
-    desired_frame_id: "odom"
+      path_topic: debug/traj_generated
+      reference_setpoint: debug/ref_traj_point
+      reference_end_waypoint: debug/ref_traj_end_point
+      reference_waypoints: debug/waypoints

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp
@@ -1,0 +1,421 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file generate_polynomial_trajectory_base.hpp
+ *
+ * @brief Abstract base class for polynomial trajectory generator plugins.
+ *
+ * The base keeps only the minimal plugin-facing contract:
+ *   - lifecycle initialization with access to the hosting node,
+ *   - a namespaced `getParameter()` helper for plugin configuration,
+ *   - the pure virtual generate/evaluate/reset/progress API.
+ *
+ * All ROS 2 runtime orchestration remains in
+ * GeneratePolynomialTrajectoryBehavior.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#ifndef GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__GENERATE_POLYNOMIAL_TRAJECTORY_BASE_HPP_
+#define GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__GENERATE_POLYNOMIAL_TRAJECTORY_BASE_HPP_
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <typeinfo>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "as2_core/node.hpp"
+#include "as2_msgs/msg/pose_stamped_with_id.hpp"
+#include "as2_msgs/msg/trajectory_point.hpp"
+
+namespace generate_polynomial_trajectory_behavior_plugin_base
+{
+
+/**
+ * @brief Declare (if needed) and read a ROS 2 parameter on the hosting node.
+ *
+ * @tparam T          Parameter type.
+ * @param node_ptr    Node pointer.
+ * @param param_name  Fully-qualified parameter name.
+ * @param param_value [in] default value used when @p use_default is true,
+ *                    [out] read value on success.
+ * @param use_default Whether @p param_value is taken as a fallback default.
+ */
+template<typename T>
+inline void getParameter(
+  as2::Node * node_ptr, const std::string & param_name,
+  T & param_value, bool use_default = false)
+{
+  try {
+    if (!node_ptr->has_parameter(param_name)) {
+      if (use_default) {
+        node_ptr->declare_parameter<T>(param_name, param_value);
+      } else {
+        node_ptr->declare_parameter<T>(param_name);
+      }
+    }
+
+    if constexpr (std::is_same<T, std::vector<double>>::value) {
+      param_value = node_ptr->get_parameter(param_name).as_double_array();
+    } else if constexpr (std::is_same<T, double>::value) {
+      param_value = node_ptr->get_parameter(param_name).as_double();
+    } else if constexpr (std::is_same<T, std::string>::value) {
+      param_value = node_ptr->get_parameter(param_name).as_string();
+    } else if constexpr (std::is_same<T, bool>::value) {
+      param_value = node_ptr->get_parameter(param_name).as_bool();
+    } else if constexpr (std::is_same<T, int>::value) {
+      param_value =
+        static_cast<int>(node_ptr->get_parameter(param_name).as_int());
+    } else {
+      RCLCPP_WARN(
+        node_ptr->get_logger(),
+        "Parameter type %s not expected; falling back to generic accessor.",
+        typeid(T).name());
+      param_value = node_ptr->get_parameter(param_name).get_value<T>();
+    }
+    RCLCPP_INFO(
+      node_ptr->get_logger(), "Parameter %s: %s", param_name.c_str(),
+      node_ptr->get_parameter(param_name).value_to_string().c_str());
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(
+      node_ptr->get_logger(), "Error getting parameter %s: %s",
+      param_name.c_str(), e.what());
+  }
+}
+
+/**
+ * @brief Abstract plugin contract for polynomial trajectory generation.
+ */
+class GeneratePolynomialTrajectoryBase
+{
+public:
+  /**
+   * @brief Construct plugin base instance.
+   */
+  GeneratePolynomialTrajectoryBase() = default;
+
+  /**
+   * @brief Virtual destructor.
+   */
+  virtual ~GeneratePolynomialTrajectoryBase() = default;
+
+  /**
+   * @brief Initialize the plugin with the hosting node and its namespace.
+   *
+   * Plugins may use the node only for configuration and logging.
+   *
+   * @param node Hosting node pointer.
+   * @param plugin_name Plugin namespace identifier.
+   */
+  void initialize(as2::Node * node, const std::string & plugin_name);
+
+  /**
+   * @brief Generate a fresh trajectory from mission waypoints.
+   *
+   * The initial vehicle state (position and velocity) is NOT passed as
+   * an argument: the plugin reads it from the protected base members
+   * vehicle_pose_ / vehicle_twist_ (refreshed by the host via
+   * setVehicleState before this call). Plugins must inject vehicle_pose_
+   * as the trajectory start position and may use vehicle_twist_ as the
+   * starting velocity boundary condition when their backend supports it.
+   * The buildCurrentWaypoint() helper provides a ready-to-use entry for
+   * backends that expect the initial state as the first waypoint.
+   *
+   * The host owns a single logical trajectory time axis exposed as
+   * t_trajectory (seconds, monotonic, reset to 0 on every fresh
+   * generation). Plugins are responsible for mapping t_trajectory to
+   * whatever internal time axis their backend uses; the host never
+   * observes that mapping. On entry, t_trajectory_now indicates the
+   * current value of the host's axis, so the plugin can anchor its
+   * internal offset such that t_backend == 0 when t_trajectory ==
+   * t_trajectory_now (or whichever convention the backend prefers).
+   *
+   * @param waypoints Ordered mission waypoints (the user-specified path
+   *                  only, no synthetic "current" entry).
+   * @param max_speed Maximum cruise speed in m/s.
+   * @param t_trajectory_now Current value of the host's trajectory time
+   *                  axis at the moment of generation (typically 0.0
+   *                  for a fresh activation, or the live trajectory_time_
+   *                  for a regeneration triggered by updateWaypoints()).
+   * @return true when trajectory generation succeeds.
+   */
+  virtual bool
+  generateTrajectory(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed,
+    double t_trajectory_now) = 0;
+
+  /**
+   * @brief Evaluate trajectory references at time t_trajectory.
+   *
+   * The vehicle pose and twist are not passed in this call: they are kept
+   * as protected members (vehicle_pose_, vehicle_twist_) refreshed by the
+   * host via setVehicleState(). Implementations that need closed-loop
+   * feedback (e.g. dynamic re-planners) read them directly and must gate
+   * any state-mutating use on @p is_horizon_sample being false, since
+   * @p is_horizon_sample is true for both horizon predictions and debug
+   * evaluations.
+   *
+   * The plugin maps t_trajectory to its internal backend axis using its
+   * private offset and clamps to its own valid range; values outside
+   * the trajectory horizon are saturated to the closest endpoint
+   * rather than returning false.
+   *
+   * @param t_trajectory Evaluation time in seconds, in the host's
+   *                     trajectory time axis.
+   * @param out Output reference point.
+   * @param is_horizon_sample True for horizon predictions and debug
+   *                          sampling; false for the live control setpoint.
+   * @return true when evaluation succeeds.
+   */
+  virtual bool evaluate(
+    double t_trajectory,
+    as2_msgs::msg::TrajectoryPoint & out,
+    bool is_horizon_sample = false) = 0;
+
+  /**
+   * @brief Whether the trajectory is exhausted at the given t_trajectory.
+   *
+   * Returns true when t_trajectory has reached or exceeded the end of
+   * the currently held trajectory in the host's time axis.
+   *
+   * @param t_trajectory Current host trajectory time in seconds.
+   * @return true when the trajectory has finished.
+   */
+  virtual bool isFinished(double t_trajectory) const = 0;
+
+  /**
+   * @brief Total duration of the currently held trajectory.
+   *
+   * Returns the temporal length of the trajectory in seconds (i.e.
+   * backend max - backend min in the plugin's internal axis). Used by
+   * the host for diagnostics and feedback only; it does NOT expose the
+   * backend axis offset to the wrapper.
+   *
+   * @return Duration in seconds, or 0.0 when no trajectory is held.
+   */
+  virtual double getDuration() const = 0;
+
+  /**
+   * @brief Check whether a trajectory is currently generated.
+   *
+   * @return true when a valid trajectory is available.
+   */
+  virtual bool isTrajectoryGenerated() = 0;
+
+  /**
+   * @brief Reset internal plugin trajectory state.
+   */
+  virtual void reset() = 0;
+
+  /**
+   * @brief Update the active trajectory with a new pending waypoint list.
+   *
+   * Default implementation: regenerate from scratch by calling reset()
+   * followed by generateTrajectory() with the current vehicle state.
+   * Plugins that support smooth online re-planning (i.e. preserving the
+   * trajectory time origin so evaluation continues without restart)
+   * override this method and keep their internal time-axis offset
+   * unchanged so the host's t_trajectory keeps mapping to the same
+   * backend trajectory.
+   *
+   * @param waypoints Ordered pending waypoints (no helper "current" entry).
+   * @param max_speed Maximum cruise speed in m/s.
+   * @param t_trajectory_now Current value of the host's trajectory time
+   *                  axis. Plugins that regenerate must re-anchor their
+   *                  offset to this value; plugins that stitch must
+   *                  keep their offset untouched.
+   * @return true when the update succeeds.
+   */
+  virtual bool
+  updateWaypoints(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed,
+    double t_trajectory_now)
+  {
+    reset();
+    return generateTrajectory(waypoints, max_speed, t_trajectory_now);
+  }
+
+  /**
+   * @brief Consume and return whether the underlying backend trajectory
+   * has been regenerated since the previous call.
+   *
+   * Plugins with a synchronous updateWaypoints() (the base default)
+   * always return false: their swap is observable immediately on return
+   * from updateWaypoints() and the host can rely on the publish that
+   * happens right after in pushPendingToPlugin().
+   *
+   * Plugins that maintain an asynchronous regeneration pipeline
+   * override this to expose the deferred swap event so the host can
+   * refresh debug publications once the backend has actually swapped
+   * its internal trajectory.
+   *
+   * @return true at most once per regeneration event.
+   */
+  virtual bool consumeRegeneratedFlag() {return false;}
+
+  /**
+   * @brief Get the id of the next pending waypoint as known by the plugin.
+   *
+   * @return Empty string when there is no pending waypoint, else its id.
+   */
+  virtual std::string getNextWaypointId() = 0;
+
+  /**
+   * @brief Refresh the vehicle pose and twist held by the plugin.
+   *
+   * The host is expected to call this once per incoming state message
+   * (in its odom/twist subscription callback). The plugin therefore
+   * always holds the latest valid pose and twist; plugin entry points
+   * (generateTrajectory, updateWaypoints, evaluate) do not need a
+   * per-call refresh from the host. Both fields are stored as-is;
+   * coordinate frame consistency with the trajectory frame is the
+   * host's responsibility.
+   *
+   * @param pose Current vehicle pose in the trajectory frame.
+   * @param twist Current vehicle twist (linear in body or world per the
+   *              host configuration; not interpreted by the base class).
+   */
+  void setVehicleState(
+    const geometry_msgs::msg::PoseStamped & pose,
+    const geometry_msgs::msg::TwistStamped & twist);
+
+  /**
+   * @brief Read-only access to the latest vehicle pose set by the host.
+   *
+   * The host refreshes the underlying member through setVehicleState()
+   * once per state message; the value seen here is the latest value
+   * successfully delivered by the host.
+   *
+   * @return Const reference to the cached vehicle pose.
+   */
+  const geometry_msgs::msg::PoseStamped & getVehiclePose() const
+  {
+    return vehicle_pose_;
+  }
+
+  /**
+   * @brief Read-only access to the latest vehicle twist set by the host.
+   *
+   * @return Const reference to the cached vehicle twist.
+   */
+  const geometry_msgs::msg::TwistStamped & getVehicleTwist() const
+  {
+    return vehicle_twist_;
+  }
+
+protected:
+  /**
+   * @brief Optional plugin-specific initialization hook.
+   */
+  virtual void ownInitialize() {}
+
+  /**
+   * @brief Build a synthetic waypoint capturing the current vehicle pose.
+   *
+   * Returns a PoseStampedWithID with id="current" and pose=vehicle_pose_,
+   * intended to be prepended to the waypoint list before feeding the
+   * backend whenever the backend expects the start state as the first
+   * waypoint. The accompanying initial velocity must be read separately
+   * from vehicle_twist_ — PoseStampedWithID does not carry twist.
+   *
+   * @return Synthetic "current" waypoint built from vehicle_pose_.
+   */
+  as2_msgs::msg::PoseStampedWithID buildCurrentWaypoint() const;
+
+  /**
+   * @brief Read a plugin-scoped parameter.
+   *
+   * @tparam T Parameter type.
+   * @param param_name Parameter name.
+   * @param param_value [in] default value when @p use_default is true,
+   *                    [out] read value.
+   * @param use_default Whether to declare with default value.
+   */
+  template<typename T>
+  inline void getParameter(
+    const std::string & param_name, T & param_value,
+    bool use_default = false)
+  {
+    generate_polynomial_trajectory_behavior_plugin_base::getParameter(
+      node_ptr_, qualifyParameterName(param_name), param_value, use_default);
+  }
+
+  /**
+   * @brief Get mutable hosting node pointer.
+   *
+   * @return Mutable hosting node pointer.
+   */
+  as2::Node * getNodePtr() {return node_ptr_;}
+
+  /**
+   * @brief Get const hosting node pointer.
+   *
+   * @return Const hosting node pointer.
+   */
+  const as2::Node * getNodePtr() const {return node_ptr_;}
+
+  /**
+   * @brief Get plugin namespace name.
+   *
+   * @return Plugin namespace string.
+   */
+  const std::string & getPluginName() const {return plugin_name_;}
+
+  // Latest vehicle state set by the host via setVehicleState(). Derived
+  // plugins may read these directly inside generateTrajectory(),
+  // updateWaypoints() and evaluate(); they are valid only after the host
+  // has invoked the setter at least once.
+  geometry_msgs::msg::PoseStamped vehicle_pose_;
+  geometry_msgs::msg::TwistStamped vehicle_twist_;
+
+private:
+  /**
+   * @brief Qualify parameter name with plugin namespace.
+   *
+   * @param param_name Parameter key.
+   * @return Namespaced parameter key.
+   */
+  std::string qualifyParameterName(const std::string & param_name) const;
+
+  as2::Node * node_ptr_{nullptr};
+  std::string plugin_name_;
+};
+
+}  // namespace generate_polynomial_trajectory_behavior_plugin_base
+
+#endif  // GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__GENERATE_POLYNOMIAL_TRAJECTORY_BASE_HPP_

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Universidad Politécnica de Madrid
+// Copyright 2026 Universidad Politecnica de Madrid
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,8 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //
@@ -29,235 +30,530 @@
 /**
  * @file generate_polynomial_trajectory_behavior.hpp
  *
- * @brief Class definition for the GeneratePolynomialTrajectoryBehavior class.
+ * @brief Pluginlib-based BehaviorServer wrapper for polynomial trajectory
+ * generators.
  *
- * @author Miguel Fernández Cortizas
- *         Pedro Arias Pérez
- *         David Pérez Saura
- *         Rafael Pérez Seguí
+ * @authors Rafael Perez-Segui
  */
 
 #ifndef GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR_HPP_
 #define GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR_HPP_
 
-#include <tf2/LinearMath/Quaternion.h>
-
-#include <Eigen/Dense>
-#include <string>
+#include <deque>
 #include <memory>
+#include <string>
+#include <vector>
 
-#include <rclcpp/clock.hpp>
+#include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <std_srvs/srv/set_bool.hpp>
 
-#include "as2_behavior/behavior_server.hpp"
-#include "as2_core/names/actions.hpp"
-#include "as2_core/names/services.hpp"
-#include "as2_core/names/topics.hpp"
-#include "as2_core/node.hpp"
-#include "as2_core/utils/frame_utils.hpp"
-#include "as2_core/utils/tf_utils.hpp"
-#include "as2_motion_reference_handlers/hover_motion.hpp"
-#include "as2_motion_reference_handlers/trajectory_motion.hpp"
-#include "as2_msgs/action/generate_polynomial_trajectory.hpp"
-#include "as2_msgs/srv/set_speed.hpp"
-#include "dynamic_trajectory_generator/dynamic_trajectory.hpp"
-#include "dynamic_trajectory_generator/dynamic_waypoint.hpp"
-
-#include "as2_msgs/msg/pose_stamped_with_id_array.hpp"
-#include "as2_msgs/msg/pose_with_id.hpp"
-#include "as2_msgs/msg/traj_gen_info.hpp"
-
-#include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
-#include <nav_msgs/msg/odometry.hpp>
 #include <nav_msgs/msg/path.hpp>
 #include <std_msgs/msg/float32.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-class DynamicPolynomialTrajectoryGenerator
+#include "as2_behavior/behavior_server.hpp"
+#include "as2_core/names/actions.hpp"
+#include "as2_core/names/topics.hpp"
+#include "as2_core/node.hpp"
+#include "as2_core/utils/tf_utils.hpp"
+#include "as2_motion_reference_handlers/hover_motion.hpp"
+#include "as2_motion_reference_handlers/trajectory_motion.hpp"
+#include "as2_msgs/action/generate_polynomial_trajectory.hpp"
+#include "as2_msgs/msg/pose_stamped_with_id.hpp"
+#include "as2_msgs/msg/pose_stamped_with_id_array.hpp"
+#include "as2_msgs/msg/trajectory_point.hpp"
+#include "as2_msgs/msg/trajectory_setpoints.hpp"
+#include "as2_msgs/msg/yaw_mode.hpp"
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+/**
+ * @class GeneratePolynomialTrajectoryBehavior
+ *
+ * ROS2 BehaviorServer that wraps polynomial trajectory generator plugins. It
+ * receives a path of waypoints and other parameters as a goal, and then uses the
+ * specified plugin to generate a trajectory.
+ */
+class GeneratePolynomialTrajectoryBehavior
   : public as2_behavior::BehaviorServer<
     as2_msgs::action::GeneratePolynomialTrajectory>
 {
 public:
-  DynamicPolynomialTrajectoryGenerator(
+  using Action = as2_msgs::action::GeneratePolynomialTrajectory;
+  using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+    GeneratePolynomialTrajectoryBase;
+
+  /**
+   * @brief Construct behavior server node.
+   *
+   * @param options ROS node options.
+   */
+  explicit GeneratePolynomialTrajectoryBehavior(
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
-  ~DynamicPolynomialTrajectoryGenerator() {}
+
+  /**
+   * @brief Virtual destructor.
+   */
+  ~GeneratePolynomialTrajectoryBehavior() override = default;
 
 private:
-  /** Subscriptions **/
+  // BehaviorServer overrides.
+
+  /**
+   * @brief Activate behavior with a new goal.
+   *
+   * @param goal Requested behavior goal.
+   * @return true when goal activation succeeds.
+   */
+  bool on_activate(std::shared_ptr<const Action::Goal> goal) override;
+
+  /**
+   * @brief Modify currently active goal.
+   *
+   * @param goal New goal request.
+   * @return true when goal modification succeeds.
+   */
+  bool on_modify(std::shared_ptr<const Action::Goal> goal) override;
+
+  /**
+   * @brief Deactivate behavior.
+   *
+   * @param message Optional deactivation message.
+   * @return true when deactivation succeeds.
+   */
+  bool on_deactivate(const std::shared_ptr<std::string> & message) override;
+
+  /**
+   * @brief Pause behavior and hand over to hover.
+   *
+   * @param message Optional pause message.
+   * @return true when pause handling succeeds.
+   */
+  bool on_pause(const std::shared_ptr<std::string> & message) override;
+
+  /**
+   * @brief Resume behavior from stored progress.
+   *
+   * @param message Optional resume message.
+   * @return true when resume activation succeeds.
+   */
+  bool on_resume(const std::shared_ptr<std::string> & message) override;
+
+  /**
+   * @brief Execute behavior run step.
+   *
+   * @param goal Active goal.
+   * @param feedback_msg Output feedback message.
+   * @param result_msg Output result message.
+   * @return Current execution status.
+   */
+  as2_behavior::ExecutionStatus
+  on_run(
+    const std::shared_ptr<const Action::Goal> & goal,
+    std::shared_ptr<Action::Feedback> & feedback_msg,
+    std::shared_ptr<Action::Result> & result_msg) override;
+
+  /**
+   * @brief Finalize execution and cleanup runtime state.
+   *
+   * @param state Final behavior execution state.
+   */
+  void on_execution_end(const as2_behavior::ExecutionStatus & state) override;
+
+  // Utils and internal methods.
+
+  /**
+   * @brief Read parameter through shared helper.
+   *
+   * @tparam T Parameter type.
+   * @param param_name Parameter name.
+   * @param param_value [in] default value when @p use_default is true,
+   *                    [out] read value.
+   * @param use_default Whether to use @p param_value as default.
+   */
+  template<typename T>
+  inline void getParameter(
+    const std::string & param_name, T & param_value,
+    bool use_default = false)
+  {
+    generate_polynomial_trajectory_behavior_plugin_base::getParameter(
+      this, param_name, param_value, use_default);
+  }
+
+  /**
+   * @brief Load trajectory generation plugin.
+   */
+  void loadPlugin();
+
+  /**
+   * @brief Build internal waypoint list from goal.
+   *
+   * The output contains only the user-specified mission waypoints
+   * converted to desired_frame_id_ with normalized ids. The synthetic
+   * "current" entry is no longer prepended here: each plugin reads the
+   * vehicle state from the protected base members and injects it into
+   * its backend if needed.
+   *
+   * @param goal Input goal.
+   * @param out Output waypoint vector.
+   * @return true when waypoint list is valid and converted.
+   */
+  bool buildWaypoints(
+    const std::shared_ptr<const Action::Goal> & goal,
+    std::vector<as2_msgs::msg::PoseStampedWithID> & out);
+
+  /**
+   * @brief Validate waypoint constraints.
+   *
+   * @param waypoints Waypoint list to validate.
+   * @return true when waypoint list is valid.
+   */
+  bool validateWaypoints(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints) const;
+
+  /**
+   * @brief Convert waypoint poses to desired_frame_id_ and normalize ids.
+   *
+   * Empty ids are auto-generated as waypoint_XXX using the waypoint index.
+   *
+   * @param in Input waypoint list.
+   * @param out Output converted waypoint list.
+   * @param log_context Context string for error logs.
+   * @return true when all waypoints are converted.
+   */
+  bool convertWaypointsToDesiredFrame(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & in,
+    std::vector<as2_msgs::msg::PoseStampedWithID> & out,
+    const char * log_context);
+
+  /**
+   * @brief Generate a fresh trajectory through the plugin and reset time
+   *        bases.
+   *
+   * Refreshes the plugin vehicle state (pose + twist) before delegating
+   * to plugin_->generateTrajectory(). The plugin reads the live state
+   * from the protected base members and is responsible for injecting it
+   * into its backend, so the waypoint list passed here contains only
+   * the user-specified mission waypoints (no synthetic "current" entry).
+   *
+   * @param waypoints Mission waypoints in desired_frame_id_.
+   * @param max_speed Maximum speed in m/s.
+   * @return true when generation succeeds.
+   */
+  bool generateTrajectory(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed);
+
+  /**
+   * @brief Get pending waypoints from goal_.path starting at next_id.
+   *
+   * @param next_id Id of the next pending waypoint.
+   * @return Subset of goal_.path from next_id (inclusive) to the end.
+   *         If next_id is empty or not found, returns the full path.
+   */
+  std::vector<as2_msgs::msg::PoseStampedWithID>
+  getPendingWaypoints(const std::string & next_id) const;
+
+  /**
+   * @brief Count remaining waypoints in goal_.path from next_id onwards.
+   *
+   * @param next_id Id of the next pending waypoint.
+   * @return Number of waypoints from next_id (inclusive) to end of path.
+   */
+  uint16_t remainingWaypointCount(const std::string & next_id) const;
+
+  /**
+   * @brief Apply a modify request onto goal_.path.
+   *
+   * Drops already-passed waypoints (those before next_id), updates the pose
+   * for any matching id, and appends new ids at the end. Waypoints not
+   * referenced in the modify list are kept with their previous pose.
+   *
+   * @param modify_waypoints Waypoints from the modify goal, already in
+   *                         desired_frame_id_.
+   * @param next_id Id of the next pending waypoint at modify time.
+   * @return The resulting pending waypoint list (= new goal_.path).
+   */
+  std::vector<as2_msgs::msg::PoseStampedWithID>
+  mergeModifyIntoGoal(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & modify_waypoints,
+    const std::string & next_id);
+
+  /**
+   * @brief Publish trajectory and waypoints debug topics.
+   */
+  void publishGenerationDebug();
+
+  /**
+   * @brief Push the current pending queue to the plugin via updateWaypoints.
+   *
+   * Refreshes the plugin vehicle state and calls
+   * plugin_->updateWaypoints(..., trajectory_time_) with the pending
+   * list derived from goal_.path and the plugin's getNextWaypointId().
+   * The plugin decides whether to stitch smoothly (preserving its
+   * internal offset) or regenerate from scratch (re-anchoring its
+   * offset against the current trajectory_time_). The wrapper does NOT
+   * realign anything: trajectory_time_ keeps progressing monotonically.
+   * Triggers publishGenerationDebug() on success.
+   *
+   * @return true when the plugin accepts the update.
+   */
+  bool pushPendingToPlugin();
+
+  /**
+   * @brief Evaluate one trajectory setpoint.
+   *
+   * Refreshes the plugin vehicle state (pose + twist) before delegating to
+   * the plugin so closed-loop backends can read it via the protected
+   * members.
+   *
+   * @param t Evaluation time in seconds.
+   * @param out Output trajectory point.
+   * @param is_horizon_sample True for horizon predictions and debug
+   *                          sampling; false for the live control setpoint.
+   * @return true when evaluation succeeds.
+   */
+  bool evaluatePoint(
+    double t, as2_msgs::msg::TrajectoryPoint & out,
+    bool is_horizon_sample);
+
+  /**
+   * @brief Evaluate a horizon of setpoints.
+   *
+   * @param t0 Initial evaluation time in seconds.
+   * @param dt Sampling period in seconds.
+   * @param n Number of samples.
+   * @param out Output setpoint array.
+   * @return true when all samples are evaluated.
+   */
+  bool evaluateHorizon(
+    double t0, double dt, std::size_t n,
+    as2_msgs::msg::TrajectorySetpoints & out);
+
+  /**
+   * @brief Compute yaw command for a trajectory point.
+   *
+   * @param point Current trajectory point.
+   * @return Yaw angle in radians.
+   */
+  double computeYaw(const as2_msgs::msg::TrajectoryPoint & point);
+
+  /**
+   * @brief Compute yaw aligned to XY velocity vector.
+   *
+   * @param vx X velocity in m/s.
+   * @param vy Y velocity in m/s.
+   * @return Yaw angle in radians.
+   */
+  double computeYawAnglePathFacing(double vx, double vy) const;
+
+  /**
+   * @brief Compute yaw facing next reference waypoint.
+   *
+   * @return Yaw angle in radians.
+   */
+  double computeYawFaceReference();
+
+  /**
+   * @brief Get next reference waypoint based on plugin progress.
+   *
+   * @return Pointer to waypoint within goal_.path, or nullptr when none.
+   */
+  const as2_msgs::msg::PoseStampedWithID * getNextReferenceWaypoint() const;
+
+  /**
+   * @brief Reset runtime state variables.
+   */
+  void resetRuntimeState();
+
+  /**
+   * @brief Handle vehicle state updates.
+   *
+   * @param msg Incoming twist message.
+   */
+  void stateCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
+
+  /**
+   * @brief Handle external yaw updates.
+   *
+   * @param msg Incoming yaw message.
+   */
+  void yawCallback(const std_msgs::msg::Float32::SharedPtr msg);
+
+  /**
+   * @brief Handle waypoint modification requests.
+   *
+   * @param msg Incoming waypoint updates.
+   */
+  void modifyWaypointCallback(
+    const as2_msgs::msg::PoseStampedWithIDArray::SharedPtr msg);
+
+  /**
+   * @brief Periodic frame-drift watchdog callback.
+   */
+  void timerUpdateFrameCallback();
+
+  /**
+   * @brief Compute whether frame drift exceeds threshold.
+   *
+   * @return true when regeneration is required.
+   */
+  bool computeFrameError();
+
+  /**
+   * @brief Initialize debug publishers.
+   */
+  void initDebugPublishers();
+
+  /**
+   * @brief Split a waypoint list into the active window fed to the plugin
+   * and a queue drained incrementally by on_run.
+   *
+   * No-op when path_length_ <= 0. The active vector is truncated in
+   * place. When the plugin's updateWaypoints() falls back to the base
+   * default (i.e. regeneration), each window slide implies a fresh
+   * trajectory; this is functionally correct but may cause time-base
+   * realignment per slide.
+   *
+   * @param active [in/out] Full pending list. On return, contains only the
+   *               first path_length_ entries.
+   * @param queued [in/out] Receives the truncated tail (appended in order).
+   */
+  void splitForPathLength(
+    std::vector<as2_msgs::msg::PoseStampedWithID> & active,
+    std::deque<as2_msgs::msg::PoseStampedWithID> & queued) const;
+
+  /**
+   * @brief Publish sampled generated trajectory for visualization.
+   */
+  void publishGeneratedTrajectory();
+
+  /**
+   * @brief Publish active waypoints markers.
+   */
+  void publishWaypoints();
+
+  /**
+   * @brief Publish evaluated point marker.
+   *
+   * @param point Point to publish.
+   * @param is_last_in_horizon True when it is the horizon last sample.
+   */
+  void publishEvaluatedPoint(
+    const as2_msgs::msg::TrajectoryPoint & point,
+    bool is_last_in_horizon);
+
+  // Member variables.
+
+  // Frame ids
+  std::string desired_frame_id_;
+  std::string map_frame_id_;
+  std::string base_link_frame_id_;
+
+  // Handlers
+  as2::tf::TfHandler tf_handler_;
+  as2::motionReferenceHandlers::TrajectoryMotion trajectory_motion_handler_;
+  as2::motionReferenceHandlers::HoverMotion hover_motion_handler_;
+
+  // Plugin
+  std::shared_ptr<pluginlib::ClassLoader<PluginBase>> plugin_loader_;
+  std::shared_ptr<PluginBase> plugin_;
+  std::string plugin_name_;
+
+  // Subscriptions
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr state_sub_;
   rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr yaw_sub_;
-
-  // For faster waypoint modified
   rclcpp::Subscription<as2_msgs::msg::PoseStampedWithIDArray>::SharedPtr
     mod_waypoint_sub_;
 
-  /** Timer**/
+  // Trajectory behavior parameters
+  int sampling_n_{1};
+  double sampling_dt_{0.01};
+  double yaw_threshold_{0.1};
+  double yaw_speed_threshold_{0.0};
+
+  // Active-window size fed to the plugin. 0 disables the feature and the
+  // wrapper feeds the full mission up front (legacy behavior).
+  int path_length_{0};
+
+  // Pending waypoints not yet pushed to the plugin (path_length > 0).
+  // Stored in desired_frame_id_, in mission order. Drained as the plugin
+  // consumes its active window.
+  std::deque<as2_msgs::msg::PoseStampedWithID> pending_waypoints_queue_;
+
+  // Mirror of the waypoint slice currently held by the plugin (without the
+  // "current" prefix). Used to count plugin-side remaining and to extend the
+  // active window via plugin_->updateWaypoints() when path_length > 0.
+  std::vector<as2_msgs::msg::PoseStampedWithID> active_waypoints_;
+
+  // Frame drift checking parameters
   rclcpp::TimerBase::SharedPtr timer_update_frame_;
-  double frequency_update_frame_ = 0.0;
+  double frequency_update_frame_{0.0};
+  double transform_threshold_{1.0};
+  geometry_msgs::msg::TransformStamped last_map_to_desired_;
 
-  /** Dynamic trajectory generator library */
-  // dynamic_traj_generator::DynamicTrajectory trajectory_generator_;
-  std::shared_ptr<dynamic_traj_generator::DynamicTrajectory>
-  trajectory_generator_;
+  // Wrapper-level latch indicating that the state subscription has
+  // delivered at least one valid TwistStamped (so downstream calls
+  // can rely on plugin_->getVehiclePose() / getVehicleTwist()).
+  bool has_vehicle_state_{false};
 
-  /** Handlers **/
-  as2::motionReferenceHandlers::HoverMotion hover_motion_handler_;
-  as2::motionReferenceHandlers::TrajectoryMotion trajectory_motion_handler_;
-  as2::tf::TfHandler tf_handler_;
+  // Stored goal and feedback. goal_.path is the source of truth for the
+  // ordered queue of pending mission waypoints (in desired_frame_id_).
+  Action::Goal goal_;
+  Action::Feedback feedback_;
 
-  /** Parameters */
-  // Parameters
-  std::string base_link_frame_id_;
-  std::string desired_frame_id_;
-  std::string map_frame_id_;
-  int sampling_n_ = 1;
-  double sampling_dt_ = 0.0;
-  int path_length_ = 0;
-  float yaw_threshold_ = 0;
-  float transform_threshold_ = 1.0;
-  double yaw_speed_threshold_ = 2.0;
-  double wp_close_threshold_ = 0.0;
-  bool start_on_paused_ = false;
-  bool has_paused_ = false;
-  bool external_pause_ = false;
+  // Trajectory time bookkeeping.
+  //
+  // The wrapper owns a single logical trajectory time axis,
+  // trajectory_time_, reset to 0 at every fresh generateTrajectory()
+  // call (including external resume regeneration) and advanced by
+  // (now - last_tick_time_) on every on_run tick. Each plugin maps
+  // trajectory_time_ to its own backend time axis via an internal
+  // offset that the wrapper never observes. updateWaypoints() does NOT
+  // touch trajectory_time_; the plugin re-anchors its offset on
+  // regeneration and preserves it on smooth stitching, so the host
+  // axis is unaffected.
+  //
+  // first_tick_after_anchor_ guards the first tick after generation or
+  // resume so the dt accumulator does not jump (last_tick_time_ would
+  // otherwise be uninitialized or stale).
+  double trajectory_time_{0.0};
+  rclcpp::Time last_tick_time_;
+  bool first_tick_after_anchor_{true};
 
-  // Behavior action parameters
-  as2_msgs::msg::YawMode yaw_mode_;
-  as2_msgs::action::GeneratePolynomialTrajectory::Goal goal_;
-  as2_msgs::action::GeneratePolynomialTrajectory::Feedback feedback_;
-  as2_msgs::action::GeneratePolynomialTrajectory::Result result_;
-
-  // Yaw from topic
-  bool has_yaw_from_topic_ = false;
-  float yaw_from_topic_ = 0.0f;
-
-  // Initial yaw
-  float init_yaw_angle_ = 0.0f;
-
-  // State
-  Eigen::Vector3d current_position_;
-  geometry_msgs::msg::TransformStamped current_map_to_odom_transform_;
-  geometry_msgs::msg::TransformStamped last_map_to_odom_transform_;
-  double current_yaw_;
-
-  // Command
-  as2_msgs::msg::TrajectorySetpoints trajectory_command_;
-
-  // Trajectory generator
-  rclcpp::Duration eval_time_ = rclcpp::Duration(0, 0);
-  rclcpp::Duration eval_time_yaw_ = rclcpp::Duration(0, 0);
-  rclcpp::Time time_zero_;
+  double init_yaw_angle_{0.0};
   rclcpp::Time time_zero_yaw_;
-  bool first_run_ = false;
-  bool has_odom_ = false;
-  dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set_;
-  std::optional<rclcpp::Time> time_debug_;
 
-  // Debug
-  bool enable_debug_ = false;
-  std::thread plot_thread_;
+  // External yaw input.
+  bool has_yaw_from_topic_{false};
+  float yaw_from_topic_{0.0f};
 
-private:
-  /** As2 Behavior methods **/
-  bool on_activate(
-    std::shared_ptr<
-      const as2_msgs::action::GeneratePolynomialTrajectory::Goal>
-    goal) override;
+  // Snapshot of next waypoint id captured in on_pause for on_resume.
+  std::string paused_next_waypoint_id_;
 
-  bool on_modify(
-    std::shared_ptr<
-      const as2_msgs::action::GeneratePolynomialTrajectory::Goal>
-    goal) override;
+  // Pause-after-generate flow (Action::Goal::start_on_paused).
+  // - start_on_paused_:  copy of the goal flag, latched on_activate.
+  // - has_paused_:       true once on_run has emitted the auto-PAUSED
+  //                      transition (idempotent, only fires once).
+  // - external_pause_:   true once on_pause has been called by an external
+  //                      request, so on_resume can distinguish a user
+  //                      pause/resume from the auto-pause wake-up.
+  bool start_on_paused_{false};
+  bool has_paused_{false};
+  bool external_pause_{false};
 
-  bool on_deactivate(const std::shared_ptr<std::string> & message) override;
-
-  bool on_pause(const std::shared_ptr<std::string> & message) override;
-
-  bool on_resume(const std::shared_ptr<std::string> & message) override;
-
-  as2_behavior::ExecutionStatus on_run(
-    const std::shared_ptr<
-      const as2_msgs::action::GeneratePolynomialTrajectory::Goal> & goal,
-    std::shared_ptr<as2_msgs::action::GeneratePolynomialTrajectory::Feedback>
-    & feedback_msg,
-    std::shared_ptr<as2_msgs::action::GeneratePolynomialTrajectory::Result>
-    & result_msg) override;
-
-  void on_execution_end(const as2_behavior::ExecutionStatus & state) override;
-
-private:
-  /**
-  * @brief Callback to check the errors between frames and update the frame offset
-  */
-  void timerUpdateFrameCallback();
-
-  /** Topic Callbacks **/
-  void stateCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
-  void yawCallback(const std_msgs::msg::Float32::SharedPtr _msg);
-
-  // For faster waypoint modified
-  void modifyWaypointCallback(
-    const as2_msgs::msg::PoseStampedWithIDArray::SharedPtr _msg);
-
-  /** Trajectory generator functions */
-  void setup();
-  bool goalToDynamicWaypoint(
-    std::shared_ptr<
-      const as2_msgs::action::GeneratePolynomialTrajectory::Goal>
-    goal,
-    dynamic_traj_generator::DynamicWaypoint::Deque & waypoints);
-  bool evaluateTrajectory(double eval_time);
-  bool evaluateSetpoint(
-    double eval_time,
-    as2_msgs::msg::TrajectoryPoint & trajectory_command,
-    bool current_setpoint, const double current_yaw);
-
-  /**
-   * @brief update the trajectory waypoint and waypoint_to_set_queue with the frame offset
-   * @param goal the goal of the action
-   * @return bool Return false if the transform between the map and the desired frame is not available and true otherwise
-   */
-  bool updateFrame(
-    const as2_msgs::action::GeneratePolynomialTrajectory::Goal &
-    goal);
-
-  double computeYawAnglePathFacing(double vx, double vy);
-
-  /**
-  * @brief Compute the Yaw angle to face the next reference point
-  *   * @param current_yaw Current yaw angle
-  * @return double Current yaw angle if the distance to the next reference point is less than the yaw_threshold_ or the angle to face the next reference point otherwise
-  */
-  double computeYawFaceReference(double current_yaw);
-
-  /**
-* @brief Compute the error frames between the map and the desired frame
-* @return bool Return true if the frame offset is bigger than the transform_threshold_ and false otherwise
-*/
-  bool computeErrorFrames();
-
-  /** For debuging **/
-
-  /** Debug publishers **/
+  // Debug publishers
+  bool enable_debug_{false};
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr debug_path_pub_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_waypoints_pub_;
-  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr debug_ref_point_pub_;
-  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr debug_end_ref_point_pub_;
-
-  /** Debug functions **/
-  void plotTrajectory();
-  void plotTrajectoryThread();
-  void plotRefTrajPoint();
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
+    debug_waypoints_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr
+    debug_ref_point_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr
+    debug_end_ref_point_pub_;
 };
-
-/** Auxiliar Functions **/
-
-void generateDynamicPoint(
-  const as2_msgs::msg::PoseStampedWithID & msg,
-  dynamic_traj_generator::DynamicWaypoint & dynamic_point);
 
 #endif  // GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR_HPP_

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/composable_generate_polynomial_trajectory_behavior.launch.py
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/composable_generate_polynomial_trajectory_behavior.launch.py
@@ -27,7 +27,6 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-
 """Launch trajectory generator composable node."""
 
 __authors__ = 'CVAR'
@@ -39,33 +38,82 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
 from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+import yaml
+
+
+PACKAGE = 'as2_behaviors_trajectory_generation'
+BEHAVIOR = 'generate_polynomial_trajectory_behavior'
+PLUGINS_FILE = f'{BEHAVIOR}/plugins.xml'
+
+
+def recursive_search(data_dict, target_key, result=None):
+    """Search for a target key in a nested dictionary or list."""
+    if result is None:
+        result = []
+
+    if isinstance(data_dict, dict):
+        for key, value in data_dict.items():
+            if key == target_key:
+                result.append(value)
+            else:
+                recursive_search(value, target_key, result)
+    elif isinstance(data_dict, list):
+        for item in data_dict:
+            recursive_search(item, target_key, result)
+
+    return result
+
+
+def override_plugin_name_in_context(context):
+    """Override plugin_name in the context from config_file if it is not provided as argument."""
+    plugin_name = LaunchConfiguration('plugin_name').perform(context)
+    if plugin_name == '':
+        config_file = LaunchConfiguration('config_file').perform(context)
+        with open(config_file, 'r') as file:
+            config = yaml.safe_load(file)
+        plugin_names = recursive_search(config, 'plugin_name')
+        available_plugins = get_available_plugins(PACKAGE, plugins_file=PLUGINS_FILE)
+        for candidate in plugin_names:
+            if candidate in available_plugins:
+                plugin_name = candidate
+                break
+
+    if plugin_name == '':
+        raise RuntimeError('No plugin_name provided or not found in config_file.')
+
+    context.launch_configurations['plugin_name'] = plugin_name
+    return
 
 
 def generate_launch_description():
     """Launch trajectory generator composable node."""
-    package_folder = get_package_share_directory('as2_behaviors_trajectory_generation')
+    package_folder = get_package_share_directory(PACKAGE)
     config_file = os.path.join(package_folder,
-                               'generate_polynomial_trajectory_behavior/'
-                               'config/config_default.yaml')
+                               BEHAVIOR + '/config/config_default.yaml')
     traj_generator_node = ComposableNode(
         namespace=LaunchConfiguration('namespace'),
-        package='as2_behaviors_trajectory_generation',
-        plugin='DynamicPolynomialTrajectoryGenerator',
+        package=PACKAGE,
+        plugin='GeneratePolynomialTrajectoryBehavior',
         name='TrajectoryGeneratorBehavior',
         parameters=[
             {
                 'use_sim_time': LaunchConfiguration('use_sim_time'),
+                'plugin_name': LaunchConfiguration('plugin_name'),
             },
             LaunchConfigurationFromConfigFile(
                 'config_file',
                 default_file=config_file)]
     )
+
+    plugin_choices = get_available_plugins(PACKAGE, plugins_file=PLUGINS_FILE)
+    plugin_choices.append('')
 
     return LaunchDescription([
         DeclareLaunchArgument('namespace', default_value=EnvironmentVariable(
@@ -83,9 +131,16 @@ def generate_launch_description():
         DeclareLaunchArgument('use_sim_time',
                               description='Use simulation clock if true',
                               default_value='false'),
+        DeclareLaunchArgument(
+            'plugin_name',
+            default_value='dynamic_mav_trajectory_generator',
+            description='Trajectory generator plugin to load. '
+                        'If empty, it must be declared in config_file.',
+            choices=plugin_choices),
         DeclareLaunchArgumentsFromConfigFile(
             name='config_file', source_file=config_file,
             description='Path to behavior configuration file'),
+        OpaqueFunction(function=override_plugin_name_in_context),
         # Load in existing container
         LoadComposableNodes(
             condition=LaunchConfigurationNotEquals('container', ''),

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/generate_polynomial_trajectory_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/generate_polynomial_trajectory_behavior_launch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Universidad Politécnica de Madrid
+# Copyright 2026 Universidad Politécnica de Madrid
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -27,11 +27,10 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+"""Launch trajectory generator behavior with a runtime-selectable plugin."""
 
-"""Launch trajectory generator node."""
-
-__authors__ = 'CVAR'
-__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+__authors__ = 'Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2026 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
 
 import os
@@ -39,18 +38,101 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
 from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
 from launch_ros.actions import Node
+import yaml
 
 
-def generate_launch_description():
-    # Get default configuration file
-    package_folder = get_package_share_directory('as2_behaviors_trajectory_generation')
-    config_file = os.path.join(package_folder,
-                               'generate_polynomial_trajectory_behavior/'
-                               'config/config_default.yaml')
+PACKAGE = 'as2_behaviors_trajectory_generation'
+BEHAVIOR = 'generate_polynomial_trajectory_behavior'
+PLUGINS_FILE = f'{BEHAVIOR}/plugins.xml'
+
+
+def recursive_search(data_dict, target_key, result=None):
+    """Search for a target key in a nested dictionary or list."""
+    if result is None:
+        result = []
+
+    if isinstance(data_dict, dict):
+        for key, value in data_dict.items():
+            if key == target_key:
+                result.append(value)
+            else:
+                recursive_search(value, target_key, result)
+    elif isinstance(data_dict, list):
+        for item in data_dict:
+            recursive_search(item, target_key, result)
+
+    return result
+
+
+def override_plugin_name_in_context(context):
+    """Override plugin_name in the context from config_file if it is not provided as argument."""
+    plugin_name = LaunchConfiguration('plugin_name').perform(context)
+    if plugin_name == '':
+        config_file = LaunchConfiguration('config_file').perform(context)
+        with open(config_file, 'r') as file:
+            config = yaml.safe_load(file)
+        plugin_names = recursive_search(config, 'plugin_name')
+        available_plugins = get_available_plugins(PACKAGE, plugins_file=PLUGINS_FILE)
+        for candidate in plugin_names:
+            if candidate in available_plugins:
+                plugin_name = candidate
+                break
+
+    if plugin_name == '':
+        raise RuntimeError('No plugin_name provided or not found in config_file.')
+
+    context.launch_configurations['plugin_name'] = plugin_name
+    return
+
+
+def _build_node(context, *_args, **_kwargs):
+    """Build the node action with the plugin-specific config resolved at launch time."""
+    pkg_share = get_package_share_directory(PACKAGE)
+    common_config = os.path.join(pkg_share, BEHAVIOR, 'config', 'config_default.yaml')
+
+    plugin_name = LaunchConfiguration('plugin_name').perform(context)
+    plugin_config = os.path.join(
+        pkg_share, BEHAVIOR, 'plugins', plugin_name, 'config',
+        f'{plugin_name}.yaml')
+
+    parameters = [
+        {
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'plugin_name': plugin_name,
+        },
+        LaunchConfigurationFromConfigFile(
+            'config_file', default_file=common_config),
+    ]
+    if os.path.isfile(plugin_config):
+        parameters.append(plugin_config)
+
+    return [
+        Node(
+            package=PACKAGE,
+            executable=f'{BEHAVIOR}_node',
+            namespace=LaunchConfiguration('namespace'),
+            output='screen',
+            arguments=['--ros-args', '--log-level',
+                       LaunchConfiguration('log_level')],
+            emulate_tty=True,
+            parameters=parameters,
+        )
+    ]
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Entrypoint."""
+    pkg_share = get_package_share_directory(PACKAGE)
+    common_config = os.path.join(pkg_share, BEHAVIOR, 'config', 'config_default.yaml')
+
+    plugin_choices = get_available_plugins(PACKAGE, plugins_file=PLUGINS_FILE)
+    plugin_choices.append('')
+
     return LaunchDescription([
         DeclareLaunchArgument('log_level',
                               description='Logging level',
@@ -62,23 +144,15 @@ def generate_launch_description():
                               description='Drone namespace',
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgument(
+            'plugin_name',
+            default_value='dynamic_mav_trajectory_generator',
+            description='Trajectory generator plugin to load. '
+                        'If empty, it must be declared in config_file.',
+            choices=plugin_choices),
         DeclareLaunchArgumentsFromConfigFile(
-            name='config_file', source_file=config_file,
-            description='Path to behavior configuration file'),
-        Node(
-            package='as2_behaviors_trajectory_generation',
-            executable='generate_polynomial_trajectory_behavior_node',
-            namespace=LaunchConfiguration('namespace'),
-            output='screen',
-            arguments=['--ros-args', '--log-level',
-                       LaunchConfiguration('log_level')],
-            parameters=[
-                {
-                    'use_sim_time': LaunchConfiguration('use_sim_time'),
-                },
-                LaunchConfigurationFromConfigFile(
-                    'config_file',
-                    default_file=config_file)],
-            emulate_tty=True
-        )
+            name='config_file', source_file=common_config,
+            description='Path to common behavior configuration file'),
+        OpaqueFunction(function=override_plugin_name_in_context),
+        OpaqueFunction(function=_build_node),
     ])

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
@@ -1,0 +1,8 @@
+<class_libraries>
+  <library path="dynamic_mav_trajectory_generator">
+    <class type="dynamic_mav_trajectory_generator::Plugin"
+           base_class_type="generate_polynomial_trajectory_behavior_plugin_base::GeneratePolynomialTrajectoryBase">
+      <description>Dynamic (runtime-modifiable) polynomial trajectory generator built on top of mav_trajectory_generation.</description>
+    </class>
+  </library>
+</class_libraries>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/CMakeLists.txt
@@ -1,0 +1,117 @@
+cmake_minimum_required(VERSION 3.5)
+set(PLUGIN_NAME dynamic_mav_trajectory_generator)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# Set Release as default
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Plugin dependencies (mostly inherited from the package).
+set(PLUGIN_DEPENDENCIES
+  ament_cmake
+  rclcpp
+  pluginlib
+  as2_core
+  as2_msgs
+  geometry_msgs
+  nav_msgs
+  visualization_msgs
+  Eigen3
+)
+
+foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
+  find_package(${DEPENDENCY} REQUIRED)
+endforeach()
+
+# --- dynamic_trajectory_generator: prefer system → local clone → FetchContent
+# The local clone lives in plugins/<plugin>/thirdparties/<lib>/ so it is fetched
+# only the first time and reused on subsequent builds. The parent thirdparties/
+# directory is gitignored repo-wide; we drop an AMENT_IGNORE there at configure
+# time so colcon never indexes the upstream package.xml files as ROS packages
+# and so the ament file-walking linters (cpplint, uncrustify, ...) skip the
+# vendored sources.
+set(_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
+file(MAKE_DIRECTORY ${_THIRDPARTIES_DIR})
+file(WRITE ${_THIRDPARTIES_DIR}/AMENT_IGNORE "")
+
+find_package(dynamic_trajectory_generator QUIET)
+if(${dynamic_trajectory_generator_FOUND})
+  message(STATUS "dynamic_trajectory_generator found system-wide")
+else()
+  set(LOCAL_DTG_SRC ${_THIRDPARTIES_DIR}/dynamic_trajectory_generator)
+  if(EXISTS ${LOCAL_DTG_SRC}/CMakeLists.txt)
+    message(STATUS "dynamic_trajectory_generator: using local clone at ${LOCAL_DTG_SRC}")
+    add_subdirectory(${LOCAL_DTG_SRC} ${CMAKE_BINARY_DIR}/dynamic_trajectory_generator_build)
+  else()
+    message(STATUS "dynamic_trajectory_generator: cloning into ${LOCAL_DTG_SRC}")
+    include(FetchContent)
+    fetchcontent_declare(
+      dynamic_trajectory_generator
+      GIT_REPOSITORY https://github.com/miferco97/dynamic_trajectory_generator.git
+      GIT_TAG v1.1
+      SOURCE_DIR ${LOCAL_DTG_SRC}
+    )
+    fetchcontent_makeavailable(dynamic_trajectory_generator)
+  endif()
+endif()
+
+include_directories(
+  include
+  include/${PLUGIN_NAME}
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
+set(SOURCE_CPP_FILES
+  src/${PLUGIN_NAME}.cpp
+)
+
+# Plugin shared library (loaded by pluginlib::ClassLoader).
+add_library(${PLUGIN_NAME} SHARED ${SOURCE_CPP_FILES})
+target_link_libraries(${PLUGIN_NAME}
+  ${BEHAVIOR_NAME}_plugin_base
+  dynamic_trajectory_generator
+)
+ament_target_dependencies(${PLUGIN_NAME} ${PLUGIN_DEPENDENCIES})
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PLUGIN_NAME})
+ament_export_targets(export_${PLUGIN_NAME})
+
+install(
+  TARGETS ${PLUGIN_NAME}
+  EXPORT export_${PLUGIN_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Re-export upstream targets so downstream packages can resolve them.
+install(
+  TARGETS dynamic_trajectory_generator
+  EXPORT export_dynamic_trajectory_generator
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+install(
+  TARGETS mav_trajectory_generation
+  EXPORT export_mav_trajectory_generation
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/config/dynamic_mav_trajectory_generator.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/config/dynamic_mav_trajectory_generator.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    # Plugin-specific parameters live under the plugin namespace. Today the
+    # dynamic generator does not need any extra knobs; future options would
+    # be added here.
+    dynamic_mav_trajectory_generator:
+      # Reserved for future use.
+      null: null

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/include/dynamic_mav_trajectory_generator/dynamic_mav_trajectory_generator.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/include/dynamic_mav_trajectory_generator/dynamic_mav_trajectory_generator.hpp
@@ -1,0 +1,216 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file dynamic_mav_trajectory_generator.hpp
+ *
+ * @brief Plugin wrapper around the dynamic_trajectory_generator library.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#ifndef DYNAMIC_MAV_TRAJECTORY_GENERATOR__DYNAMIC_MAV_TRAJECTORY_GENERATOR_HPP_
+#define DYNAMIC_MAV_TRAJECTORY_GENERATOR__DYNAMIC_MAV_TRAJECTORY_GENERATOR_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+#include "dynamic_trajectory_generator/dynamic_trajectory.hpp"
+#include "dynamic_trajectory_generator/dynamic_waypoint.hpp"
+
+namespace dynamic_mav_trajectory_generator
+{
+
+/**
+ * @brief Plugin wrapper for DynamicTrajectory backend.
+ */
+class Plugin : public generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase
+{
+public:
+  /**
+   * @brief Construct plugin instance.
+   */
+  Plugin();
+
+  /**
+   * @brief Virtual destructor.
+   */
+  ~Plugin() override = default;
+
+  /**
+   * @brief Generate trajectory from waypoint list.
+   *
+   * The starting position is read from vehicle_pose_ (refreshed by the
+   * host) and pushed into the backend before scheduling the new
+   * trajectory. The DynamicTrajectory backend forces zero velocity at
+   * the starting waypoint when generating from scratch, so the live
+   * vehicle_twist_ is intentionally ignored on this path; smooth
+   * velocity matching is only available through updateWaypoints() after
+   * a previous trajectory has been generated.
+   *
+   * Anchors the internal time-axis offset so that the host's
+   * t_trajectory_now maps to the backend's getMinTime().
+   *
+   * @param waypoints Mission waypoints (no synthetic "current" entry).
+   * @param max_speed Maximum speed in m/s.
+   * @param t_trajectory_now Current host trajectory time (seconds).
+   * @return true when generation succeeds.
+   */
+  bool generateTrajectory(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed,
+    double t_trajectory_now) override;
+
+  /**
+   * @brief Evaluate references at host trajectory time @p t_trajectory.
+   *
+   * Reads the live vehicle pose from the protected base member
+   * (vehicle_pose_) so the dynamic backend can close the loop on the
+   * actual vehicle state. The injection is gated on @p is_horizon_sample
+   * being false: for horizon predictions and debug sampling the call is
+   * non-mutating (for_plotting=true).
+   *
+   * @param t_trajectory Evaluation time in the host's trajectory axis.
+   * @param out Output trajectory point.
+   * @param is_horizon_sample True for horizon predictions and debug
+   *                          sampling; false for the live control setpoint.
+   * @return true when evaluation succeeds.
+   */
+  bool evaluate(
+    double t_trajectory,
+    as2_msgs::msg::TrajectoryPoint & out,
+    bool is_horizon_sample) override;
+
+  /**
+   * @brief Whether the trajectory is exhausted at the given t_trajectory.
+   *
+   * @param t_trajectory Current host trajectory time in seconds.
+   * @return true when the trajectory has finished.
+   */
+  bool isFinished(double t_trajectory) const override;
+  double getDuration() const override;
+
+  /**
+   * @brief Check if a trajectory is currently available.
+   *
+   * @return true when trajectory was generated.
+   */
+  bool isTrajectoryGenerated() override;
+
+  /**
+   * @brief Reset trajectory generator state.
+   */
+  void reset() override;
+
+  /**
+   * @brief Update the active trajectory using the backend stitching logic.
+   *
+   * Overrides the base default (regenerate) to leverage
+   * DynamicTrajectory's automatic stitching, which evaluates the
+   * existing trajectory at the current time and uses position +
+   * velocity + acceleration of that sample as boundary conditions for
+   * the new trajectory. The backend keeps its internal time origin so
+   * the plugin's internal_offset_ is preserved unchanged and the host's
+   * t_trajectory keeps mapping to the same backend trajectory.
+   *
+   * @param waypoints Updated pending waypoints (mission only).
+   * @param max_speed Maximum cruise speed in m/s.
+   * @param t_trajectory_now Current host trajectory time (unused on the
+   *                  stitching path, but kept for API symmetry).
+   * @return true when the backend accepts the update request.
+   */
+  bool updateWaypoints(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed,
+    double t_trajectory_now) override;
+
+  /**
+   * @brief Consume and return the backend's "trajectory regenerated"
+   * flag.
+   *
+   * Delegates to DynamicTrajectory::getWasTrajectoryRegenerated(), which
+   * is set to true by swapTrajectory() (the deferred event triggered by
+   * an asynchronous updateWaypoints()) and consumed (reset to false) on
+   * read.
+   *
+   * @return true at most once per asynchronous regeneration event.
+   */
+  bool consumeRegeneratedFlag() override;
+
+  /**
+   * @brief Get the id of the next pending mission waypoint.
+   *
+   * Auxiliary backend waypoints (e.g. stitching points) are filtered out.
+   *
+   * @return Empty string when no pending waypoint, else its id.
+   */
+  std::string getNextWaypointId() override;
+
+protected:
+  /**
+   * @brief Optional plugin-specific initialization hook.
+   */
+  void ownInitialize() override;
+
+private:
+  /**
+   * @brief Convert AS2 waypoints to dynamic generator deque.
+   *
+   * @param waypoints Input waypoint list.
+   * @return Converted dynamic waypoint deque.
+   */
+  static dynamic_traj_generator::DynamicWaypoint::Deque toDynamicDeque(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints);
+
+  /**
+   * @brief Push vehicle position into generator state.
+   *
+   * @param pose Current vehicle pose.
+   */
+  void
+  pushVehiclePositionToGenerator(const geometry_msgs::msg::PoseStamped & pose);
+
+  std::shared_ptr<dynamic_traj_generator::DynamicTrajectory>
+  trajectory_generator_;
+
+  // Maps host trajectory time to backend time:
+  //   t_backend = t_trajectory + internal_offset_.
+  // Anchored on generateTrajectory(); preserved across stitched
+  // updateWaypoints() so the backend's continuous time axis stays
+  // aligned with the host's t_trajectory.
+  double internal_offset_{0.0};
+};
+
+}  // namespace dynamic_mav_trajectory_generator
+
+#endif  // DYNAMIC_MAV_TRAJECTORY_GENERATOR__DYNAMIC_MAV_TRAJECTORY_GENERATOR_HPP_

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/src/dynamic_mav_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/src/dynamic_mav_trajectory_generator.cpp
@@ -1,0 +1,261 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file dynamic_mav_trajectory_generator.cpp
+ *
+ * @brief Plugin wrapper around dynamic_trajectory_generator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include "dynamic_mav_trajectory_generator/dynamic_mav_trajectory_generator.hpp"
+
+#include <pluginlib/class_list_macros.hpp>
+#include <rclcpp/logging.hpp>
+
+namespace dynamic_mav_trajectory_generator
+{
+
+namespace
+{
+bool isAuxiliaryWaypointId(const std::string & id)
+{
+  // Internal helper ids are excluded from mission progress reporting.
+  return id.empty() || id == "stitching_point" || id == "current";
+}
+}  // namespace
+
+Plugin::Plugin()
+: trajectory_generator_(
+    std::make_shared<dynamic_traj_generator::DynamicTrajectory>()) {}
+
+void Plugin::ownInitialize()
+{
+  // Route DYNAMIC_LOG / COUNT_TIME messages emitted by the upstream
+  // dynamic_trajectory_generator library to the rclcpp DEBUG-severity logger
+  // named "dynamic_traj_generator". Visibility is then controlled at runtime
+  // with: --ros-args --log-level dynamic_traj_generator:=debug
+  dynamic_traj_generator::setLogSink(
+    [](const std::string & msg) {
+      RCLCPP_INFO(
+        rclcpp::get_logger("dynamic_traj_generator"), "%s", msg.c_str());
+    });
+
+  // No plugin-specific parameters yet. The base keeps getParameter() available
+  // so future plugin options can live under "<plugin_name>.*".
+}
+
+dynamic_traj_generator::DynamicWaypoint::Deque Plugin::toDynamicDeque(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints)
+{
+  dynamic_traj_generator::DynamicWaypoint::Deque out;
+  for (const auto & wp : waypoints) {
+    // Preserve waypoint names so behavior feedback can map progress by id.
+    dynamic_traj_generator::DynamicWaypoint dyn_wp;
+    dyn_wp.setName(wp.id);
+    dyn_wp.resetWaypoint(
+      Eigen::Vector3d(
+        wp.pose.pose.position.x,
+        wp.pose.pose.position.y,
+        wp.pose.pose.position.z));
+    out.emplace_back(std::move(dyn_wp));
+  }
+  return out;
+}
+
+void Plugin::pushVehiclePositionToGenerator(
+  const geometry_msgs::msg::PoseStamped & pose)
+{
+  trajectory_generator_->updateVehiclePosition(
+    Eigen::Vector3d(
+      pose.pose.position.x, pose.pose.position.y, pose.pose.position.z));
+}
+
+bool Plugin::generateTrajectory(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+  double max_speed,
+  double t_trajectory_now)
+{
+  // Recreate backend per goal to avoid stale trajectory state.
+  trajectory_generator_ =
+    std::make_shared<dynamic_traj_generator::DynamicTrajectory>();
+  trajectory_generator_->setSpeed(max_speed);
+
+  // Seed generator vehicle state from the live pose published by the
+  // host. The backend prepends an internal "current" waypoint with zero
+  // velocity / acceleration constraints, so vehicle_twist_ is not
+  // applied here.
+  pushVehiclePositionToGenerator(vehicle_pose_);
+
+  auto deque = toDynamicDeque(waypoints);
+  dynamic_traj_generator::DynamicWaypoint::Vector vector;
+  vector.reserve(deque.size());
+  for (auto & wp : deque) {
+    vector.emplace_back(std::move(wp));
+  }
+  trajectory_generator_->setWaypoints(vector);
+
+  // Anchor the host axis to the backend axis: when t_trajectory ==
+  // t_trajectory_now, t_backend == backend_min_time.
+  internal_offset_ =
+    trajectory_generator_->getMinTime() - t_trajectory_now;
+  return true;
+}
+
+bool Plugin::evaluate(
+  double t_trajectory,
+  as2_msgs::msg::TrajectoryPoint & out,
+  bool is_horizon_sample)
+{
+  if (!is_horizon_sample) {
+    // Inject live vehicle position only for control setpoint evaluation.
+    // Horizon predictions and debug sampling must not mutate generator
+    // state, so for_plotting=true skips the internal time advance.
+    pushVehiclePositionToGenerator(vehicle_pose_);
+  }
+
+  const double t_backend = t_trajectory + internal_offset_;
+
+  dynamic_traj_generator::References refs;
+  const bool ok = trajectory_generator_->evaluateTrajectory(
+    t_backend, refs, /*only_pos=*/ false, /*for_plotting=*/ is_horizon_sample);
+  if (!ok) {
+    return false;
+  }
+
+  out.position.x = refs.position.x();
+  out.position.y = refs.position.y();
+  out.position.z = refs.position.z();
+  out.twist.x = refs.velocity.x();
+  out.twist.y = refs.velocity.y();
+  out.twist.z = refs.velocity.z();
+  out.acceleration.x = refs.acceleration.x();
+  out.acceleration.y = refs.acceleration.y();
+  out.acceleration.z = refs.acceleration.z();
+  return true;
+}
+
+bool Plugin::isFinished(double t_trajectory) const
+{
+  if (!trajectory_generator_) {
+    return true;
+  }
+  return (t_trajectory + internal_offset_) >=
+         trajectory_generator_->getMaxTime();
+}
+
+double Plugin::getDuration() const
+{
+  if (!trajectory_generator_) {
+    return 0.0;
+  }
+  return trajectory_generator_->getMaxTime() -
+         trajectory_generator_->getMinTime();
+}
+
+bool Plugin::isTrajectoryGenerated()
+{
+  return trajectory_generator_ && trajectory_generator_->getMaxTime() > 0.0;
+}
+
+void Plugin::reset()
+{
+  trajectory_generator_ =
+    std::make_shared<dynamic_traj_generator::DynamicTrajectory>();
+  internal_offset_ = 0.0;
+}
+
+bool Plugin::updateWaypoints(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+  double /*max_speed*/,
+  double /*t_trajectory_now*/)
+{
+  // Cruise speed is fixed at the previous generateTrajectory(); the
+  // backend does not expose a per-update setter so max_speed is
+  // intentionally ignored here. The backend stitches in place over its
+  // continuous time axis, so internal_offset_ is preserved unchanged.
+  if (!trajectory_generator_ || waypoints.empty()) {
+    return false;
+  }
+
+  dynamic_traj_generator::DynamicWaypoint::Vector remaining;
+  remaining.reserve(waypoints.size());
+  for (const auto & wp : waypoints) {
+    if (isAuxiliaryWaypointId(wp.id)) {
+      continue;
+    }
+    dynamic_traj_generator::DynamicWaypoint dyn_wp;
+    dyn_wp.setName(wp.id);
+    dyn_wp.resetWaypoint(
+      Eigen::Vector3d(
+        wp.pose.pose.position.x,
+        wp.pose.pose.position.y,
+        wp.pose.pose.position.z));
+    remaining.emplace_back(std::move(dyn_wp));
+  }
+
+  if (remaining.empty()) {
+    return false;
+  }
+
+  trajectory_generator_->setWaypoints(remaining);
+  return true;
+}
+
+std::string Plugin::getNextWaypointId()
+{
+  if (!trajectory_generator_) {
+    return {};
+  }
+
+  for (const auto & waypoint :
+    trajectory_generator_->getNextTrajectoryWaypoints())
+  {
+    if (!isAuxiliaryWaypointId(waypoint.getName())) {
+      return waypoint.getName();
+    }
+  }
+  return {};
+}
+
+bool Plugin::consumeRegeneratedFlag()
+{
+  if (!trajectory_generator_) {
+    return false;
+  }
+  return trajectory_generator_->getWasTrajectoryRegenerated();
+}
+
+}  // namespace dynamic_mav_trajectory_generator
+
+PLUGINLIB_EXPORT_CLASS(
+  dynamic_mav_trajectory_generator::Plugin,
+  generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase)

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+# GTest of the dynamic_mav_trajectory_generator plugin.
+# Loads the plugin via pluginlib and exercises the public base API.
+file(GLOB GTEST_SOURCES "*_gtest.cpp")
+file(GLOB BENCHMARK_SOURCES "*_benchmark.cpp")
+
+if(GTEST_SOURCES)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
+
+  foreach(TEST_SOURCE ${GTEST_SOURCES})
+    get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+
+    ament_add_gtest(${TEST_NAME} ${TEST_SOURCE})
+    ament_target_dependencies(${TEST_NAME} ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${TEST_NAME}
+      ament_index_cpp::ament_index_cpp
+      gtest_main
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()
+
+# Per-plugin Google-Benchmark binaries. Each source owns its main() and
+# registers whichever plugin it wants to exercise.
+find_package(benchmark QUIET)
+if(benchmark_FOUND AND BENCHMARK_SOURCES)
+  set(BENCHMARK_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/common)
+
+  foreach(BENCHMARK_SOURCE ${BENCHMARK_SOURCES})
+    get_filename_component(BENCHMARK_NAME ${BENCHMARK_SOURCE} NAME_WE)
+
+    add_executable(${PROJECT_NAME}_${BENCHMARK_NAME} ${BENCHMARK_SOURCE})
+    target_include_directories(${PROJECT_NAME}_${BENCHMARK_NAME} PRIVATE
+      ${BENCHMARK_COMMON_DIR})
+    ament_target_dependencies(${PROJECT_NAME}_${BENCHMARK_NAME}
+      ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${PROJECT_NAME}_${BENCHMARK_NAME}
+      benchmark::benchmark
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/dynamic_mav_trajectory_generator_benchmark.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/dynamic_mav_trajectory_generator_benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Universidad Politécnica de Madrid
+// Copyright 2026 Universidad Politecnica de Madrid
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,8 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //
@@ -26,24 +27,20 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-/**
- * @file generate_polynomial_trajectory_behavior_node.cpp
- *
- * @brief Standalone executable for the polynomial trajectory generator
- * behavior. Spins a `GeneratePolynomialTrajectoryBehavior` node with the
- * plugin selected via the `plugin_name` ROS parameter.
- *
- * @authors Rafael Pérez Seguí
- */
+#include <benchmark/benchmark.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include "as2_core/core_functions.hpp"
-#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp"
+#include "generate_polynomial_trajectory_benchmark_common.hpp"
 
-int main(int argc, char * argv[])
+int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<GeneratePolynomialTrajectoryBehavior>();
-  as2::spinLoop(node);
+  generate_polynomial_trajectory_benchmark::silenceRosLogging();
+  benchmark::Initialize(&argc, argv);
+  generate_polynomial_trajectory_benchmark::registerPluginBenchmarks(
+    "dynamic_mav_trajectory_generator");
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/dynamic_mav_trajectory_generator_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/dynamic_mav_trajectory_generator_gtest.cpp
@@ -1,0 +1,260 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file dynamic_mav_trajectory_generator_gtest.cpp
+ *
+ * @brief Plugin-level tests for dynamic_mav_trajectory_generator.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "as2_core/node.hpp"
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase;
+
+namespace
+{
+as2_msgs::msg::PoseStampedWithID makeWaypoint(
+  const std::string & id, double x,
+  double y, double z)
+{
+  as2_msgs::msg::PoseStampedWithID wp;
+  wp.id = id;
+  wp.pose.header.frame_id = "earth";
+  wp.pose.pose.position.x = x;
+  wp.pose.pose.position.y = y;
+  wp.pose.pose.position.z = z;
+  wp.pose.pose.orientation.w = 1.0;
+  return wp;
+}
+
+geometry_msgs::msg::PoseStamped makePose(double x, double y, double z)
+{
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header.frame_id = "earth";
+  pose.pose.position.x = x;
+  pose.pose.position.y = y;
+  pose.pose.position.z = z;
+  pose.pose.orientation.w = 1.0;
+  return pose;
+}
+
+struct PluginFixture
+{
+  std::shared_ptr<as2::Node> node;
+  std::shared_ptr<pluginlib::ClassLoader<PluginBase>> loader;
+  std::shared_ptr<PluginBase> plugin;
+};
+
+PluginFixture
+makePluginFixture(
+  const std::string & node_name,
+  const std::vector<rclcpp::Parameter> & parameter_overrides)
+{
+  PluginFixture f;
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(parameter_overrides);
+  f.node = std::make_shared<as2::Node>(node_name, options);
+  f.loader = std::make_shared<pluginlib::ClassLoader<PluginBase>>(
+    "as2_behaviors_trajectory_generation",
+    "generate_polynomial_trajectory_behavior_plugin_base::"
+    "GeneratePolynomialTrajectoryBase");
+  f.plugin = f.loader->createSharedInstance(
+    "dynamic_mav_trajectory_generator::Plugin");
+  f.plugin->initialize(f.node.get(), "dynamic_mav_trajectory_generator");
+  return f;
+}
+
+class TestParameterPlugin
+  : public generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase
+{
+public:
+  using GeneratePolynomialTrajectoryBase::getParameter;
+
+  bool generateTrajectory(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> &,
+    double,
+    double /*t_trajectory_now*/) override
+  {
+    return true;
+  }
+  bool evaluate(
+    double, as2_msgs::msg::TrajectoryPoint &, bool) override
+  {
+    return true;
+  }
+  bool isFinished(double) const override {return false;}
+  double getDuration() const override {return 0.0;}
+  bool isTrajectoryGenerated() override {return false;}
+  void reset() override {}
+  std::string getNextWaypointId() override {return {};}
+};
+}  // namespace
+
+TEST(DynamicMavTrajectoryGenerator, load_generate_update_get_next) {
+  auto fx = makePluginFixture("dynamic_mav_traj_gen_test", {});
+
+  // Mission waypoints only — the plugin reads the start state from
+  // vehicle_pose_/vehicle_twist_ via setVehicleState.
+  std::vector<as2_msgs::msg::PoseStampedWithID> waypoints = {
+    makeWaypoint("waypoint_000", 1.0, 0.0, 0.0),
+    makeWaypoint("waypoint_001", 2.0, 0.0, 0.0),
+  };
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 0.0), zero_twist);
+
+  ASSERT_TRUE(
+    fx.plugin->generateTrajectory(
+      waypoints, /*max_speed=*/ 1.0, /*t_trajectory_now=*/ 0.0));
+  ASSERT_TRUE(fx.plugin->isTrajectoryGenerated());
+  ASSERT_FALSE(fx.plugin->isFinished(0.0));
+  ASSERT_TRUE(fx.plugin->isFinished(1e6));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_000");
+
+  as2_msgs::msg::TrajectoryPoint point;
+  EXPECT_TRUE(fx.plugin->evaluate(0.0, point, false));
+
+  // Smooth update: modify pose of an existing waypoint and add a new one.
+  // The dynamic backend stitches without resetting its internal time
+  // origin, so subsequent isFinished/evaluate calls on the same
+  // t_trajectory axis must keep working.
+  std::vector<as2_msgs::msg::PoseStampedWithID> updated = {
+    makeWaypoint("waypoint_000", 1.5, 0.0, 0.0),
+    makeWaypoint("waypoint_001", 2.5, 0.0, 0.0),
+    makeWaypoint("waypoint_002", 3.0, 0.0, 0.0),
+  };
+  EXPECT_TRUE(
+    fx.plugin->updateWaypoints(
+      updated, /*max_speed=*/ 1.0, /*t_trajectory_now=*/ 0.5));
+  EXPECT_FALSE(fx.plugin->isFinished(0.5));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_000");
+}
+
+TEST(GetParameter, with_default_and_override) {
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+  {
+    rclcpp::Parameter("test_plugin.test_param_double", 1.5),
+  });
+  auto node =
+    std::make_shared<as2::Node>("get_param_default_with_override", options);
+  TestParameterPlugin plugin;
+  plugin.initialize(node.get(), "test_plugin");
+
+  double value = 0.25;
+  plugin.getParameter("test_param_double", value, true);
+  EXPECT_DOUBLE_EQ(value, 1.5);
+  EXPECT_TRUE(node->has_parameter("test_plugin.test_param_double"));
+}
+
+TEST(GetParameter, with_default_no_override_keeps_default) {
+  rclcpp::NodeOptions options;
+  auto node =
+    std::make_shared<as2::Node>("get_param_default_no_override", options);
+  TestParameterPlugin plugin;
+  plugin.initialize(node.get(), "test_plugin");
+
+  double value = 0.25;
+  plugin.getParameter("test_param_double", value, true);
+  EXPECT_DOUBLE_EQ(value, 0.25);
+  EXPECT_TRUE(node->has_parameter("test_plugin.test_param_double"));
+}
+
+TEST(GetParameter, required_with_override) {
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+  {
+    rclcpp::Parameter("test_plugin.required_string", std::string("provided")),
+  });
+  auto node =
+    std::make_shared<as2::Node>("get_param_required_with_override", options);
+  TestParameterPlugin plugin;
+  plugin.initialize(node.get(), "test_plugin");
+
+  std::string value;
+  plugin.getParameter("required_string", value, false);
+  EXPECT_EQ(value, "provided");
+  EXPECT_TRUE(node->has_parameter("test_plugin.required_string"));
+}
+
+TEST(GetParameter, required_no_override_logs_error) {
+  rclcpp::NodeOptions options;
+  auto node =
+    std::make_shared<as2::Node>("get_param_required_no_override", options);
+  TestParameterPlugin plugin;
+  plugin.initialize(node.get(), "test_plugin");
+
+  std::string value = "untouched";
+  plugin.getParameter("missing_required", value, false);
+  EXPECT_EQ(value, "untouched");
+}
+
+TEST(GetParameter, unsupported_type_falls_back_to_generic) {
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+  {
+    rclcpp::Parameter(
+      "test_plugin.test_param_int64",
+      static_cast<int64_t>(42)),
+  });
+  auto node =
+    std::make_shared<as2::Node>("get_param_unsupported_type", options);
+  TestParameterPlugin plugin;
+  plugin.initialize(node.get(), "test_plugin");
+
+  int64_t value = 0;
+  plugin.getParameter("test_param_int64", value, true);
+  EXPECT_EQ(value, static_cast<int64_t>(42));
+  EXPECT_TRUE(node->has_parameter("test_plugin.test_param_int64"));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_base.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_base.cpp
@@ -1,0 +1,84 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file generate_polynomial_trajectory_base.cpp
+ *
+ * @brief Minimal non-virtual implementation for the plugin base class.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+namespace generate_polynomial_trajectory_behavior_plugin_base
+{
+
+void GeneratePolynomialTrajectoryBase::initialize(
+  as2::Node * node, const std::string & plugin_name)
+{
+  // Cache execution context before delegating plugin-specific setup.
+  node_ptr_ = node;
+  plugin_name_ = plugin_name;
+  ownInitialize();
+}
+
+void GeneratePolynomialTrajectoryBase::setVehicleState(
+  const geometry_msgs::msg::PoseStamped & pose,
+  const geometry_msgs::msg::TwistStamped & twist)
+{
+  vehicle_pose_ = pose;
+  vehicle_twist_ = twist;
+}
+
+as2_msgs::msg::PoseStampedWithID
+GeneratePolynomialTrajectoryBase::buildCurrentWaypoint() const
+{
+  as2_msgs::msg::PoseStampedWithID current;
+  current.id = "current";
+  current.pose = vehicle_pose_;
+  return current;
+}
+
+std::string GeneratePolynomialTrajectoryBase::qualifyParameterName(
+  const std::string & param_name) const
+{
+  if (plugin_name_.empty()) {
+    return param_name;
+  }
+
+  // Keep explicit fully-qualified names unchanged.
+  const std::string prefix = plugin_name_ + ".";
+  if (param_name.rfind(prefix, 0) == 0) {
+    return param_name;
+  }
+  return prefix + param_name;
+}
+
+}  // namespace generate_polynomial_trajectory_behavior_plugin_base

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Universidad Politécnica de Madrid
+// Copyright 2026 Universidad Politecnica de Madrid
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,8 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //
@@ -29,968 +30,1198 @@
 /**
  * @file generate_polynomial_trajectory_behavior.cpp
  *
- * @brief Source file for the GeneratePolynomialTrajectoryBehavior class.
+ * @brief Implementation of GeneratePolynomialTrajectoryBehavior.
  *
- * @author Miguel Fernández Cortizas
- *         Pedro Arias Pérez
- *         David Pérez Saura
- *         Rafael Pérez Seguí
+ * @authors Rafael Perez-Segui
  */
 
-#include "generate_polynomial_trajectory_behavior.hpp"
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp"
 
-DynamicPolynomialTrajectoryGenerator::DynamicPolynomialTrajectoryGenerator(
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <deque>
+#include <unordered_set>
+#include <utility>
+
+#include "as2_core/utils/frame_utils.hpp"
+
+GeneratePolynomialTrajectoryBehavior::GeneratePolynomialTrajectoryBehavior(
   const rclcpp::NodeOptions & options)
 : as2_behavior::BehaviorServer<
     as2_msgs::action::GeneratePolynomialTrajectory>(
     as2_names::actions::behaviors::trajectorygenerator, options),
-  trajectory_motion_handler_(this),
-  hover_motion_handler_(this),
-  tf_handler_(this)
+  tf_handler_(this), trajectory_motion_handler_(this),
+  hover_motion_handler_(this)
 {
-  this->declare_parameter<std::string>("desired_frame_id", "odom");
-  std::string odom_frame = this->get_parameter("desired_frame_id").as_string();
-  desired_frame_id_ = as2::tf::generateTfName(this, odom_frame);
-  map_frame_id_ = as2::tf::generateTfName(this, "map");
+  // Load plugin
+  loadPlugin();
+
+  // Frames
   base_link_frame_id_ = as2::tf::generateTfName(this, "base_link");
+  map_frame_id_ = as2::tf::generateTfName(this, "map");
 
-  trajectory_generator_ =
-    std::make_shared<dynamic_traj_generator::DynamicTrajectory>();
+  std::string desired_frame_id;
+  getParameter("desired_frame_id", desired_frame_id);
+  RCLCPP_INFO(this->get_logger(), "Using desired_frame_id: %s", desired_frame_id.c_str());
+  desired_frame_id_ = as2::tf::generateTfName(this, desired_frame_id);
 
+  // Parameters
+  getParameter("sampling_n", sampling_n_);
+  getParameter("sampling_dt", sampling_dt_);
+  getParameter("transform_threshold", transform_threshold_);
+  getParameter("frequency_update_frame", frequency_update_frame_);
+  getParameter("yaw_threshold", yaw_threshold_);
+  getParameter("yaw_speed_threshold", yaw_speed_threshold_);
+  getParameter("path_length", path_length_);
+
+  // Parameters checks
+  if (path_length_ < 0) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "path_length must be >= 0, got %d. Disabling partial-trajectory feed.",
+      path_length_);
+    path_length_ = 0;
+  }
+  if (sampling_n_ < 1) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Sampling n must be >= 1, got %d",
+      sampling_n_);
+    sampling_n_ = 1;
+  }
+
+  RCLCPP_INFO(
+    this->get_logger(), "Sampling with n=%d and dt=%.4fs",
+    sampling_n_, sampling_dt_);
+
+  // Initialize debug publishers
+  initDebugPublishers();
+
+  // Subscriptions
   state_sub_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
     as2_names::topics::self_localization::twist,
     as2_names::topics::self_localization::qos,
     std::bind(
-      &DynamicPolynomialTrajectoryGenerator::stateCallback, this,
+      &GeneratePolynomialTrajectoryBehavior::stateCallback, this,
       std::placeholders::_1));
 
   yaw_sub_ = this->create_subscription<std_msgs::msg::Float32>(
-    "traj_gen/yaw", rclcpp::SensorDataQoS(),
+    "motion_reference/yaw", rclcpp::SensorDataQoS(),
     std::bind(
-      &DynamicPolynomialTrajectoryGenerator::yawCallback, this,
+      &GeneratePolynomialTrajectoryBehavior::yawCallback, this,
       std::placeholders::_1));
 
-  /** For faster waypoint modified */
   mod_waypoint_sub_ =
     this->create_subscription<as2_msgs::msg::PoseStampedWithIDArray>(
     as2_names::topics::motion_reference::modify_waypoint,
     as2_names::topics::motion_reference::qos_waypoint,
     std::bind(
-      &DynamicPolynomialTrajectoryGenerator::modifyWaypointCallback,
+      &GeneratePolynomialTrajectoryBehavior::modifyWaypointCallback,
       this, std::placeholders::_1));
-
-  // Read ROS 2 parameters
-  this->declare_parameter<int>("sampling_n");
-  sampling_n_ = this->get_parameter("sampling_n").as_int();
-  this->declare_parameter<double>("sampling_dt");
-  sampling_dt_ = this->get_parameter("sampling_dt").as_double();
-  path_length_ = this->declare_parameter<int>("path_length", 0);
-  yaw_threshold_ = this->declare_parameter<float>("yaw_threshold", 0.0);
-  transform_threshold_ = this->declare_parameter<float>("transform_threshold", 1.0);
-  yaw_speed_threshold_ = this->declare_parameter<double>("yaw_speed_threshold", 0.0);
-  frequency_update_frame_ = this->declare_parameter<double>("frequency_update_frame", 0.0);
-  wp_close_threshold_ = this->declare_parameter<double>("wp_close_threshold", 0.0);
-
-  if (sampling_n_ < 1) {
-    RCLCPP_ERROR(this->get_logger(), "Sampling n must be greater than 0");
-    return;
-  }
-  RCLCPP_INFO(this->get_logger(), "Sampling with n = %d and dt = %f", sampling_n_, sampling_dt_);
-
-  /** Debug publishers **/
-  std::string path_topic = this->declare_parameter<std::string>("debug.path_topic", "");
-  std::string reference_setpoint = this->declare_parameter<std::string>(
-    "debug.reference_setpoint",
-    "");
-  std::string reference_end_waypoint = this->declare_parameter<std::string>(
-    "debug.reference_end_waypoint", "");
-  std::string reference_waypoints = this->declare_parameter<std::string>(
-    "debug.reference_waypoints", "");
-
-  if (path_topic != "") {
-    debug_path_pub_ = this->create_publisher<nav_msgs::msg::Path>(path_topic, 1);
-  }
-
-  if (reference_setpoint != "") {
-    debug_ref_point_pub_ = this->create_publisher<visualization_msgs::msg::Marker>(
-      reference_setpoint, 1);
-  }
-
-  if (reference_end_waypoint != "") {
-    debug_end_ref_point_pub_ = this->create_publisher<visualization_msgs::msg::Marker>(
-      reference_end_waypoint, 1);
-  }
-
-  if (reference_waypoints != "") {
-    debug_waypoints_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
-      reference_waypoints, 1);
-  }
-
-  if (debug_path_pub_ != nullptr || debug_ref_point_pub_ != nullptr ||
-    debug_end_ref_point_pub_ != nullptr || debug_waypoints_pub_ != nullptr)
-  {
-    enable_debug_ = true;
-  }
-  return;
 }
-void DynamicPolynomialTrajectoryGenerator::timerUpdateFrameCallback()
-{
-  if (computeErrorFrames()) {
-    if (!updateFrame(goal_)) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Could not update transform between %s and %s",
-        map_frame_id_.c_str(), desired_frame_id_.c_str());
-    }
-  }
-}
-void DynamicPolynomialTrajectoryGenerator::stateCallback(
-  const geometry_msgs::msg::TwistStamped::SharedPtr _twist_msg)
+
+void GeneratePolynomialTrajectoryBehavior::loadPlugin()
 {
   try {
-    geometry_msgs::msg::PoseStamped pose_msg =
-      tf_handler_.getPoseStamped(
-      desired_frame_id_, base_link_frame_id_,
-      tf2_ros::fromMsg(_twist_msg->header.stamp));
+    getParameter("plugin_name", plugin_name_);
 
-    if (!has_odom_) {
-      RCLCPP_INFO(this->get_logger(), "State callback working");
-      has_odom_ = true;
-    }
+    plugin_loader_ = std::make_shared<pluginlib::ClassLoader<PluginBase>>(
+      "as2_behaviors_trajectory_generation",
+      "generate_polynomial_trajectory_behavior_plugin_base::"
+      "GeneratePolynomialTrajectoryBase");
 
-    current_position_ =
-      Eigen::Vector3d(
-      pose_msg.pose.position.x, pose_msg.pose.position.y,
-      pose_msg.pose.position.z);
-    current_yaw_ = as2::frame::getYawFromQuaternion(pose_msg.pose.orientation);
-    trajectory_generator_->updateVehiclePosition(
-      Eigen::Vector3d(
-        pose_msg.pose.position.x, pose_msg.pose.position.y,
-        pose_msg.pose.position.z));
-  } catch (tf2::TransformException & ex) {
-    RCLCPP_WARN(this->get_logger(), "Could not get transform: %s", ex.what());
-  }
-  return;
-}
+    const std::string class_name = plugin_name_ + "::Plugin";
+    // Resolve and instantiate plugin class at runtime.
+    plugin_ = plugin_loader_->createSharedInstance(class_name);
+    plugin_->initialize(this, plugin_name_);
 
-void DynamicPolynomialTrajectoryGenerator::yawCallback(
-  const std_msgs::msg::Float32::SharedPtr _msg)
-{
-  has_yaw_from_topic_ = true;
-  yaw_from_topic_ = _msg->data;
-}
-
-bool DynamicPolynomialTrajectoryGenerator::goalToDynamicWaypoint(
-  std::shared_ptr<const as2_msgs::action::GeneratePolynomialTrajectory::Goal>
-  _goal,
-  dynamic_traj_generator::DynamicWaypoint::Deque & _waypoints_to_set)
-{
-  std::vector<std::string> waypoint_ids;
-  waypoint_ids.reserve(_goal->path.size());
-
-  if (_goal->max_speed < 0) {
-    RCLCPP_ERROR(this->get_logger(), "Goal max speed is negative");
-    return false;
-  }
-  trajectory_generator_->setSpeed(_goal->max_speed);
-  _waypoints_to_set.clear();
-  for (as2_msgs::msg::PoseStampedWithID waypoint : _goal->path) {
-    // Process each waypoint id
-    if (waypoint.id == "") {
-      RCLCPP_ERROR(this->get_logger(), "Waypoint ID is empty");
-      return false;
-    } else {
-      // Else if waypoint ID is in the list of waypoint IDs, then return false
-      if (std::find(
-          waypoint_ids.begin(), waypoint_ids.end(),
-          waypoint.id) != waypoint_ids.end())
-      {
-        RCLCPP_ERROR(
-          this->get_logger(), "Waypoint ID %s is not unique",
-          waypoint.id.c_str());
-        return false;
-      }
-    }
-
-    waypoint_ids.push_back(waypoint.id);
-
-    // Process each waypoint frame_id
-    if (waypoint.pose.header.frame_id != desired_frame_id_) {
-      geometry_msgs::msg::PoseStamped pose_stamped;
-      try {
-        waypoint.pose = tf_handler_.convert(waypoint.pose, desired_frame_id_);
-      } catch (tf2::TransformException & ex) {
-        RCLCPP_WARN(
-          this->get_logger(), "Could not get transform: %s",
-          ex.what());
-        return false;
-      }
-    }
-
-    // Set to dynamic trajectory generator
-    dynamic_traj_generator::DynamicWaypoint dynamic_waypoint;
-    generateDynamicPoint(waypoint, dynamic_waypoint);
-    _waypoints_to_set.emplace_back(dynamic_waypoint);
-  }
-  return true;
-}
-
-bool DynamicPolynomialTrajectoryGenerator::on_activate(
-  std::shared_ptr<const as2_msgs::action::GeneratePolynomialTrajectory::Goal>
-  goal)
-{
-  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator on activate");
-
-  if (!has_odom_) {
-    RCLCPP_ERROR(this->get_logger(), "No odometry information available");
-    return false;
-  }
-  if (frequency_update_frame_ > 0) {
-    /** Calback to check the transform between frames */
-    timer_update_frame_ = this->create_wall_timer(
-      std::chrono::milliseconds(static_cast<int>(1000 / frequency_update_frame_)),
-      std::bind(
-        &DynamicPolynomialTrajectoryGenerator::timerUpdateFrameCallback,
-        this));
-    // wait until needed
-    timer_update_frame_->cancel();
-  }
-  setup();
-  start_on_paused_ = goal->start_on_paused;
-  // Print goal path
-  for (auto waypoint : goal->path) {
     RCLCPP_INFO(
       this->get_logger(),
-      "Waypoint ID: %s, frame_id: %s, position : [%f, %f, %f]",
-      waypoint.id.c_str(), waypoint.pose.header.frame_id.c_str(),
-      waypoint.pose.pose.position.x, waypoint.pose.pose.position.y,
-      waypoint.pose.pose.position.z);
+      "Trajectory generator plugin loaded: %s",
+      plugin_name_.c_str());
+  } catch (const pluginlib::PluginlibException & ex) {
+    RCLCPP_FATAL(
+      this->get_logger(), "Failed to load plugin '%s': %s",
+      plugin_name_.c_str(), ex.what());
+    throw;
   }
+}
 
-  if (!goalToDynamicWaypoint(goal, waypoints_to_set_)) {
+void GeneratePolynomialTrajectoryBehavior::publishGenerationDebug()
+{
+  publishWaypoints();
+  publishGeneratedTrajectory();
+}
+
+bool GeneratePolynomialTrajectoryBehavior::on_activate(
+  std::shared_ptr<const Action::Goal> goal)
+{
+  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator on_activate");
+  if (!has_vehicle_state_) {
+    RCLCPP_ERROR(this->get_logger(), "No state received yet - rejecting goal");
     return false;
   }
 
-  dynamic_traj_generator::DynamicWaypoint::Vector waypoints_to_set;
-  if (path_length_ == 0 || (goal->path.size() < (path_length_))) {
-    waypoints_to_set.reserve(waypoints_to_set_.size());
-    for (dynamic_traj_generator::DynamicWaypoint wp : waypoints_to_set_) {
-      waypoints_to_set.emplace_back(wp);
-    }
-    waypoints_to_set_.clear();
-  } else {
-    waypoints_to_set.reserve(path_length_);
-    for (int i = 0; i < path_length_; i++) {
-      waypoints_to_set.emplace_back(waypoints_to_set_.front());
-      waypoints_to_set_.pop_front();
-    }
+  // Build mission waypoints in desired_frame_id_ (no synthetic prefix).
+  std::vector<as2_msgs::msg::PoseStampedWithID> waypoints;
+  if (!buildWaypoints(goal, waypoints)) {
+    return false;
   }
-  // Set waypoints to trajectory generator
-  trajectory_generator_->setWaypoints(waypoints_to_set);
-  last_map_to_odom_transform_ = tf_handler_.getTransform(
-    map_frame_id_, desired_frame_id_,
-    tf2::TimePointZero);
-  yaw_mode_ = goal->yaw;
-  RCLCPP_INFO(this->get_logger(), "Yaw mode: %d", yaw_mode_.mode);
-  goal_ = *goal;
 
-  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator goal accepted");
-
-
-  if (enable_debug_) {
-    double max_time = trajectory_generator_->getMaxTime();
-    if ((debug_path_pub_ != nullptr || debug_waypoints_pub_ != nullptr) &&
-      trajectory_generator_->getWasTrajectoryRegenerated())
+  // Apply path_length truncation: feed only the first path_length_
+  // waypoints to the plugin and queue the rest for incremental injection.
+  // The plugin's updateWaypoints() decides at each window slide whether
+  // to stitch smoothly or regenerate (fallback in the base class).
+  std::deque<as2_msgs::msg::PoseStampedWithID> pending;
+  const auto goal_count = static_cast<int>(waypoints.size());
+  if (path_length_ > 0 && goal_count > path_length_) {
+    for (std::size_t i = static_cast<std::size_t>(path_length_);
+      i < waypoints.size(); ++i)
     {
-      plotTrajectory();
+      pending.push_back(waypoints[i]);
     }
+    waypoints.resize(static_cast<std::size_t>(path_length_));
   }
 
-  // Reset internal flags
+  if (!generateTrajectory(waypoints, goal->max_speed)) {
+    return false;
+  }
+
+  // Persist the goal with canonicalized ids and frame-converted poses.
+  // goal_.path holds the FULL mission queue (including pending) so the
+  // feedback's remaining_waypoints count and on_resume rebuild stay correct.
+  goal_ = *goal;
+  goal_.path.assign(waypoints.begin(), waypoints.end());
+  for (const auto & wp : pending) {
+    goal_.path.emplace_back(wp);
+  }
+  pending_waypoints_queue_ = std::move(pending);
+  active_waypoints_.assign(waypoints.begin(), waypoints.end());
+
+  // Latch pause-after-generate flag and reset its sub-state.
+  start_on_paused_ = goal->start_on_paused;
   has_paused_ = false;
   external_pause_ = false;
 
-  return true;
-}
-
-void DynamicPolynomialTrajectoryGenerator::setup()
-{
-  // trajectory_generator_ =
-  //     std::make_shared<dynamic_traj_generator::DynamicTrajectory>();
-  has_yaw_from_topic_ = false;
-  has_odom_ = false;
-  first_run_ = true;
-
-  trajectory_command_ = as2_msgs::msg::TrajectorySetpoints();
-  trajectory_command_.header.frame_id = desired_frame_id_;
-  trajectory_command_.setpoints.resize(sampling_n_);
-  time_zero_yaw_ = this->now();
-  init_yaw_angle_ = current_yaw_;
-  if (frequency_update_frame_ > 0) {
+  // Frame-drift watchdog.
+  if (frequency_update_frame_ > 0.0) {
+    if (!timer_update_frame_) {
+      timer_update_frame_ = this->create_wall_timer(
+        std::chrono::milliseconds(
+          static_cast<int>(1000.0 / frequency_update_frame_)),
+        std::bind(
+          &GeneratePolynomialTrajectoryBehavior::timerUpdateFrameCallback,
+          this));
+    }
     timer_update_frame_->reset();
-  }
-}
-
-bool DynamicPolynomialTrajectoryGenerator::on_modify(
-  std::shared_ptr<const as2_msgs::action::GeneratePolynomialTrajectory::Goal>
-  goal)
-{
-  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator goal modified");
-
-  // Generate queue of waypoints for trajectory generator, from goal to
-  // dynamic_traj_generator::DynamicWaypoint::Deque
-  waypoints_to_set_.clear();
-  if (!goalToDynamicWaypoint(goal, waypoints_to_set_)) {return false;}
-  dynamic_traj_generator::DynamicWaypoint::Vector waypoints_to_set;
-  if (path_length_ == 0 || (goal->path.size() < (path_length_))) {
-    waypoints_to_set.reserve(waypoints_to_set_.size());
-    for (dynamic_traj_generator::DynamicWaypoint wp : waypoints_to_set_) {
-      waypoints_to_set.emplace_back(wp);
-    }
-    waypoints_to_set_.clear();
-  } else {
-    waypoints_to_set.reserve(path_length_);
-    for (int i = 0; i < path_length_; i++) {
-      waypoints_to_set.emplace_back(waypoints_to_set_.front());
-      waypoints_to_set_.pop_front();
+    try {
+      last_map_to_desired_ = tf_handler_.getTransform(
+        map_frame_id_, desired_frame_id_, tf2::TimePointZero);
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_WARN(
+        this->get_logger(), "Could not cache map->%s transform: %s",
+        desired_frame_id_.c_str(), ex.what());
+      timer_update_frame_->cancel();
     }
   }
 
-
-  // Modify each waypoint
-  for (dynamic_traj_generator::DynamicWaypoint dynamic_waypoint :
-    waypoints_to_set)
-  {
-    trajectory_generator_->modifyWaypoint(
-      dynamic_waypoint.getName(), dynamic_waypoint.getCurrentPosition());
-
-    // DEBUG
-    RCLCPP_INFO(
-      this->get_logger(), "waypoint[%s] added: (%.2f, %.2f, %.2f)",
-      dynamic_waypoint.getName().c_str(),
-      dynamic_waypoint.getOriginalPosition().x(),
-      dynamic_waypoint.getOriginalPosition().y(),
-      dynamic_waypoint.getOriginalPosition().z());
-  }
-
+  publishGenerationDebug();
+  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator goal accepted");
   return true;
 }
 
-/** For faster waypoint modified */
-void DynamicPolynomialTrajectoryGenerator::modifyWaypointCallback(
-  const as2_msgs::msg::PoseStampedWithIDArray::SharedPtr _msg)
+bool GeneratePolynomialTrajectoryBehavior::on_modify(
+  std::shared_ptr<const Action::Goal> goal)
 {
-  for (as2_msgs::msg::PoseStampedWithID waypoint : _msg->poses) {
-    geometry_msgs::msg::PoseStamped pose_stamped = waypoint.pose;
+  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator on_modify");
 
-    if (pose_stamped.header.frame_id != desired_frame_id_) {
-      try {
-        pose_stamped = tf_handler_.convert(pose_stamped, desired_frame_id_);
-      } catch (tf2::TransformException & ex) {
-        RCLCPP_WARN(this->get_logger(), "Could not get transform: %s", ex.what());
-        return;
-      }
-    }
-
-    Eigen::Vector3d position;
-    position.x() = pose_stamped.pose.position.x;
-    position.y() = pose_stamped.pose.position.y;
-    position.z() = pose_stamped.pose.position.z;
-    trajectory_generator_->modifyWaypoint(waypoint.id, position);
-    RCLCPP_DEBUG(
-      this->get_logger(), "waypoint[%s] modified: %s - (%.2f, %.2f, %.2f)",
-      waypoint.id.c_str(), pose_stamped.header.frame_id.c_str(),
-      position.x(), position.y(), position.z());
+  const std::string current_next = plugin_->getNextWaypointId();
+  // Avoid desynchronization when finishing trajectory and a modify arrives
+  if (current_next.empty()) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "No pending waypoint reported by plugin - rejecting modify");
+    return false;
   }
+
+  // Convert each modify waypoint to desired_frame_id_ before merging.
+  std::vector<as2_msgs::msg::PoseStampedWithID> modify_converted;
+  if (!convertWaypointsToDesiredFrame(
+      goal->path, modify_converted, "on_modify"))
+  {
+    return false;
+  }
+
+  // Already waypoints pose is modify
+  // New waypoints are added to the end
+  // TODO(RPS98): enable insert new waypoints in the already trajectory
+  auto pending = mergeModifyIntoGoal(modify_converted, current_next);
+  if (pending.empty()) {
+    RCLCPP_ERROR(this->get_logger(), "on_modify: no pending waypoints left");
+    return false;
+  }
+
+  goal_.yaw = goal->yaw;
+  goal_.max_speed = goal->max_speed;
+  goal_.stamp = goal->stamp;
+
+  return pushPendingToPlugin();
 }
 
-bool DynamicPolynomialTrajectoryGenerator::on_deactivate(
+bool GeneratePolynomialTrajectoryBehavior::on_deactivate(
   const std::shared_ptr<std::string> & message)
 {
-  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator cancelled");
+  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator on_deactivate");
   return true;
 }
 
-bool DynamicPolynomialTrajectoryGenerator::on_pause(
+bool GeneratePolynomialTrajectoryBehavior::on_pause(
   const std::shared_ptr<std::string> & message)
 {
   RCLCPP_WARN(
-    this->get_logger(),
-    "TrajectoryGenerator can not be paused, try "
-    "to cancel it and start a new one");
-  if (frequency_update_frame_ > 0) {
+    this->get_logger(), "TrajectoryGenerator pause: capturing pending queue "
+    "and switching to hover");
+  if (timer_update_frame_) {
     timer_update_frame_->cancel();
   }
-  // Reset the trajectory generator
-  trajectory_generator_ =
-    std::make_shared<dynamic_traj_generator::DynamicTrajectory>();
-
-  // Send the hover motion command
+  // Snapshot the next pending id BEFORE resetting so on_resume can rebuild.
+  paused_next_waypoint_id_ = plugin_->getNextWaypointId();
+  if (plugin_) {
+    plugin_->reset();
+  }
   hover_motion_handler_.sendHover();
-
+  // Mark this as an external pause so on_resume can tell it apart from the
+  // auto-pause emitted by the start_on_paused flow.
   external_pause_ = true;
   return true;
 }
 
-bool DynamicPolynomialTrajectoryGenerator::on_resume(
+bool GeneratePolynomialTrajectoryBehavior::on_resume(
   const std::shared_ptr<std::string> & message)
 {
+  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator on_resume");
+  if (!has_vehicle_state_) {
+    RCLCPP_ERROR(this->get_logger(), "Cannot resume: no vehicle state");
+    return false;
+  }
+
+  // Wake-up from the auto-pause emitted by start_on_paused: the trajectory
+  // generated in on_activate is still loaded in the plugin and execution has
+  // never started, so just clear the latch and let on_run drive the first
+  // sample at trajectory_time_ == 0 (first_tick_after_anchor_ remains true).
   if (start_on_paused_ && !external_pause_) {
     if (!has_paused_) {
       RCLCPP_ERROR(
         this->get_logger(),
-        "TrajectoryGenerator was not paused from the start, can not resume");
+        "Cannot resume: start_on_paused requested but on_run never reached "
+        "the auto-PAUSED transition");
       return false;
     }
     RCLCPP_INFO(
       this->get_logger(),
-      "TrajectoryGenerator is already paused from the start, resuming");
+      "TrajectoryGenerator: resuming from start_on_paused auto-pause");
     return true;
   }
 
-  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator resume from pause");
-
-  if (!has_odom_) {
-    RCLCPP_ERROR(this->get_logger(), "No odometry information available");
-    return false;
-  }
-  setup();
-
-  // Print goal path
-  bool start_trajectory = false;
-  auto paused_goal = as2_msgs::action::GeneratePolynomialTrajectory::Goal();
-  paused_goal.stamp = this->now();
-  paused_goal.yaw = goal_.yaw;
-  paused_goal.max_speed = goal_.max_speed;
-
-  paused_goal.path = std::vector<as2_msgs::msg::PoseStampedWithID>();
-  for (auto waypoint : goal_.path) {
-    if (waypoint.id != feedback_.next_waypoint_id && !start_trajectory) {
-      continue;
-    }
-    start_trajectory = true;
-    paused_goal.path.push_back(waypoint);
-
-    RCLCPP_INFO(
-      this->get_logger(),
-      "Waypoint remainings ID: %s, frame_id: %s, position : [%f, %f, %f]",
-      waypoint.id.c_str(), waypoint.pose.header.frame_id.c_str(),
-      waypoint.pose.pose.position.x, waypoint.pose.pose.position.y,
-      waypoint.pose.pose.position.z);
-  }
-
-  if (paused_goal.path.size() == 0) {
-    RCLCPP_ERROR(this->get_logger(), "No waypoint remaining");
+  auto pending = getPendingWaypoints(paused_next_waypoint_id_);
+  paused_next_waypoint_id_.clear();
+  if (pending.empty()) {
+    RCLCPP_ERROR(this->get_logger(), "Cannot resume: no pending waypoints");
     return false;
   }
 
-  // Generate queue of waypoints for trajectory generator, from goal to
-  // dynamic_traj_generator::DynamicWaypoint::Deque
-  auto paused_goal_shared_ptr =
-    std::make_shared<as2_msgs::action::GeneratePolynomialTrajectory::Goal>(
-    paused_goal);
-  waypoints_to_set_.clear();
-  if (!goalToDynamicWaypoint(paused_goal_shared_ptr, waypoints_to_set_)) {
+  // Apply path_length truncation on resume so the partial-feed invariants
+  // are restored.
+  std::deque<as2_msgs::msg::PoseStampedWithID> resume_pending;
+  const auto resumed_count = static_cast<int>(pending.size());
+  if (path_length_ > 0 && resumed_count > path_length_) {
+    for (std::size_t i = static_cast<std::size_t>(path_length_);
+      i < pending.size(); ++i)
+    {
+      resume_pending.push_back(pending[i]);
+    }
+    pending.resize(static_cast<std::size_t>(path_length_));
+  }
+
+  if (!generateTrajectory(pending, goal_.max_speed)) {
     return false;
   }
-  dynamic_traj_generator::DynamicWaypoint::Vector waypoints_to_set;
-  if (path_length_ == 0 || (paused_goal.path.size() < (path_length_))) {
-    waypoints_to_set.reserve(waypoints_to_set_.size());
-    for (dynamic_traj_generator::DynamicWaypoint wp : waypoints_to_set_) {
-      waypoints_to_set.emplace_back(wp);
-    }
-    waypoints_to_set_.clear();
-  } else {
-    waypoints_to_set.reserve(path_length_);
-    for (int i = 0; i < path_length_; i++) {
-      waypoints_to_set.emplace_back(waypoints_to_set_.front());
-      waypoints_to_set_.pop_front();
-    }
+
+  // Refresh the stored queue with the resumed pending list.
+  goal_.path = pending;
+  for (const auto & wp : resume_pending) {
+    goal_.path.emplace_back(wp);
   }
+  goal_.stamp = this->now();
+  pending_waypoints_queue_ = std::move(resume_pending);
+  active_waypoints_.assign(pending.begin(), pending.end());
 
-  // Set waypoints to trajectory generator
-  trajectory_generator_->setWaypoints(waypoints_to_set);
-  yaw_mode_ = paused_goal.yaw;
-  goal_ = paused_goal;
-
-  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator resumed");
+  publishGenerationDebug();
   return true;
 }
 
-void DynamicPolynomialTrajectoryGenerator::on_execution_end(
+as2_behavior::ExecutionStatus GeneratePolynomialTrajectoryBehavior::on_run(
+  const std::shared_ptr<const Action::Goal> & /*goal*/,
+  std::shared_ptr<Action::Feedback> & feedback_msg,
+  std::shared_ptr<Action::Result> & result_msg)
+{
+  if (!plugin_ || !plugin_->isTrajectoryGenerated()) {
+    result_msg->trajectory_generator_success = false;
+    return as2_behavior::ExecutionStatus::FAILURE;
+  }
+
+  // Pause-after-generate: if the goal requested start_on_paused, emit a
+  // single PAUSED transition before any setpoint is sent. The wrapper stays
+  // paused until an external on_resume() call switches the behavior back to
+  // RUNNING.
+  if (start_on_paused_ && !has_paused_) {
+    has_paused_ = true;
+    RCLCPP_INFO(
+      this->get_logger(),
+      "TrajectoryGenerator: start_on_paused requested, holding PAUSED until "
+      "resume");
+    return as2_behavior::ExecutionStatus::PAUSED;
+  }
+
+  // Advance the host trajectory time axis. The first tick after a
+  // generation / resume keeps dt = 0 so the control sample lands at
+  // trajectory_time_ exactly (which is 0 right after a fresh
+  // generation, or the preserved value across stitched updates).
+  const auto now = this->now();
+  double dt = 0.0;
+  if (first_tick_after_anchor_) {
+    first_tick_after_anchor_ = false;
+  } else {
+    dt = (now - last_tick_time_).seconds();
+  }
+  last_tick_time_ = now;
+  trajectory_time_ += dt;
+
+  as2_msgs::msg::TrajectorySetpoints setpoints;
+  if (!evaluateHorizon(
+      trajectory_time_, sampling_dt_,
+      static_cast<std::size_t>(sampling_n_), setpoints))
+  {
+    result_msg->trajectory_generator_success = false;
+    return as2_behavior::ExecutionStatus::FAILURE;
+  }
+
+  // Asynchronous-regeneration plugins (e.g. dynamic_mav_trajectory_generator)
+  // perform the deferred swap of an in-flight updateWaypoints() request inside
+  // evaluateTrajectory(); the first sample of evaluateHorizon() above runs
+  // with is_horizon_sample=false, which is exactly the call that triggers
+  // that swap. consumeRegeneratedFlag() reports the transition once. Refresh
+  // the debug path so RViz catches up with the new trajectory; synchronous
+  // plugins keep the base default (always false) and this branch is a no-op.
+  if (enable_debug_ && plugin_->consumeRegeneratedFlag()) {
+    publishGenerationDebug();
+  }
+
+  if (!trajectory_motion_handler_.sendTrajectorySetpoints(setpoints)) {
+    RCLCPP_ERROR(this->get_logger(), "Could not send trajectory setpoints");
+    result_msg->trajectory_generator_success = false;
+    return as2_behavior::ExecutionStatus::FAILURE;
+  }
+
+  // Feedback: next id from plugin, remaining count from goal_.path.
+  const std::string next_id = plugin_->getNextWaypointId();
+  feedback_msg->next_waypoint_id = next_id;
+  feedback_msg->remaining_waypoints = remainingWaypointCount(next_id);
+  feedback_ = *feedback_msg;
+
+  // path_length partial-trajectory feed: extend the active window via
+  // plugin_->updateWaypoints() when the plugin-side remaining drops below
+  // path_length_. Skipped when the queue is empty or the plugin reports no
+  // pending waypoint yet (next_id empty). The plugin re-anchors its
+  // internal offset against trajectory_time_ on regeneration; the host
+  // axis keeps progressing without realignment.
+  if (path_length_ > 0 && !pending_waypoints_queue_.empty() &&
+    !next_id.empty())
+  {
+    auto next_it = std::find_if(
+      active_waypoints_.begin(), active_waypoints_.end(),
+      [&next_id](const as2_msgs::msg::PoseStampedWithID & wp) {
+        return wp.id == next_id;
+      });
+    if (next_it != active_waypoints_.end()) {
+      active_waypoints_.erase(active_waypoints_.begin(), next_it);
+    }
+    if (active_waypoints_.size() <
+      static_cast<std::size_t>(path_length_))
+    {
+      const auto wp = pending_waypoints_queue_.front();
+      active_waypoints_.push_back(wp);
+      const auto compute_t0 = std::chrono::steady_clock::now();
+      if (plugin_->updateWaypoints(
+          active_waypoints_, goal_.max_speed, trajectory_time_))
+      {
+        const double compute_ms = std::chrono::duration<double, std::milli>(
+          std::chrono::steady_clock::now() - compute_t0).count();
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Trajectory updated (path_length feed): %zu waypoints, "
+          "compute=%.2f ms, duration=%.2f s",
+          active_waypoints_.size(), compute_ms, plugin_->getDuration());
+        pending_waypoints_queue_.pop_front();
+        if (enable_debug_) {
+          publishGenerationDebug();
+        }
+      } else {
+        // Roll back the speculative append and retry next cycle.
+        active_waypoints_.pop_back();
+        RCLCPP_WARN(
+          this->get_logger(),
+          "path_length: updateWaypoints failed, retrying next cycle "
+          "(%zu pending)",
+          pending_waypoints_queue_.size());
+      }
+    }
+  }
+
+  if (plugin_->isFinished(trajectory_time_)) {
+    if (!pending_waypoints_queue_.empty()) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Plugin reports trajectory done while %zu waypoints are still "
+        "pending — partial mission only.",
+        pending_waypoints_queue_.size());
+    }
+    result_msg->trajectory_generator_success = true;
+    return as2_behavior::ExecutionStatus::SUCCESS;
+  }
+
+  return as2_behavior::ExecutionStatus::RUNNING;
+}
+
+void GeneratePolynomialTrajectoryBehavior::on_execution_end(
   const as2_behavior::ExecutionStatus & state)
 {
-  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator end");
-  if (frequency_update_frame_ > 0) {
+  RCLCPP_INFO(this->get_logger(), "TrajectoryGenerator on_execution_end");
+  if (timer_update_frame_) {
     timer_update_frame_.reset();
   }
-  // Reset the trajectory generator
-  trajectory_generator_ =
-    std::make_shared<dynamic_traj_generator::DynamicTrajectory>();
+  if (plugin_) {
+    plugin_->reset();
+  }
+  resetRuntimeState();
 
-  // Reset the queue of waypoints
-  waypoints_to_set_.clear();
   if (state == as2_behavior::ExecutionStatus::SUCCESS ||
     state == as2_behavior::ExecutionStatus::ABORTED)
   {
     return;
   }
-
-  // If the trajectory generator is not successful, we send a hover command
-  hover_motion_handler_.sendHover();
-  return;
+  // Keep vehicle safe if execution ended unexpectedly.
+  if (state != as2_behavior::ExecutionStatus::SUCCESS) {
+    hover_motion_handler_.sendHover();
+  }
 }
 
-as2_behavior::ExecutionStatus DynamicPolynomialTrajectoryGenerator::on_run(
-  const std::shared_ptr<
-    const as2_msgs::action::GeneratePolynomialTrajectory::Goal> & goal,
-  std::shared_ptr<as2_msgs::action::GeneratePolynomialTrajectory::Feedback>
-  & feedback_msg,
-  std::shared_ptr<as2_msgs::action::GeneratePolynomialTrajectory::Result>
-  & result_msg)
+bool GeneratePolynomialTrajectoryBehavior::validateWaypoints(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints) const
 {
-  // If start on paused, pause the behavior right after starting it
-  if (start_on_paused_ && !has_paused_) {
-    has_paused_ = true;
-    return as2_behavior::ExecutionStatus::PAUSED;
-  }
-
-  bool publish_trajectory = false;
-  if (first_run_) {
-    publish_trajectory = evaluateTrajectory(trajectory_generator_->getMinTime());
-    time_zero_ = this->now();
-    eval_time_ = rclcpp::Duration(0, 0);
-    first_run_ = false;
-  } else {
-    eval_time_ = this->now() - time_zero_;
-    publish_trajectory = evaluateTrajectory(eval_time_.seconds());
-  }
-
-  // Check success trajectory generator evaluation
-  if (!publish_trajectory) {
-    // TODO(CVAR): When trajectory_generator_->evaluateTrajectory == False?
-    result_msg->trajectory_generator_success = false;
-    return as2_behavior::ExecutionStatus::FAILURE;
-  }
-
-  // Check if the trajectory generator has finished
-  if (trajectory_generator_->getMaxTime() < (eval_time_.seconds() - 0.01) &&
-    !first_run_ && !trajectory_generator_->getGenerateNewTraj())
-  {
-    if (waypoints_to_set_.empty()) {
-      result_msg->trajectory_generator_success = true;
-      return as2_behavior::ExecutionStatus::SUCCESS;
-    } else {
-      trajectory_generator_->appendWaypoint(waypoints_to_set_.front());
-      waypoints_to_set_.pop_front();
-      eval_time_ = this->now() - time_zero_;
-      publish_trajectory = evaluateTrajectory(eval_time_.seconds());
-      RCLCPP_ERROR(this->get_logger(), "Trajectory has not generated all the waypoints ");
-      // TO DO: carmendrpr
-    }
-  }
-
-  // Plot debug trajectory
-  if (enable_debug_) {
-    plotRefTrajPoint();
-  }
-
-  // Publish trajectory motion reference
-  if (!trajectory_motion_handler_.sendTrajectorySetpoints(trajectory_command_)) {
+  if (waypoints.empty()) {
     RCLCPP_ERROR(
       this->get_logger(),
-      "TrajectoryGenerator: Could not send trajectory command");
-    result_msg->trajectory_generator_success = false;
-    return as2_behavior::ExecutionStatus::FAILURE;
+      "At least 1 waypoint is required, got %zu",
+      waypoints.size());
+    return false;
   }
 
-  auto next_trajectory_waypoints =
-    trajectory_generator_->getNextTrajectoryWaypoints();
-
-  feedback_.remaining_waypoints = trajectory_generator_->getRemainingWaypoints();
-  if (feedback_.remaining_waypoints > 0) {
-    feedback_.next_waypoint_id = next_trajectory_waypoints[0].getName();
-  } else {
-    feedback_.next_waypoint_id = "";
-  }
-
-  feedback_msg->remaining_waypoints = feedback_.remaining_waypoints;
-  feedback_msg->next_waypoint_id = feedback_.next_waypoint_id;
-
-  if (trajectory_generator_->getComputingNewTrajectoryStatus() ||
-    trajectory_generator_->getGenerateNewTraj() || path_length_ == 0)
-  {
-    return as2_behavior::ExecutionStatus::RUNNING;
-  }
-
-  if (goal->path.size() < this->path_length_) {
-    return as2_behavior::ExecutionStatus::RUNNING;
-  }
-
-
-  if (waypoints_to_set_.empty()) {
-    return as2_behavior::ExecutionStatus::RUNNING;
-  }
-
-  if (trajectory_generator_->getRemainingWaypoints() < path_length_) {
-    trajectory_generator_->appendWaypoint(waypoints_to_set_.front());
-    waypoints_to_set_.pop_front();
-  }
-
-
-  return as2_behavior::ExecutionStatus::RUNNING;
-}
-
-bool DynamicPolynomialTrajectoryGenerator::evaluateTrajectory(
-  double eval_time)
-{
-  as2_msgs::msg::TrajectoryPoint setpoint;
-  double initial_yaw = current_yaw_;
-  for (int i = 0; i < sampling_n_; i++) {
-    bool success;
-    if (i == 0) {
-      success = evaluateSetpoint(eval_time, setpoint, true, initial_yaw);
-    } else {
-      success = evaluateSetpoint(eval_time, setpoint, false, initial_yaw);
-    }
-    if (!success) {
+  std::unordered_set<std::string> ids;
+  ids.reserve(waypoints.size());
+  for (std::size_t i = 0; i < waypoints.size(); ++i) {
+    if (waypoints[i].id.empty()) {
+      RCLCPP_ERROR(this->get_logger(), "Waypoint #%zu has empty id", i);
       return false;
     }
-    trajectory_command_.setpoints[i] = setpoint;
-    initial_yaw = setpoint.yaw_angle;
-    eval_time += sampling_dt_;
+    if (!ids.insert(waypoints[i].id).second) {
+      RCLCPP_ERROR(
+        this->get_logger(), "Duplicate waypoint id '%s'",
+        waypoints[i].id.c_str());
+      return false;
+    }
   }
-  trajectory_command_.header.stamp = this->now();
   return true;
 }
 
-bool DynamicPolynomialTrajectoryGenerator::evaluateSetpoint(
-  double eval_time,
-  as2_msgs::msg::TrajectoryPoint & setpoint,
-  bool current_setpoint,
-  const double current_yaw)
+bool GeneratePolynomialTrajectoryBehavior::convertWaypointsToDesiredFrame(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & in,
+  std::vector<as2_msgs::msg::PoseStampedWithID> & out,
+  const char * log_context)
 {
-  dynamic_traj_generator::References traj_command;
-  double yaw_angle;
+  out.clear();
+  out.reserve(in.size());
 
-  if (eval_time <= trajectory_generator_->getMinTime()) {
-    eval_time = trajectory_generator_->getMinTime();
-  } else if (eval_time >= trajectory_generator_->getMaxTime()) {
-    eval_time = trajectory_generator_->getMaxTime();
+  for (std::size_t i = 0; i < in.size(); ++i) {
+    const auto & wp = in[i];
+    as2_msgs::msg::PoseStampedWithID converted;
+    if (wp.id.empty()) {
+      // Use id = waypoint_{index} for waypoints with empty id
+      // index has 3 digits
+      char buf[32];
+      std::snprintf(buf, sizeof(buf), "waypoint_%03zu", i);
+      converted.id = buf;
+    } else {
+      converted.id = wp.id;
+    }
+
+    try {
+      converted.pose = tf_handler_.convert(wp.pose, desired_frame_id_);
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "%s: could not convert waypoint #%zu (id '%s'): %s",
+        log_context, i, wp.id.c_str(), ex.what());
+      return false;
+    }
+
+    out.emplace_back(std::move(converted));
   }
-  bool succes_eval =
-    trajectory_generator_->evaluateTrajectory(eval_time, traj_command, false, !current_setpoint);
 
-  switch (yaw_mode_.mode) {
-    case as2_msgs::msg::YawMode::FACE_REFERENCE:
-      yaw_angle = computeYawFaceReference(current_yaw);
-      break;
+  return true;
+}
+
+bool GeneratePolynomialTrajectoryBehavior::buildWaypoints(
+  const std::shared_ptr<const Action::Goal> & goal,
+  std::vector<as2_msgs::msg::PoseStampedWithID> & out)
+{
+  if (goal->path.empty()) {
+    RCLCPP_ERROR(this->get_logger(), "Goal path is empty");
+    return false;
+  }
+  if (goal->max_speed <= 0.0f) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Goal max_speed must be > 0, got %f",
+      goal->max_speed);
+    return false;
+  }
+
+  if (!convertWaypointsToDesiredFrame(goal->path, out, "buildWaypoints")) {
+    return false;
+  }
+
+  return validateWaypoints(out);
+}
+
+bool GeneratePolynomialTrajectoryBehavior::generateTrajectory(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+  double max_speed)
+{
+  if (max_speed <= 0.0) {
+    RCLCPP_ERROR(this->get_logger(), "max_speed must be > 0, got %f", max_speed);
+    return false;
+  }
+  if (waypoints.empty()) {
+    RCLCPP_ERROR(this->get_logger(), "generateTrajectory: empty waypoints");
+    return false;
+  }
+
+  // Plugin already holds the latest vehicle state pushed by stateCallback;
+  // it reads it directly as the boundary condition for the new trajectory.
+  // The host's trajectory_time_ is reset to 0 here, so the plugin anchors
+  // its internal offset such that t_trajectory == 0 maps to the start of
+  // the new backend trajectory.
+  trajectory_time_ = 0.0;
+  const auto compute_t0 = std::chrono::steady_clock::now();
+  if (!plugin_->generateTrajectory(waypoints, max_speed, trajectory_time_)) {
+    RCLCPP_ERROR(this->get_logger(), "Plugin generateTrajectory failed");
+    return false;
+  }
+  const double compute_ms = std::chrono::duration<double, std::milli>(
+    std::chrono::steady_clock::now() - compute_t0).count();
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Trajectory generated: %zu waypoints, compute=%.2f ms, duration=%.2f s",
+    waypoints.size(), compute_ms, plugin_->getDuration());
+
+  // Fresh trajectory: reset host time-axis bookkeeping. The first on_run
+  // tick uses dt = 0 so the control sample lands at trajectory_time_ == 0
+  // exactly, and yaw rate-limit machinery is re-anchored to the new start.
+  first_tick_after_anchor_ = true;
+  last_tick_time_ = this->now();
+  time_zero_yaw_ = this->now();
+  init_yaw_angle_ =
+    as2::frame::getYawFromQuaternion(waypoints.front().pose.pose.orientation);
+  return true;
+}
+
+bool GeneratePolynomialTrajectoryBehavior::evaluatePoint(
+  double t, as2_msgs::msg::TrajectoryPoint & out, bool is_horizon_sample)
+{
+  if (!plugin_ || !plugin_->isTrajectoryGenerated()) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 1000,
+      "evaluatePoint: trajectory not generated yet");
+    return false;
+  }
+  if (!has_vehicle_state_) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "evaluatePoint: vehicle pose not available");
+    return false;
+  }
+
+  // The plugin maps t to its own backend axis and clamps internally.
+  if (!plugin_->evaluate(t, out, is_horizon_sample)) {
+    return false;
+  }
+
+  out.yaw_angle = static_cast<float>(computeYaw(out));
+  return true;
+}
+
+bool GeneratePolynomialTrajectoryBehavior::evaluateHorizon(
+  double t0, double dt, std::size_t n,
+  as2_msgs::msg::TrajectorySetpoints & out)
+{
+  if (n == 0 || dt <= 0.0) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "evaluateHorizon: invalid arguments (n=%zu, dt=%f)", n, dt);
+    return false;
+  }
+
+  out.header.frame_id = desired_frame_id_;
+  out.header.stamp = this->now();
+  out.setpoints.resize(n);
+
+  for (std::size_t i = 0; i < n; ++i) {
+    // First sample may use current-state correction; the rest are horizon-only.
+    const bool is_horizon_sample = (i > 0);
+    if (!evaluatePoint(
+        t0 + static_cast<double>(i) * dt, out.setpoints[i],
+        is_horizon_sample))
+    {
+      return false;
+    }
+  }
+
+  if (enable_debug_ && !out.setpoints.empty()) {
+    publishEvaluatedPoint(out.setpoints.front(), false);
+    if (out.setpoints.size() >= 2) {
+      publishEvaluatedPoint(out.setpoints.back(), true);
+    }
+  }
+  return true;
+}
+
+double GeneratePolynomialTrajectoryBehavior::computeYaw(
+  const as2_msgs::msg::TrajectoryPoint & point)
+{
+  const double current_yaw =
+    as2::frame::getYawFromQuaternion(
+    plugin_->getVehiclePose().pose.orientation);
+
+  switch (goal_.yaw.mode) {
+    // Centralized yaw policy dispatch based on the active goal's yaw mode.
     case as2_msgs::msg::YawMode::KEEP_YAW:
-      yaw_angle = init_yaw_angle_;
-      break;
+      return init_yaw_angle_;
     case as2_msgs::msg::YawMode::PATH_FACING:
-      yaw_angle = computeYawAnglePathFacing(
-        traj_command.velocity.x(),
-        traj_command.velocity.y());
-      break;
+      return computeYawAnglePathFacing(point.twist.x, point.twist.y);
     case as2_msgs::msg::YawMode::FIXED_YAW:
-      yaw_angle = yaw_mode_.angle;
-      break;
+      return goal_.yaw.angle;
     case as2_msgs::msg::YawMode::YAW_FROM_TOPIC:
       if (has_yaw_from_topic_) {
-        yaw_angle = yaw_from_topic_;
-      } else {
-        auto & clk = *this->get_clock();
-        RCLCPP_WARN_THROTTLE(
-          this->get_logger(), clk, 1000,
-          "Yaw from topic not received yet, using last yaw angle");
-        yaw_angle = init_yaw_angle_;
+        return yaw_from_topic_;
       }
-      break;
-    default:
-      auto & clk = *this->get_clock();
       RCLCPP_WARN_THROTTLE(
-        this->get_logger(), clk, 5000,
-        "Unknown yaw mode, using keep yaw");
-      yaw_angle = current_yaw_;
-      break;
+        this->get_logger(), *this->get_clock(), 1000,
+        "Yaw from topic not received yet, using initial yaw angle");
+      return init_yaw_angle_;
+    case as2_msgs::msg::YawMode::FACE_REFERENCE:
+      return computeYawFaceReference();
+    default:
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000,
+        "Unknown yaw mode %u, using current yaw", goal_.yaw.mode);
+      return current_yaw;
   }
-
-  setpoint.position.x = traj_command.position.x();
-  setpoint.position.y = traj_command.position.y();
-  setpoint.position.z = traj_command.position.z();
-  setpoint.twist.x = traj_command.velocity.x();
-  setpoint.twist.y = traj_command.velocity.y();
-  setpoint.twist.z = traj_command.velocity.z();
-  setpoint.acceleration.x = traj_command.acceleration.x();
-  setpoint.acceleration.y = traj_command.acceleration.y();
-  setpoint.acceleration.z = traj_command.acceleration.z();
-  setpoint.yaw_angle = yaw_angle;
-
-  return succes_eval;
 }
-bool DynamicPolynomialTrajectoryGenerator::updateFrame(
-  const as2_msgs::action::GeneratePolynomialTrajectory::Goal &
-  goal)
+
+double GeneratePolynomialTrajectoryBehavior::computeYawAnglePathFacing(
+  double vx, double vy) const
 {
-  std::vector<std::pair<std::string, Eigen::Vector3d>> waypoints_to_set_vector;
-  dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set_queue;
-  // Update the frame
-  for (as2_msgs::msg::PoseStampedWithID waypoint : goal.path) {
-    if (!tf_handler_.tryConvert(waypoint.pose, desired_frame_id_)) {return false;}
-    // Update the waypoint in the trajectory generator
-    for (auto traj_waypoint : trajectory_generator_->getNextTrajectoryWaypoints()) {
-      if (traj_waypoint.getName() == waypoint.id) {
-        if ((traj_waypoint.getTime() - eval_time_.seconds()) > wp_close_threshold_) {
-          waypoint.pose.header.stamp = this->now();
-          Eigen::Vector3d position;
-          position.x() = waypoint.pose.pose.position.x;
-          position.y() = waypoint.pose.pose.position.y;
-          position.z() = waypoint.pose.pose.position.z;
-          waypoints_to_set_vector.emplace_back(waypoint.id, position);
-        }
-      }
-    }
-    // Update the waypoints in the queue
-    for (auto waypoints_queue : waypoints_to_set_) {
-      if (waypoints_queue.getName() == waypoint.id) {
-        waypoints_to_set_queue.emplace_back(waypoints_queue);
-      }
+  if (std::sqrt(vx * vx + vy * vy) > yaw_threshold_) {
+    return as2::frame::getVector2DAngle(vx, vy);
+  }
+  return as2::frame::getYawFromQuaternion(
+    plugin_->getVehiclePose().pose.orientation);
+}
+
+const as2_msgs::msg::PoseStampedWithID *
+GeneratePolynomialTrajectoryBehavior::getNextReferenceWaypoint() const
+{
+  if (goal_.path.empty() || !plugin_) {
+    return nullptr;
+  }
+
+  const std::string next_id = plugin_->getNextWaypointId();
+  if (!next_id.empty()) {
+    const auto it = std::find_if(
+      goal_.path.begin(), goal_.path.end(),
+      [&next_id](const as2_msgs::msg::PoseStampedWithID & wp) {
+        return wp.id == next_id;
+      });
+    if (it != goal_.path.end()) {
+      return &(*it);
     }
   }
-  waypoints_to_set_.clear();
-  waypoints_to_set_ = waypoints_to_set_queue;
-  last_map_to_odom_transform_ = tf_handler_.getTransform(
-    map_frame_id_, desired_frame_id_,
-    tf2::TimePointZero);
-  trajectory_generator_->modifyWaypoints(waypoints_to_set_vector);
-  time_debug_ = this->now();
-  waypoints_to_set_vector.clear();
+  return &goal_.path.front();
+}
+
+double GeneratePolynomialTrajectoryBehavior::computeYawFaceReference()
+{
+  const auto & vehicle_pose = plugin_->getVehiclePose();
+  const double current_yaw =
+    as2::frame::getYawFromQuaternion(vehicle_pose.pose.orientation);
+  const auto * next_waypoint = getNextReferenceWaypoint();
+  if (next_waypoint == nullptr) {
+    time_zero_yaw_ = this->now();
+    return current_yaw;
+  }
+
+  const Eigen::Vector2d diff(
+    next_waypoint->pose.pose.position.x - vehicle_pose.pose.position.x,
+    next_waypoint->pose.pose.position.y - vehicle_pose.pose.position.y);
+
+  if (diff.norm() <= yaw_threshold_) {
+    time_zero_yaw_ = this->now();
+    return current_yaw;
+  }
+
+  const double target_yaw = as2::frame::getVector2DAngle(diff.x(), diff.y());
+  const double yaw_error = as2::frame::angleMinError(target_yaw, current_yaw);
+  const rclcpp::Duration dt = this->now() - time_zero_yaw_;
+  const double dt_seconds = std::max(dt.seconds(), 1e-3);
+  // Convert angle error to bounded yaw-rate command. A non-positive
+  // yaw_speed_threshold disables the rate limit (raw error tracked).
+  double yaw_speed = yaw_error / dt_seconds;
+  if (yaw_speed_threshold_ > 0.0) {
+    yaw_speed =
+      std::clamp(yaw_speed, -yaw_speed_threshold_, yaw_speed_threshold_);
+  }
+  time_zero_yaw_ = this->now();
+  return current_yaw + yaw_speed * dt_seconds;
+}
+
+std::vector<as2_msgs::msg::PoseStampedWithID>
+GeneratePolynomialTrajectoryBehavior::getPendingWaypoints(
+  const std::string & next_id) const
+{
+  if (next_id.empty() || goal_.path.empty()) {
+    return {goal_.path.begin(), goal_.path.end()};
+  }
+  const auto it = std::find_if(
+    goal_.path.begin(), goal_.path.end(),
+    [&next_id](const as2_msgs::msg::PoseStampedWithID & wp) {
+      return wp.id == next_id;
+    });
+  if (it == goal_.path.end()) {
+    return {goal_.path.begin(), goal_.path.end()};
+  }
+  return {it, goal_.path.end()};
+}
+
+uint16_t GeneratePolynomialTrajectoryBehavior::remainingWaypointCount(
+  const std::string & next_id) const
+{
+  if (goal_.path.empty()) {
+    return 0;
+  }
+  if (next_id.empty()) {
+    return static_cast<uint16_t>(goal_.path.size());
+  }
+  const auto it = std::find_if(
+    goal_.path.begin(), goal_.path.end(),
+    [&next_id](const as2_msgs::msg::PoseStampedWithID & wp) {
+      return wp.id == next_id;
+    });
+  if (it == goal_.path.end()) {
+    return 0;
+  }
+  return static_cast<uint16_t>(std::distance(it, goal_.path.end()));
+}
+
+std::vector<as2_msgs::msg::PoseStampedWithID>
+GeneratePolynomialTrajectoryBehavior::mergeModifyIntoGoal(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & modify_waypoints,
+  const std::string & next_id)
+{
+  // Drop already-passed waypoints.
+  if (!next_id.empty() && !goal_.path.empty()) {
+    const auto it = std::find_if(
+      goal_.path.begin(), goal_.path.end(),
+      [&next_id](const as2_msgs::msg::PoseStampedWithID & wp) {
+        return wp.id == next_id;
+      });
+    if (it != goal_.path.end()) {
+      goal_.path.erase(goal_.path.begin(), it);
+    }
+  }
+
+  // Update existing entries / append new ones at the end.
+  for (const auto & mod_wp : modify_waypoints) {
+    auto it = std::find_if(
+      goal_.path.begin(), goal_.path.end(),
+      [&mod_wp](const as2_msgs::msg::PoseStampedWithID & wp) {
+        return wp.id == mod_wp.id;
+      });
+    if (it != goal_.path.end()) {
+      it->pose = mod_wp.pose;
+    } else {
+      goal_.path.emplace_back(mod_wp);
+    }
+  }
+
+  return {goal_.path.begin(), goal_.path.end()};
+}
+
+bool GeneratePolynomialTrajectoryBehavior::pushPendingToPlugin()
+{
+  if (!plugin_) {
+    return false;
+  }
+
+  const std::string next_id = plugin_->getNextWaypointId();
+  auto pending = getPendingWaypoints(next_id);
+
+  // path_length: split the pending list into the active window we feed to
+  // the plugin and a queue we drain incrementally in on_run.
+  std::deque<as2_msgs::msg::PoseStampedWithID> queued;
+  splitForPathLength(pending, queued);
+
+  // If no pending waypoints, no waypoints to push
+  if (pending.empty()) {
+    return false;
+  }
+
+  // Delegate to updateWaypoints. The plugin reads the live vehicle
+  // state from its protected members (refreshed continuously by
+  // stateCallback) and decides between smooth stitching (preserving its
+  // internal offset) or regeneration (re-anchoring its offset against
+  // trajectory_time_). The host axis is unaffected either way.
+  const auto compute_t0 = std::chrono::steady_clock::now();
+  if (!plugin_->updateWaypoints(pending, goal_.max_speed, trajectory_time_)) {
+    RCLCPP_WARN(this->get_logger(), "updateWaypoints failed");
+    return false;
+  }
+  const double compute_ms = std::chrono::duration<double, std::milli>(
+    std::chrono::steady_clock::now() - compute_t0).count();
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Trajectory updated (push pending): %zu waypoints, compute=%.2f ms, "
+    "duration=%.2f s",
+    pending.size(), compute_ms, plugin_->getDuration());
+  active_waypoints_ = pending;
+  pending_waypoints_queue_ = std::move(queued);
+  publishGenerationDebug();
   return true;
 }
 
-double DynamicPolynomialTrajectoryGenerator::computeYawAnglePathFacing(
-  double vx, double vy)
+void GeneratePolynomialTrajectoryBehavior::splitForPathLength(
+  std::vector<as2_msgs::msg::PoseStampedWithID> & active,
+  std::deque<as2_msgs::msg::PoseStampedWithID> & queued) const
 {
-  if (sqrt(vx * vx + vy * vy) > yaw_threshold_) {
-    return as2::frame::getVector2DAngle(vx, vy);
+  if (path_length_ <= 0) {
+    return;
   }
-  return current_yaw_;
+  if (static_cast<int>(active.size()) <= path_length_) {
+    return;
+  }
+  for (std::size_t i = static_cast<std::size_t>(path_length_);
+    i < active.size(); ++i)
+  {
+    queued.push_back(active[i]);
+  }
+  active.resize(static_cast<std::size_t>(path_length_));
 }
-double DynamicPolynomialTrajectoryGenerator::computeYawFaceReference(double current_yaw)
+
+void GeneratePolynomialTrajectoryBehavior::resetRuntimeState()
 {
-  eval_time_yaw_ = rclcpp::Duration(0, 0);
-  if (trajectory_generator_->getRemainingWaypoints() < 1) {
-    return current_yaw;
+  goal_ = Action::Goal{};
+  feedback_ = Action::Feedback{};
+  paused_next_waypoint_id_.clear();
+  has_yaw_from_topic_ = false;
+  trajectory_time_ = 0.0;
+  first_tick_after_anchor_ = true;
+  init_yaw_angle_ = 0.0;
+  start_on_paused_ = false;
+  has_paused_ = false;
+  external_pause_ = false;
+  pending_waypoints_queue_.clear();
+  active_waypoints_.clear();
+}
+
+bool GeneratePolynomialTrajectoryBehavior::computeFrameError()
+{
+  // A non-positive transform_threshold disables the drift check.
+  if (transform_threshold_ <= 0.0) {
+    return false;
+  }
+  if (last_map_to_desired_.header.frame_id.empty()) {
+    return false;
   }
 
-  dynamic_traj_generator::DynamicWaypoint::Vector next_trajectory_waypoint =
-    trajectory_generator_->getNextTrajectoryWaypoints();
-  Eigen::Vector3d next_position;
-  for (int i = 0; i < next_trajectory_waypoint.size(); i++) {
-    std::string name = next_trajectory_waypoint[i].getName();
-    if (name.find("ny") != std::string::npos) {
+  geometry_msgs::msg::TransformStamped current;
+  try {
+    current = tf_handler_.getTransform(
+      map_frame_id_, desired_frame_id_,
+      tf2::TimePointZero);
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "computeFrameError: could not get transform: %s", ex.what());
+    return false;
+  }
+
+  const Eigen::Vector3d current_t(current.transform.translation.x,
+    current.transform.translation.y,
+    current.transform.translation.z);
+  const Eigen::Vector3d last_t(last_map_to_desired_.transform.translation.x,
+    last_map_to_desired_.transform.translation.y,
+    last_map_to_desired_.transform.translation.z);
+  // Trigger regeneration when map-to-desired translation drifts too far.
+  return (current_t - last_t).norm() > transform_threshold_;
+}
+
+void GeneratePolynomialTrajectoryBehavior::timerUpdateFrameCallback()
+{
+  if (!computeFrameError()) {
+    return;
+  }
+
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Map<->odom drift exceeded %.2fm threshold, regenerating trajectory",
+    transform_threshold_);
+
+  // Re-convert cached goal poses under the new frame state.
+  auto goal_ptr = std::make_shared<const Action::Goal>(goal_);
+  std::vector<as2_msgs::msg::PoseStampedWithID> refreshed;
+  if (!buildWaypoints(goal_ptr, refreshed)) {
+    return;
+  }
+  goal_.path = refreshed;
+
+  pushPendingToPlugin();
+
+  // Refresh transform cache regardless of the push outcome.
+  try {
+    last_map_to_desired_ = tf_handler_.getTransform(
+      map_frame_id_, desired_frame_id_, tf2::TimePointZero);
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN(
+      this->get_logger(), "Could not refresh transform cache: %s",
+      ex.what());
+  }
+}
+
+void GeneratePolynomialTrajectoryBehavior::stateCallback(
+  const geometry_msgs::msg::TwistStamped::SharedPtr twist_msg)
+{
+  try {
+    auto [vehicle_pose, vehicle_twist] =
+      tf_handler_.getState(
+      *twist_msg,
+      desired_frame_id_,
+      desired_frame_id_,
+      base_link_frame_id_);
+    // Push the freshly-resolved state directly into the plugin so it
+    // becomes the single source of truth for everything downstream
+    // (plugin entry points and wrapper readers via getVehiclePose /
+    // getVehicleTwist accessors).
+    if (plugin_) {
+      plugin_->setVehicleState(vehicle_pose, vehicle_twist);
+    }
+    if (!has_vehicle_state_) {
+      RCLCPP_INFO(this->get_logger(), "State callback active");
+      has_vehicle_state_ = true;
+    }
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 1000,
+      "stateCallback: could not get transform: %s",
+      ex.what());
+  }
+}
+
+void GeneratePolynomialTrajectoryBehavior::yawCallback(
+  const std_msgs::msg::Float32::SharedPtr msg)
+{
+  has_yaw_from_topic_ = true;
+  yaw_from_topic_ = msg->data;
+}
+
+void GeneratePolynomialTrajectoryBehavior::modifyWaypointCallback(
+  const as2_msgs::msg::PoseStampedWithIDArray::SharedPtr msg)
+{
+  if (!plugin_) {
+    return;
+  }
+
+  // Apply each new pose onto goal_.path (with frame conversion).
+  for (const auto & wp : msg->poses) {
+    geometry_msgs::msg::PoseStamped pose_stamped = wp.pose;
+    if (pose_stamped.header.frame_id != desired_frame_id_) {
+      try {
+        pose_stamped = tf_handler_.convert(pose_stamped, desired_frame_id_);
+      } catch (const tf2::TransformException & ex) {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "modifyWaypointCallback: could not convert frame for '%s': %s",
+          wp.id.c_str(), ex.what());
+        continue;
+      }
+    }
+    for (auto & gp : goal_.path) {
+      if (gp.id == wp.id) {
+        gp.pose = pose_stamped;
+        break;
+      }
+    }
+  }
+
+  // Delegate to the plugin via updateWaypoints. The plugin decides
+  // whether to stitch smoothly (preserving its internal offset) or
+  // regenerate (re-anchoring its offset against trajectory_time_).
+  pushPendingToPlugin();
+}
+
+void GeneratePolynomialTrajectoryBehavior::initDebugPublishers()
+{
+  std::string path_topic;
+  std::string ref_setpoint;
+  std::string ref_end_waypoint;
+  std::string ref_waypoints;
+
+  getParameter("debug.path_topic", path_topic);
+  getParameter("debug.reference_setpoint", ref_setpoint);
+  getParameter("debug.reference_end_waypoint", ref_end_waypoint);
+  getParameter("debug.reference_waypoints", ref_waypoints);
+
+  if (!path_topic.empty()) {
+    debug_path_pub_ =
+      this->create_publisher<nav_msgs::msg::Path>(path_topic, 1);
+  }
+  if (!ref_setpoint.empty()) {
+    debug_ref_point_pub_ =
+      this->create_publisher<visualization_msgs::msg::Marker>(
+      ref_setpoint,
+      1);
+  }
+  if (!ref_end_waypoint.empty()) {
+    debug_end_ref_point_pub_ =
+      this->create_publisher<visualization_msgs::msg::Marker>(
+      ref_end_waypoint, 1);
+  }
+  if (!ref_waypoints.empty()) {
+    debug_waypoints_pub_ =
+      this->create_publisher<visualization_msgs::msg::MarkerArray>(
+      ref_waypoints, 1);
+  }
+
+  enable_debug_ = debug_path_pub_ || debug_ref_point_pub_ ||
+    debug_end_ref_point_pub_ || debug_waypoints_pub_;
+}
+
+void GeneratePolynomialTrajectoryBehavior::publishGeneratedTrajectory()
+{
+  if (!debug_path_pub_ || !plugin_ || !plugin_->isTrajectoryGenerated()) {
+    return;
+  }
+
+  nav_msgs::msg::Path path_msg;
+  path_msg.header.frame_id = desired_frame_id_;
+  path_msg.header.stamp = this->now();
+
+  // Fixed decimation step and safety cap for the debug trajectory dump.
+  // The host axis runs from trajectory_time_ (current) until the plugin
+  // reports isFinished(); the cap keeps an unbounded backend trajectory
+  // from spinning forever.
+  constexpr double kStep = 0.2;
+  constexpr double kMaxDuration = 600.0;
+
+  const double t_start = trajectory_time_;
+  for (double t = t_start;
+    !plugin_->isFinished(t) && (t - t_start) <= kMaxDuration;
+    t += kStep)
+  {
+    as2_msgs::msg::TrajectoryPoint setpoint;
+    if (!evaluatePoint(t, setpoint, true)) {
       continue;
     }
-    next_position = next_trajectory_waypoint[i].getOriginalPosition();
-    break;
+
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header = path_msg.header;
+    pose.pose.position.x = setpoint.position.x;
+    pose.pose.position.y = setpoint.position.y;
+    pose.pose.position.z = setpoint.position.z;
+    path_msg.poses.emplace_back(std::move(pose));
   }
-  // Eigen::Vector3d next_position = next_trajectory_waypoint.begin()->getOriginalPosition();
-  Eigen::Vector2d diff(next_position[0] - current_position_[0],
-    next_position[1] - current_position_[1]);
-  if (diff.norm() > yaw_threshold_) {
-    // Error from the current yaw to the desired yaw
-    double yaw_error =
-      as2::frame::angleMinError(
-      as2::frame::getVector2DAngle(diff.x(), diff.y()), current_yaw);
-    // Compute the speed to reach the desired yaw
-    double yaw_speed = yaw_error / sampling_dt_;
-    if (yaw_speed_threshold_ != 0.0) {
-      // Limit the yaw speed
-      yaw_speed = std::clamp(yaw_speed, (-yaw_speed_threshold_), yaw_speed_threshold_);
-    }
-    // Store the time when the yaw is set
-    return current_yaw + yaw_speed * sampling_dt_;
-  } else {
-    // Store the time when the yaw is set
-    // If there are no more waypoints, keep the current yaw
-    return current_yaw;
-  }
-}
-bool DynamicPolynomialTrajectoryGenerator::computeErrorFrames()
-{
-  current_map_to_odom_transform_ =
-    tf_handler_.getTransform(map_frame_id_, desired_frame_id_, tf2::TimePointZero);
-  Eigen::Vector3d current_traslation = Eigen::Vector3d(
-    current_map_to_odom_transform_.transform.translation.x,
-    current_map_to_odom_transform_.transform.translation.y,
-    current_map_to_odom_transform_.transform.translation.z);
-  Eigen::Vector3d last_traslation = Eigen::Vector3d(
-    last_map_to_odom_transform_.transform.translation.x,
-    last_map_to_odom_transform_.transform.translation.y,
-    last_map_to_odom_transform_.transform.translation.z);
-  double current_yaw = as2::frame::getYawFromQuaternion(
-    current_map_to_odom_transform_.transform.rotation);
-  double last_yaw =
-    as2::frame::getYawFromQuaternion(last_map_to_odom_transform_.transform.rotation);
-  Eigen::Vector3d traslation_error =
-    Eigen::Vector3d(
-    current_traslation[0] - last_traslation[0],
-    current_traslation[1] - last_traslation[1],
-    current_traslation[2] - last_traslation[2]);
-  if (traslation_error.norm() > transform_threshold_) {
-    return true;
-  }
-  // if (as2::frame::angleMinError(current_yaw, last_yaw) > 0.5) {
-  //   return true;
-  // }
-  return false;
+
+  debug_path_pub_->publish(path_msg);
 }
 
-/** Debug functions **/
-
-void DynamicPolynomialTrajectoryGenerator::plotTrajectory()
+void GeneratePolynomialTrajectoryBehavior::publishWaypoints()
 {
-  // launch async plot
-  if (plot_thread_.joinable()) {
-    plot_thread_.join();
+  if (!debug_waypoints_pub_) {
+    return;
   }
-  plot_thread_ = std::thread(
-    &DynamicPolynomialTrajectoryGenerator::plotTrajectoryThread, this);
+
+  visualization_msgs::msg::MarkerArray msg;
+  const auto stamp = this->now();
+
+  // Clear any markers left over from a previous publish so that, when the
+  // pending list shrinks (e.g. after on_modify drops the already-consumed
+  // waypoints from goal_.path), the stale spheres with high ids don't
+  // remain visible in RViz forever.
+  visualization_msgs::msg::Marker clear;
+  clear.header.frame_id = desired_frame_id_;
+  clear.header.stamp = stamp;
+  clear.action = visualization_msgs::msg::Marker::DELETEALL;
+  msg.markers.emplace_back(clear);
+
+  visualization_msgs::msg::Marker marker;
+  marker.header.frame_id = desired_frame_id_;
+  marker.header.stamp = stamp;
+  marker.type = visualization_msgs::msg::Marker::SPHERE;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.color.r = 1.0f;
+  marker.color.a = 1.0f;
+  marker.scale.x = marker.scale.y = marker.scale.z = 0.1;
+
+  int id = 0;
+  for (const auto & wp : goal_.path) {
+    marker.id = id++;
+    marker.pose.position = wp.pose.pose.position;
+    msg.markers.emplace_back(marker);
+  }
+  debug_waypoints_pub_->publish(msg);
 }
 
-void DynamicPolynomialTrajectoryGenerator::plotTrajectoryThread()
+void GeneratePolynomialTrajectoryBehavior::publishEvaluatedPoint(
+  const as2_msgs::msg::TrajectoryPoint & point, bool is_last_in_horizon)
 {
-  rclcpp::Time time_stamp;
-  if (time_debug_.has_value()) {
-    time_stamp = time_debug_.value();
-  } else {
-    time_stamp = this->now();
+  visualization_msgs::msg::Marker marker;
+  marker.header.frame_id = desired_frame_id_;
+  marker.header.stamp = this->now();
+  marker.type = visualization_msgs::msg::Marker::SPHERE;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.color.a = 1.0f;
+  marker.scale.x = marker.scale.y = marker.scale.z = 0.1;
+  marker.pose.position.x = point.position.x;
+  marker.pose.position.y = point.position.y;
+  marker.pose.position.z = point.position.z;
+
+  if (!is_last_in_horizon && debug_ref_point_pub_) {
+    marker.color.b = 1.0f;
+    debug_ref_point_pub_->publish(marker);
+  } else if (is_last_in_horizon && debug_end_ref_point_pub_) {
+    marker.color.g = 1.0f;
+    debug_end_ref_point_pub_->publish(marker);
   }
-
-  if (debug_path_pub_ != nullptr) {
-    nav_msgs::msg::Path path_msg;
-    const float step = 0.2;
-    const float max_time = trajectory_generator_->getMaxTime();
-    const float min_time = trajectory_generator_->getMinTime();
-    dynamic_traj_generator::References refs;
-    const int n_measures = (max_time - min_time) / step;
-    // path_msg.poses.reserve(n_measures);
-    for (float time = min_time; time <= max_time; time += step) {
-      geometry_msgs::msg::PoseStamped pose_msg;
-      pose_msg.header.frame_id = desired_frame_id_;
-      pose_msg.header.stamp = time_stamp;
-      trajectory_generator_->evaluateTrajectory(time, refs, true, true);
-      pose_msg.pose.position.x = refs.position.x();
-      pose_msg.pose.position.y = refs.position.y();
-      pose_msg.pose.position.z = refs.position.z();
-      path_msg.poses.emplace_back(pose_msg);
-    }
-    path_msg.header.frame_id = desired_frame_id_;
-    path_msg.header.stamp = time_stamp;
-
-    RCLCPP_INFO(this->get_logger(), "DEBUG: Plotting trajectory");
-    debug_path_pub_->publish(path_msg);
-  }
-
-  // Plot waypoints
-  if (debug_waypoints_pub_ != nullptr) {
-    visualization_msgs::msg::MarkerArray waypoints_msg;
-    visualization_msgs::msg::Marker waypoint_msg;
-    waypoint_msg.header.frame_id = desired_frame_id_;
-    waypoint_msg.header.stamp = time_stamp;
-    waypoint_msg.type = visualization_msgs::msg::Marker::SPHERE;
-    waypoint_msg.action = visualization_msgs::msg::Marker::ADD;
-    waypoint_msg.color.r = 1.0f;
-    waypoint_msg.color.g = 0.0f;
-    waypoint_msg.color.b = 0.0f;
-    waypoint_msg.color.a = 1.0f;
-    waypoint_msg.scale.x = 0.1;
-    waypoint_msg.scale.y = 0.1;
-    waypoint_msg.scale.z = 0.1;
-
-    dynamic_traj_generator::DynamicWaypoint::Deque waypoints_to_set;
-    std::shared_ptr<const as2_msgs::action::GeneratePolynomialTrajectory::Goal> goal;
-    goal = std::make_shared<const as2_msgs::action::GeneratePolynomialTrajectory::Goal>(goal_);
-    if (!goalToDynamicWaypoint(goal, waypoints_to_set)) {return;}
-
-    int id = 0;
-    for (dynamic_traj_generator::DynamicWaypoint wp : waypoints_to_set) {
-      waypoint_msg.pose.position.x = wp.getCurrentPosition().x();
-      waypoint_msg.pose.position.y = wp.getCurrentPosition().y();
-      waypoint_msg.pose.position.z = wp.getCurrentPosition().z();
-      waypoint_msg.id = id++;
-      waypoints_msg.markers.emplace_back(waypoint_msg);
-      RCLCPP_DEBUG(
-        this->get_logger(),
-        "Waypoint ID: %s, position : [%f, %f, %f]", wp.getName().c_str(),
-        waypoint_msg.pose.position.x, waypoint_msg.pose.position.y,
-        waypoint_msg.pose.position.z);
-    }
-    debug_waypoints_pub_->publish(waypoints_msg);
-  }
-}
-
-void DynamicPolynomialTrajectoryGenerator::plotRefTrajPoint()
-{
-  visualization_msgs::msg::Marker point_msg;
-
-  point_msg.header.frame_id = desired_frame_id_;
-  point_msg.header.stamp = this->now();
-  point_msg.type = visualization_msgs::msg::Marker::SPHERE;
-  point_msg.action = visualization_msgs::msg::Marker::ADD;
-
-  // Blue
-  point_msg.color.r = 0.0f;
-  point_msg.color.g = 0.0f;
-  point_msg.color.b = 1.0f;
-  point_msg.color.a = 1.0f;
-
-  point_msg.scale.x = 0.1;
-  point_msg.scale.y = 0.1;
-  point_msg.scale.z = 0.1;
-
-  if (debug_ref_point_pub_ != nullptr) {
-    point_msg.pose.position.x = trajectory_command_.setpoints[0].position.x;
-    point_msg.pose.position.y = trajectory_command_.setpoints[0].position.y;
-    point_msg.pose.position.z = trajectory_command_.setpoints[0].position.z;
-
-    debug_ref_point_pub_->publish(point_msg);
-  }
-
-  if (debug_end_ref_point_pub_ != nullptr) {
-    // If more than one setpoint, plot the last one
-    if (trajectory_command_.setpoints.size() < 2) {
-      return;
-    }
-    // Green
-    point_msg.color.g = 1.0f;
-    point_msg.color.b = 0.0f;
-    point_msg.pose.position.x =
-      trajectory_command_.setpoints[trajectory_command_.setpoints.size() - 1].position.x;
-    point_msg.pose.position.y =
-      trajectory_command_.setpoints[trajectory_command_.setpoints.size() - 1].position.y;
-    point_msg.pose.position.z =
-      trajectory_command_.setpoints[trajectory_command_.setpoints.size() - 1].position.z;
-    debug_end_ref_point_pub_->publish(point_msg);
-  }
-}
-
-/** Auxiliar Functions **/
-void generateDynamicPoint(
-  const as2_msgs::msg::PoseStampedWithID & msg,
-  dynamic_traj_generator::DynamicWaypoint & dynamic_point)
-{
-  dynamic_point.setName(msg.id);
-  Eigen::Vector3d position;
-  position.x() = msg.pose.pose.position.x;
-  position.y() = msg.pose.pose.position.y;
-  position.z() = msg.pose.pose.position.z;
-  dynamic_point.resetWaypoint(position);
 }
 
 #include "rclcpp_components/register_node_macro.hpp"
-
-// Register the component with class_loader.
-// This acts as a sort of entry point, allowing the component to be discoverable
-// when its library is being loaded into a running process.
-RCLCPP_COMPONENTS_REGISTER_NODE(DynamicPolynomialTrajectoryGenerator)
+RCLCPP_COMPONENTS_REGISTER_NODE(GeneratePolynomialTrajectoryBehavior)

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/CMakeLists.txt
@@ -1,40 +1,79 @@
-# Test
-file(GLOB TEST_SOURCE "*_test.cpp")
+# Behavior-level tests: bring up the wrapper node with the default plugin
+# and verify it constructs without throwing.
+file(GLOB GTEST_SOURCES "*_gtest.cpp")
 
-if(TEST_SOURCE)
-foreach(TEST_FILE ${TEST_SOURCE})
-    get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+if(GTEST_SOURCES)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
 
-    add_executable(${PROJECT_NAME}_${TEST_NAME} ${TEST_FILE})
-    ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME}
-        trajectory_generator_component
-        dynamic_trajectory_generator
-        mav_trajectory_generation)
-
-endforeach()
-endif()
-
-# GTest
-file(GLOB GTEST_SOURCE "*_gtest.cpp")
-
-if(GTEST_SOURCE)
-find_package(ament_cmake_gtest REQUIRED)
-find_package(ament_index_cpp REQUIRED)
-
-foreach(TEST_SOURCE ${GTEST_SOURCE})
+  foreach(TEST_SOURCE ${GTEST_SOURCES})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
-    ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-
+    ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME}
+      ${PROJECT_DEPENDENCIES}
+      ${BEHAVIOR_DEPENDENCIES})
     target_link_libraries(${PROJECT_NAME}_${TEST_NAME}
-        ament_index_cpp::ament_index_cpp
-        gtest_main
-        trajectory_generator_component
-        dynamic_trajectory_generator
-        mav_trajectory_generation)
+      ament_index_cpp::ament_index_cpp
+      gtest_main
+      ${BEHAVIOR_NAME}
+      ${BEHAVIOR_NAME}_plugin_base)
+  endforeach()
+endif()
 
-endforeach()
+# Integration tests: single-process executables that boot the behavior + a
+# mock support node + an action client and exercise pause/resume/modify
+# scenarios end-to-end. Parametrized internally over every pluginlib-declared
+# trajectory generator plugin.
+file(GLOB INTEGRATION_TEST_SOURCES "*_test.cpp")
+
+if(INTEGRATION_TEST_SOURCES)
+  find_package(GTest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
+  find_package(tf2_ros REQUIRED)
+
+  foreach(TEST_SOURCE ${INTEGRATION_TEST_SOURCES})
+    get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+
+    add_executable(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
+    ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME}
+      ${PROJECT_DEPENDENCIES}
+      ${BEHAVIOR_DEPENDENCIES}
+      tf2_ros)
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME}
+      ament_index_cpp::ament_index_cpp
+      GTest::gtest
+      ${BEHAVIOR_NAME}
+      ${BEHAVIOR_NAME}_plugin_base)
+
+    add_test(
+      NAME ${PROJECT_NAME}_${TEST_NAME}
+      COMMAND ${PROJECT_NAME}_${TEST_NAME})
+    set_tests_properties(${PROJECT_NAME}_${TEST_NAME}
+      PROPERTIES TIMEOUT 120 LABELS "integration")
+  endforeach()
+endif()
+
+# Google-Benchmark comparative suite: one executable that loads every
+# plugin via pluginlib and times generateTrajectory / updateWaypoints /
+# evaluate as a function of the mission waypoint count. Not registered as
+# a CTest target; the user runs it manually from build/ to choose a
+# backend. The dependency is intentionally optional — if Google Benchmark
+# is not installed, the rest of the package builds unchanged.
+find_package(benchmark QUIET)
+if(benchmark_FOUND)
+  set(BM_NAME ${PROJECT_NAME}_${BEHAVIOR_NAME}_benchmark)
+  add_executable(${BM_NAME}
+    generate_polynomial_trajectory_behavior_benchmark.cpp)
+  target_include_directories(${BM_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/common)
+  ament_target_dependencies(${BM_NAME}
+    ${PROJECT_DEPENDENCIES}
+    ${BEHAVIOR_DEPENDENCIES})
+  target_link_libraries(${BM_NAME}
+    benchmark::benchmark
+    ${BEHAVIOR_NAME}_plugin_base)
+else()
+  message(STATUS
+    "Google Benchmark not found; skipping comparative benchmark target.")
 endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/behavior_test.py
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/behavior_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Universidad Politécnica de Madrid
+# Copyright 2026 Universidad Politécnica de Madrid
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -27,64 +27,389 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+r"""
+Manual orchestration script for the polynomial trajectory generator behavior.
 
-"""Test trajectory generator action client."""
+Sends a configurable zigzag path goal and exercises the full behavior
+lifecycle (start_on_paused, modify, pause/resume, stop) by reacting to the
+action feedback. Not an automated CI test — invoked by hand against a
+running behavior:
 
-__authors__ = 'CVAR'
-__copyright__ = 'Copyright (c) 2024 Universidad Politécnica de Madrid'
+    ros2 launch as2_behaviors_trajectory_generation \
+        generate_polynomial_trajectory_behavior_launch.py namespace:=drone0
+
+    python3 behavior_test.py
+
+Tweak the configuration block at the top of this file to choose the path
+shape, the YawMode, and which lifecycle triggers to exercise.
+
+Requires the aerostack2 environment to be sourced (uses
+``as2_python_api.behavior_actions.behavior_handler.BehaviorHandler``).
+"""
+
+__authors__ = 'Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2026 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
 
-from as2_msgs.action import TrajectoryGenerator
-from as2_msgs.msg import PoseWithID, YawMode
+import sys
+import threading
+import time
+from typing import Optional
+
+from as2_msgs.action import GeneratePolynomialTrajectory
+from as2_msgs.msg import BehaviorStatus, PoseStampedWithID, YawMode
+from as2_python_api.behavior_actions.behavior_handler import BehaviorHandler
+
 import rclpy
-from rclpy.action import ActionClient
+from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
-from rclpy.parameter import Parameter
 
 
-class TrajectoryGeneratorClient(Node):
+# ───────────────────────────── Configuration ────────────────────────────────
+# Connection
+NAMESPACE = 'drone0'
+FRAME_ID = 'earth'
 
-    def __init__(self):
-        super().__init__('trajectory_generator_action_client')
-        self.param_use_sim_time = Parameter(
-            'use_sim_time', Parameter.Type.BOOL, False)
-        self.set_parameters([self.param_use_sim_time])
-        self._action_client = ActionClient(
-            self, TrajectoryGenerator, '/drone_sim_0/TrajectoryGeneratorBehavior')
+# Goal: motion params.
+# YAW_MODE accepts: KEEP_YAW | PATH_FACING | FIXED_YAW | YAW_FROM_TOPIC |
+# YAW_FROM_ORIENTATION | YAW_TO_FRAME | FACE_REFERENCE.
+MAX_SPEED = 1.0                  # m/s
+YAW_MODE = YawMode.KEEP_YAW
+YAW_ANGLE = 0.0                  # rad, only used when YAW_MODE == FIXED_YAW
+# START_ON_PAUSED True: behavior plans the trajectory and stays PAUSED
+# until the first resume().
+START_ON_PAUSED = False
 
-    def send_goal(self):
-        goal = TrajectoryGenerator.Goal()
-        goal.header.frame_id = 'drone_sim_0/odom'
-        goal.header.stamp = self.get_clock().now().to_msg()
-        goal.max_speed = 1.0
-        yaw_mode = YawMode()
-        yaw_mode.mode = YawMode.FIXED_YAW
-        yaw_mode.angle = 0.0
-        goal.yaw = yaw_mode
+# Zigzag path (initial goal)
+ZZ_N_SEGMENTS = 10                # number of segments along +X
+ZZ_SEGMENT_LEN = 2.0             # m per segment in X
+ZZ_AMPLITUDE = 2.0               # m peak-to-peak in Y
+ZZ_ALTITUDE = 1.0                # m, constant Z
+ZZ_X0 = 0.0                      # m, X start
+ZZ_Y0 = 0.0                      # m, Y center (zigzag oscillates around this)
+ZZ_ID_PREFIX = 'wp'
 
-        # pose0 = PoseWithID()
-        # pose0.id = '0'
-        # pose0.pose.position.x = 0.0
-        # pose0.pose.position.y = 0.0
-        # pose0.pose.position.z = 1.0
-        # goal.path.append(pose0)
+# Lifecycle triggers (set to None to disable)
+# "after N waypoints" means: trigger when feedback.next_waypoint_id matches
+# the id of path[N], i.e. the first N waypoints have been consumed.
+MODIFY_AFTER_N_WAYPOINTS: Optional[int] = None
+PAUSE_AFTER_N_WAYPOINTS: Optional[int] = None
+RESUME_AFTER_SECONDS: float = 5.0   # only honored if PAUSE_AFTER_N_WAYPOINTS != None
+STOP_AFTER_N_WAYPOINTS: Optional[int] = None
 
-        pose1 = PoseWithID()
-        pose1.id = '1'
-        pose1.pose.position.x = 0.0
-        pose1.pose.position.y = 0.0
-        pose1.pose.position.z = 2.0
-        goal.path.append(pose1)
+# Auto-resume of the initial start_on_paused (set to None to leave the
+# resume to a manual ros2 service call).
+RESUME_INITIAL_PAUSE_AFTER_S: Optional[float] = 5.0
 
-        self._action_client.wait_for_server()
-        return self._action_client.send_goal_async(goal)
+# Modify path
+#
+# The behavior's on_modify merges the new path into the pending list:
+#   - waypoints whose IDs match a pending one have their pose UPDATED;
+#   - waypoints with new IDs are APPENDED at the end of the pending list.
+# It does NOT replace the pending list. Therefore, to actually deform the
+# trajectory that the drone is currently executing you must reuse the
+# pending IDs.
+#
+# MOD_OVERRIDE_PENDING == True (recommended): the modify path reuses the
+#     original pending IDs (path[MODIFY_AFTER_N_WAYPOINTS..end]) so the
+#     remaining trajectory is reshaped in place. The geometry below
+#     (segment length / amplitude / altitude) is applied to all of them
+#     starting from the trigger waypoint position.
+# MOD_OVERRIDE_PENDING == False: the modify path uses fresh IDs
+#     (MOD_ID_PREFIX) so it is appended after the original path. The drone
+#     finishes the original zigzag first and only then visits the new
+#     waypoints. Use this to test the append branch of on_modify.
+MOD_OVERRIDE_PENDING = True
+MOD_SEGMENT_LEN = 2.0
+MOD_AMPLITUDE = 2.0             # peak-to-peak in Y
+MOD_ALTITUDE = 1.0               # m
+MOD_N_SEGMENTS = 4               # only used when MOD_OVERRIDE_PENDING is False
+MOD_ID_PREFIX = 'mod'            # only used when MOD_OVERRIDE_PENDING is False
+
+# Fail-safe / timing
+SERVER_TIMEOUT_S = 5.0
+LOOP_PERIOD_S = 0.05
+GLOBAL_TIMEOUT_S = 120.0         # hard cap on the orchestration loop
+# ───────────────────────────────────────────────────────────────────────────
 
 
-def main(args=None):
-    rclpy.init(args=args)
-    action_client = TrajectoryGeneratorClient()
-    future = action_client.send_goal()
-    rclpy.spin_until_future_complete(action_client, future)
+def build_zigzag_path(
+    n_segments: int,
+    segment_length: float,
+    amplitude: float,
+    altitude: float,
+    frame_id: str,
+    id_prefix: str,
+    x0: float = 0.0,
+    y0: float = 0.0,
+) -> list:
+    """
+    Build a zigzag path along +X alternating Y between ±amplitude/2.
+
+    Returns a list of PoseStampedWithID waypoints with unique string IDs of
+    the form ``f"{id_prefix}_{i:03d}"``. The first waypoint is at
+    ``(x0, y0, altitude)`` (no Y offset) so the drone always starts with a
+    forward-only segment.
+    """
+    half = amplitude / 2.0
+    path = []
+    for i in range(n_segments + 1):
+        wp = PoseStampedWithID()
+        wp.id = f'{id_prefix}_{i:03d}'
+        wp.pose.header.frame_id = frame_id
+        wp.pose.pose.position.x = x0 + i * segment_length
+        if i == 0:
+            wp.pose.pose.position.y = y0
+        else:
+            wp.pose.pose.position.y = y0 + (half if (i % 2) == 1 else -half)
+        wp.pose.pose.position.z = altitude
+        wp.pose.pose.orientation.w = 1.0
+        path.append(wp)
+    return path
+
+
+def build_goal(
+    path: list,
+    max_speed: float,
+    yaw_mode: int,
+    yaw_angle: float,
+    start_on_paused: bool,
+    stamp,
+) -> GeneratePolynomialTrajectory.Goal:
+    """Assemble a GeneratePolynomialTrajectory goal from path + motion params."""
+    goal = GeneratePolynomialTrajectory.Goal()
+    goal.stamp = stamp
+    goal.max_speed = float(max_speed)
+    goal.start_on_paused = bool(start_on_paused)
+
+    yaw = YawMode()
+    yaw.mode = int(yaw_mode)
+    yaw.angle = float(yaw_angle)
+    goal.yaw = yaw
+
+    goal.path = list(path)
+    return goal
+
+
+def trigger_id(path: list, n: Optional[int]) -> Optional[str]:
+    """Return the id of path[n] if n is in range, else None."""
+    if n is None or n < 0 or n >= len(path):
+        return None
+    return path[n].id
+
+
+class TrajectoryGeneratorTester(Node):
+    """Drives the polynomial trajectory behavior through a configurable scenario."""
+
+    def __init__(self, namespace: str):
+        """Create the node and the BehaviorHandler bound to the behavior."""
+        super().__init__('trajectory_generator_tester', namespace=namespace)
+        BehaviorHandler.TIMEOUT = SERVER_TIMEOUT_S
+        self._handler = BehaviorHandler(
+            self, GeneratePolynomialTrajectory, 'TrajectoryGeneratorBehavior')
+
+    def destroy(self) -> None:
+        """Release behavior clients before destroying the node."""
+        try:
+            self._handler.destroy()
+        finally:
+            self.destroy_node()
+
+    def run(self) -> bool:
+        """Execute the configured scenario. Returns True on overall success."""
+        log = self.get_logger()
+
+        path = build_zigzag_path(
+            n_segments=ZZ_N_SEGMENTS,
+            segment_length=ZZ_SEGMENT_LEN,
+            amplitude=ZZ_AMPLITUDE,
+            altitude=ZZ_ALTITUDE,
+            frame_id=FRAME_ID,
+            id_prefix=ZZ_ID_PREFIX,
+            x0=ZZ_X0,
+            y0=ZZ_Y0,
+        )
+        log.info(f'Zigzag path: {len(path)} waypoints, ids '
+                 f'[{path[0].id}..{path[-1].id}]')
+
+        modify_id = trigger_id(path, MODIFY_AFTER_N_WAYPOINTS)
+        pause_id = trigger_id(path, PAUSE_AFTER_N_WAYPOINTS)
+        stop_id = trigger_id(path, STOP_AFTER_N_WAYPOINTS)
+        log.info(f'Triggers: modify@{modify_id} pause@{pause_id} '
+                 f'(resume after {RESUME_AFTER_SECONDS}s) stop@{stop_id}')
+
+        goal = build_goal(
+            path=path,
+            max_speed=MAX_SPEED,
+            yaw_mode=YAW_MODE,
+            yaw_angle=YAW_ANGLE,
+            start_on_paused=START_ON_PAUSED,
+            stamp=self.get_clock().now().to_msg(),
+        )
+
+        try:
+            self._handler.start(goal, wait_result=False)
+        except BehaviorHandler.GoalRejected as err:
+            log.error(f'Goal rejected: {err}')
+            return False
+        log.info('Goal accepted, entering orchestration loop')
+
+        # Build the modify goal lazily.
+        #
+        # When MOD_OVERRIDE_PENDING is True we reshape the pending portion of
+        # the original path: we generate a zigzag with as many points as
+        # pending waypoints, anchored at the trigger waypoint position, and
+        # rename the IDs so they match the original pending IDs. on_modify
+        # will then update each pending waypoint pose in place.
+        #
+        # When False we generate an independent zigzag with fresh IDs that
+        # the behavior will append after the original path.
+        def make_modify_goal() -> GeneratePolynomialTrajectory.Goal:
+            if MOD_OVERRIDE_PENDING and MODIFY_AFTER_N_WAYPOINTS is not None:
+                trigger_idx = MODIFY_AFTER_N_WAYPOINTS
+                pending = path[trigger_idx:]
+                anchor = pending[0].pose.pose.position
+                mod_path = build_zigzag_path(
+                    n_segments=len(pending) - 1,
+                    segment_length=MOD_SEGMENT_LEN,
+                    amplitude=MOD_AMPLITUDE,
+                    altitude=MOD_ALTITUDE,
+                    frame_id=FRAME_ID,
+                    id_prefix='__tmp',
+                    x0=anchor.x,
+                    y0=anchor.y,
+                )
+                for new_wp, orig_wp in zip(mod_path, pending):
+                    new_wp.id = orig_wp.id
+            else:
+                anchor = path[-1].pose.pose.position
+                mod_path = build_zigzag_path(
+                    n_segments=MOD_N_SEGMENTS,
+                    segment_length=MOD_SEGMENT_LEN,
+                    amplitude=MOD_AMPLITUDE,
+                    altitude=MOD_ALTITUDE,
+                    frame_id=FRAME_ID,
+                    id_prefix=MOD_ID_PREFIX,
+                    x0=anchor.x,
+                    y0=anchor.y,
+                )
+            return build_goal(
+                path=mod_path,
+                max_speed=MAX_SPEED,
+                yaw_mode=YAW_MODE,
+                yaw_angle=YAW_ANGLE,
+                start_on_paused=False,
+                stamp=self.get_clock().now().to_msg(),
+            )
+
+        # Latches and timing
+        modify_done = modify_id is None
+        pause_done = pause_id is None
+        resume_done = pause_id is None
+        stop_done = stop_id is None
+        initial_resume_done = (
+            not START_ON_PAUSED or RESUME_INITIAL_PAUSE_AFTER_S is None)
+
+        t_start = time.monotonic()
+        t_resume_at: Optional[float] = None
+        t_initial_resume_at: Optional[float] = (
+            t_start + RESUME_INITIAL_PAUSE_AFTER_S
+            if not initial_resume_done else None)
+
+        last_seen_id = ''
+
+        while True:
+            now = time.monotonic()
+            if now - t_start > GLOBAL_TIMEOUT_S:
+                log.error(f'Global timeout ({GLOBAL_TIMEOUT_S}s) hit, stopping')
+                self._handler.stop()
+                return False
+
+            status = self._handler.status
+            if status == BehaviorStatus.IDLE:
+                # Behavior finished (success, abort, or stopped externally).
+                break
+
+            # Auto-resume the initial start_on_paused once the elapsed time has passed.
+            if (not initial_resume_done
+                    and t_initial_resume_at is not None
+                    and now >= t_initial_resume_at):
+                log.info('Auto-resuming initial start_on_paused')
+                self._handler.resume(wait_result=False)
+                initial_resume_done = True
+
+            fb = self._handler.feedback
+            if fb is not None and fb.next_waypoint_id != last_seen_id:
+                log.info(f'feedback: next={fb.next_waypoint_id} '
+                         f'remaining={fb.remaining_waypoints} '
+                         f'status={status}')
+                last_seen_id = fb.next_waypoint_id
+
+            if fb is not None:
+                if not modify_done and fb.next_waypoint_id == modify_id:
+                    log.info(f'Triggering modify at {fb.next_waypoint_id}')
+                    accepted = self._handler.modify(make_modify_goal())
+                    log.info(f'Modify accepted={accepted}')
+                    modify_done = True
+
+                if not pause_done and fb.next_waypoint_id == pause_id:
+                    log.info(f'Triggering pause at {fb.next_waypoint_id}')
+                    ok = self._handler.pause()
+                    log.info(f'Pause success={ok}')
+                    pause_done = True
+                    t_resume_at = time.monotonic() + RESUME_AFTER_SECONDS
+
+                if not stop_done and fb.next_waypoint_id == stop_id:
+                    log.info(f'Triggering stop at {fb.next_waypoint_id}')
+                    ok = self._handler.stop()
+                    log.info(f'Stop success={ok}')
+                    stop_done = True
+                    return bool(ok)
+
+            if (pause_done and not resume_done
+                    and t_resume_at is not None
+                    and time.monotonic() >= t_resume_at):
+                log.info(f'Triggering resume after {RESUME_AFTER_SECONDS}s')
+                ok = self._handler.resume(wait_result=False)
+                log.info(f'Resume success={ok}')
+                resume_done = True
+
+            time.sleep(LOOP_PERIOD_S)
+
+        # Behavior went IDLE on its own (completed or failed). Pull the result.
+        try:
+            success = self._handler.wait_to_result()
+        except BehaviorHandler.ResultUnknown as err:
+            log.error(f'Result unknown: {err}')
+            return False
+        log.info(f'Trajectory generator result: success={success}')
+        return bool(success)
+
+
+def main():
+    """Spin the node in a background thread and run the orchestration scenario."""
+    rclpy.init(args=sys.argv)
+    try:
+        node = TrajectoryGeneratorTester(NAMESPACE)
+    except BehaviorHandler.BehaviorNotAvailable as err:
+        print(f'Behavior not available: {err}', file=sys.stderr)
+        rclpy.shutdown()
+        sys.exit(1)
+
+    executor = SingleThreadedExecutor()
+    executor.add_node(node)
+    spin_thread = threading.Thread(target=executor.spin, daemon=True)
+    spin_thread.start()
+
+    ok = False
+    try:
+        ok = node.run()
+    finally:
+        executor.shutdown()
+        node.destroy()
+        rclpy.shutdown()
+        spin_thread.join(timeout=1.0)
+    sys.exit(0 if ok else 1)
 
 
 if __name__ == '__main__':

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/common/generate_polynomial_trajectory_benchmark_common.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/common/generate_polynomial_trajectory_benchmark_common.hpp
@@ -1,0 +1,422 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file generate_polynomial_trajectory_benchmark_common.hpp
+ *
+ * @brief Shared helpers for Google-Benchmark suites that compare polynomial
+ * trajectory generator plugins on the public plugin API
+ * (generateTrajectory / updateWaypoints / evaluate), parametrized over the
+ * number of mission waypoints.
+ *
+ * Header-only so both the comparative root binary and the per-plugin
+ * standalone binaries can include it without an extra link target.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#ifndef GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__BENCHMARK_COMMON_HPP_  // NOLINT
+#define GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__BENCHMARK_COMMON_HPP_  // NOLINT
+
+#include <benchmark/benchmark.h>
+#include <rcutils/logging.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "as2_core/node.hpp"
+#include "as2_msgs/msg/pose_stamped_with_id.hpp"
+#include "as2_msgs/msg/trajectory_point.hpp"
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+namespace generate_polynomial_trajectory_benchmark
+{
+
+using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase;
+
+// Synthetic mission constants used by all benchmarks. Centralized so a
+// reader does not need to chase magic numbers across helpers.
+constexpr double kBenchmarkRadius = 2.0;       // [m] helix radius
+constexpr double kBenchmarkPitchZ = 0.5;       // [m] vertical step per waypoint
+constexpr double kBenchmarkBaseZ = 1.0;        // [m] starting altitude
+constexpr double kBenchmarkMaxSpeed = 1.0;     // [m/s] cruise speed
+
+// Per-benchmark execution budget. Google Benchmark adapts the iteration
+// count so each registered benchmark runs for at least this long before
+// reporting; sub-microsecond calls still get a stable estimate, while
+// multi-millisecond calls cap at one iteration. Override on the command
+// line with --benchmark_min_time=<seconds>s.
+constexpr double kBenchmarkMinTimeSeconds = 0.1;
+
+/**
+ * @brief Raise the default rclcpp log severity threshold for the running
+ * process so per-iteration INFO logs (e.g. the parameter dumps emitted by
+ * the plugin base on every getParameter call) do not flood the benchmark
+ * output. WARN keeps genuine warnings/errors visible.
+ *
+ * Note: this only affects rclcpp/rcutils-based logging. Backends that
+ * write directly to stdout/stderr (e.g. dynamic_trajectory_generator) are
+ * not routed through rosout — for those, see ScopedStdoutSink below.
+ *
+ * @param severity One of RCUTILS_LOG_SEVERITY_*.
+ */
+inline void silenceRosLogging(int severity = RCUTILS_LOG_SEVERITY_WARN)
+{
+  rcutils_logging_set_default_logger_level(severity);
+}
+
+/**
+ * @brief RAII guard that redirects file descriptor 1 (stdout) to /dev/null
+ * for its lifetime, restoring the original target on destruction.
+ *
+ * Used inside each benchmark lambda to suppress non-rosout chatter from
+ * vendored backends that bypass rclcpp and write directly to stdout
+ * (printf / std::cout). Google Benchmark prints the final result row
+ * AFTER the lambda returns, so the table itself stays visible while the
+ * per-iteration backend chatter is dropped.
+ *
+ * Linux/POSIX-only — relies on dup/dup2/open. Not thread-safe; benchmarks
+ * here are single-threaded so this is fine.
+ */
+class ScopedStdoutSink
+{
+public:
+  ScopedStdoutSink()
+  {
+    std::fflush(stdout);
+    saved_fd_ = ::dup(STDOUT_FILENO);
+    null_fd_ = ::open("/dev/null", O_WRONLY);
+    if (null_fd_ >= 0) {
+      ::dup2(null_fd_, STDOUT_FILENO);
+    }
+  }
+
+  ~ScopedStdoutSink()
+  {
+    std::fflush(stdout);
+    if (saved_fd_ >= 0) {
+      ::dup2(saved_fd_, STDOUT_FILENO);
+      ::close(saved_fd_);
+    }
+    if (null_fd_ >= 0) {
+      ::close(null_fd_);
+    }
+  }
+
+  ScopedStdoutSink(const ScopedStdoutSink &) = delete;
+  ScopedStdoutSink & operator=(const ScopedStdoutSink &) = delete;
+
+private:
+  int saved_fd_{-1};
+  int null_fd_{-1};
+};
+
+inline as2_msgs::msg::PoseStampedWithID makeWaypoint(
+  const std::string & id, double x, double y, double z)
+{
+  as2_msgs::msg::PoseStampedWithID wp;
+  wp.id = id;
+  wp.pose.header.frame_id = "earth";
+  wp.pose.pose.position.x = x;
+  wp.pose.pose.position.y = y;
+  wp.pose.pose.position.z = z;
+  wp.pose.pose.orientation.w = 1.0;
+  return wp;
+}
+
+inline geometry_msgs::msg::PoseStamped makePose(double x, double y, double z)
+{
+  geometry_msgs::msg::PoseStamped p;
+  p.header.frame_id = "earth";
+  p.pose.position.x = x;
+  p.pose.position.y = y;
+  p.pose.position.z = z;
+  p.pose.orientation.w = 1.0;
+  return p;
+}
+
+/**
+ * @brief Build N synthetic waypoints distributed along a 3D helix.
+ *
+ * The helix has constant radius and constant vertical pitch per waypoint,
+ * with one full revolution every N waypoints. Increasing N therefore keeps
+ * total path length bounded while adding intermediate corners — which is
+ * exactly the dimension we want to scale when benchmarking how plugins
+ * handle larger waypoint sets.
+ *
+ * @param n Number of waypoints (clamped to >= 1 internally for the angular
+ *          division; an empty vector is returned when n == 0).
+ * @param radius Helix radius in metres.
+ * @param pitch_z Vertical step between consecutive waypoints in metres.
+ * @param x_offset Optional translation along x; used by updateWaypoints
+ *                 benchmarks to feed a slightly displaced replacement set.
+ */
+inline std::vector<as2_msgs::msg::PoseStampedWithID>
+generateHelixWaypoints(
+  std::size_t n,
+  double radius = kBenchmarkRadius,
+  double pitch_z = kBenchmarkPitchZ,
+  double x_offset = 0.0)
+{
+  std::vector<as2_msgs::msg::PoseStampedWithID> wps;
+  wps.reserve(n);
+  const double two_pi = 2.0 * M_PI;
+  const std::size_t denom = std::max<std::size_t>(n, 1U);
+  for (std::size_t i = 0; i < n; ++i) {
+    const double theta = two_pi * static_cast<double>(i + 1) /
+      static_cast<double>(denom);
+    const double x = x_offset + radius * std::cos(theta);
+    const double y = radius * std::sin(theta);
+    const double z = kBenchmarkBaseZ +
+      static_cast<double>(i + 1) * pitch_z;
+    char id[32];
+    std::snprintf(id, sizeof(id), "waypoint_%03zu", i);
+    wps.push_back(makeWaypoint(id, x, y, z));
+  }
+  return wps;
+}
+
+struct PluginFixture
+{
+  std::shared_ptr<as2::Node> node;
+  std::shared_ptr<pluginlib::ClassLoader<PluginBase>> loader;
+  std::shared_ptr<PluginBase> plugin;
+};
+
+/**
+ * @brief Instantiate an as2::Node, load a plugin via pluginlib, and
+ * initialize it. Vehicle state is set to the canonical origin pose with
+ * zero twist so generateTrajectory has a deterministic start point.
+ */
+inline PluginFixture makePluginFixture(
+  const std::string & plugin_name,
+  const std::string & node_name,
+  const std::vector<rclcpp::Parameter> & parameter_overrides = {})
+{
+  PluginFixture f;
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(parameter_overrides);
+  f.node = std::make_shared<as2::Node>(node_name, options);
+  f.loader = std::make_shared<pluginlib::ClassLoader<PluginBase>>(
+    "as2_behaviors_trajectory_generation",
+    "generate_polynomial_trajectory_behavior_plugin_base::"
+    "GeneratePolynomialTrajectoryBase");
+  f.plugin = f.loader->createSharedInstance(plugin_name + "::Plugin");
+  f.plugin->initialize(f.node.get(), plugin_name);
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  zero_twist.header.frame_id = "earth";
+  f.plugin->setVehicleState(makePose(0.0, 0.0, kBenchmarkBaseZ), zero_twist);
+  return f;
+}
+
+/// Returns plugin names declared by pluginlib (strips the trailing "::Plugin").
+inline std::vector<std::string> getAvailablePlugins()
+{
+  std::vector<std::string> names;
+  try {
+    pluginlib::ClassLoader<PluginBase> loader(
+      "as2_behaviors_trajectory_generation",
+      "generate_polynomial_trajectory_behavior_plugin_base::"
+      "GeneratePolynomialTrajectoryBase");
+    for (const auto & declared : loader.getDeclaredClasses()) {
+      const std::string suffix = "::Plugin";
+      if (declared.size() > suffix.size() &&
+        declared.compare(
+          declared.size() - suffix.size(), suffix.size(), suffix) == 0)
+      {
+        names.push_back(declared.substr(0, declared.size() - suffix.size()));
+      } else {
+        names.push_back(declared);
+      }
+    }
+  } catch (const std::exception & ex) {
+    std::fprintf(
+      stderr, "getAvailablePlugins: pluginlib query failed: %s\n", ex.what());
+  }
+  return names;
+}
+
+inline std::string sanitizeForRosName(const std::string & s)
+{
+  std::string out = s;
+  for (char & c : out) {
+    if (!std::isalnum(static_cast<unsigned char>(c))) {c = '_';}
+  }
+  return out;
+}
+
+/**
+ * @brief Register the three plugin-API benchmarks for a single plugin,
+ * parametrized over the default sweep of waypoint counts.
+ *
+ * Registered names follow the convention:
+ *   - BM_GenerateTrajectory/<plugin>/<N>
+ *   - BM_UpdateWaypoints/<plugin>/<N>
+ *   - BM_Evaluate/<plugin>/<N>
+ *
+ * Each benchmark also reports a `waypoints=N` counter so the user can
+ * sort/group the resulting table by problem size.
+ */
+inline void registerPluginBenchmarks(const std::string & plugin_name)
+{
+  static const std::vector<int64_t> kWaypointCounts = {
+    2, 5, 10, 20, 50, 100};
+  const std::string sanitized = sanitizeForRosName(plugin_name);
+
+  // ---- BM_GenerateTrajectory -------------------------------------------
+  // One fixture per benchmark instance; each iteration resets the held
+  // trajectory (excluded from timing) and times a fresh generateTrajectory
+  // call. This mirrors the cold-start cost the host pays on activation.
+  auto * gen_bm = benchmark::RegisterBenchmark(
+    ("BM_GenerateTrajectory/" + plugin_name).c_str(),
+    [plugin_name, sanitized](benchmark::State & state) {
+      ScopedStdoutSink quiet_stdout;
+      const auto n = static_cast<std::size_t>(state.range(0));
+      const auto waypoints = generateHelixWaypoints(n);
+      auto fx = makePluginFixture(
+        plugin_name, "bm_gen_" + sanitized + "_node");
+      for (auto _ : state) {
+        state.PauseTiming();
+        fx.plugin->reset();
+        state.ResumeTiming();
+        const bool ok = fx.plugin->generateTrajectory(
+          waypoints, kBenchmarkMaxSpeed, /*t_trajectory_now=*/ 0.0);
+        if (!ok) {
+          state.SkipWithError("generateTrajectory returned false");
+          break;
+        }
+        benchmark::DoNotOptimize(fx.plugin.get());
+      }
+      state.counters["waypoints"] = static_cast<double>(n);
+    });
+  for (int64_t n : kWaypointCounts) {
+    gen_bm->Arg(n);
+  }
+  gen_bm->Unit(benchmark::kMicrosecond);
+  gen_bm->MinTime(kBenchmarkMinTimeSeconds);
+
+  // ---- BM_UpdateWaypoints ----------------------------------------------
+  // Plugins that override updateWaypoints with online re-stitching keep
+  // their internal time origin; plugins that rely on the base default
+  // fall back to reset+regenerate. Both costs are surfaced apples to
+  // apples in the resulting table — that comparison is the actual point
+  // of this benchmark.
+  auto * upd_bm = benchmark::RegisterBenchmark(
+    ("BM_UpdateWaypoints/" + plugin_name).c_str(),
+    [plugin_name, sanitized](benchmark::State & state) {
+      ScopedStdoutSink quiet_stdout;
+      const auto n = static_cast<std::size_t>(state.range(0));
+      auto fx = makePluginFixture(
+        plugin_name, "bm_upd_" + sanitized + "_node");
+      const auto base_waypoints = generateHelixWaypoints(n);
+      const bool ok0 = fx.plugin->generateTrajectory(
+        base_waypoints, kBenchmarkMaxSpeed, /*t_trajectory_now=*/ 0.0);
+      if (!ok0) {
+        state.SkipWithError("initial generateTrajectory returned false");
+        return;
+      }
+      const auto next_waypoints =
+      generateHelixWaypoints(n, kBenchmarkRadius, kBenchmarkPitchZ, 0.1);
+      for (auto _ : state) {
+        const bool ok = fx.plugin->updateWaypoints(
+          next_waypoints, kBenchmarkMaxSpeed, /*t_trajectory_now=*/ 0.0);
+        if (!ok) {
+          state.SkipWithError("updateWaypoints returned false");
+          break;
+        }
+        benchmark::DoNotOptimize(fx.plugin.get());
+      }
+      state.counters["waypoints"] = static_cast<double>(n);
+    });
+  for (int64_t n : kWaypointCounts) {
+    upd_bm->Arg(n);
+  }
+  upd_bm->Unit(benchmark::kMicrosecond);
+  upd_bm->MinTime(kBenchmarkMinTimeSeconds);
+
+  // ---- BM_Evaluate -----------------------------------------------------
+  // Steady-state per-control-tick cost: a single evaluate at the
+  // trajectory midpoint. Google Benchmark sets the iteration count
+  // automatically to reach a stable measurement.
+  auto * eval_bm = benchmark::RegisterBenchmark(
+    ("BM_Evaluate/" + plugin_name).c_str(),
+    [plugin_name, sanitized](benchmark::State & state) {
+      ScopedStdoutSink quiet_stdout;
+      const auto n = static_cast<std::size_t>(state.range(0));
+      auto fx = makePluginFixture(
+        plugin_name, "bm_eval_" + sanitized + "_node");
+      const auto waypoints = generateHelixWaypoints(n);
+      const bool ok0 = fx.plugin->generateTrajectory(
+        waypoints, kBenchmarkMaxSpeed, /*t_trajectory_now=*/ 0.0);
+      if (!ok0) {
+        state.SkipWithError("generateTrajectory returned false");
+        return;
+      }
+      const double duration = fx.plugin->getDuration();
+      const double t_mid = 0.5 * duration;
+      as2_msgs::msg::TrajectoryPoint out;
+      for (auto _ : state) {
+        const bool ok = fx.plugin->evaluate(
+          t_mid, out, /*is_horizon_sample=*/ false);
+        if (!ok) {
+          state.SkipWithError("evaluate returned false");
+          break;
+        }
+        benchmark::DoNotOptimize(out);
+      }
+      state.counters["waypoints"] = static_cast<double>(n);
+    });
+  for (int64_t n : kWaypointCounts) {
+    eval_bm->Arg(n);
+  }
+  eval_bm->Unit(benchmark::kNanosecond);
+  eval_bm->MinTime(kBenchmarkMinTimeSeconds);
+}
+
+}  // namespace generate_polynomial_trajectory_benchmark
+
+#endif  // GENERATE_POLYNOMIAL_TRAJECTORY_BEHAVIOR__BENCHMARK_COMMON_HPP_  // NOLINT

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/generate_polynomial_trajectory_behavior_benchmark.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/generate_polynomial_trajectory_behavior_benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Universidad Politécnica de Madrid
+// Copyright 2026 Universidad Politecnica de Madrid
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,8 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //
@@ -27,23 +28,38 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 /**
- * @file generate_polynomial_trajectory_behavior_node.cpp
+ * @file generate_polynomial_trajectory_behavior_benchmark.cpp
  *
- * @brief Standalone executable for the polynomial trajectory generator
- * behavior. Spins a `GeneratePolynomialTrajectoryBehavior` node with the
- * plugin selected via the `plugin_name` ROS parameter.
+ * @brief Comparative Google-Benchmark binary that exercises the public
+ * plugin API (generateTrajectory / updateWaypoints / evaluate) of every
+ * polynomial trajectory generator plugin declared in the package's
+ * plugins.xml, parametrized over the number of mission waypoints.
  *
- * @authors Rafael Pérez Seguí
+ * Useful for end users to pick a backend by inspecting the trade-off
+ * between generation cost, replanning cost, and per-tick evaluation cost
+ * for their typical mission size.
+ *
+ * @authors Rafael Perez-Segui
  */
 
-#include "as2_core/core_functions.hpp"
-#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp"
+#include <benchmark/benchmark.h>
+#include <rclcpp/rclcpp.hpp>
 
-int main(int argc, char * argv[])
+#include "generate_polynomial_trajectory_benchmark_common.hpp"
+
+int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<GeneratePolynomialTrajectoryBehavior>();
-  as2::spinLoop(node);
+  generate_polynomial_trajectory_benchmark::silenceRosLogging();
+  benchmark::Initialize(&argc, argv);
+  for (const auto & plugin_name :
+    generate_polynomial_trajectory_benchmark::getAvailablePlugins())
+  {
+    generate_polynomial_trajectory_benchmark::registerPluginBenchmarks(
+      plugin_name);
+  }
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
   rclcpp::shutdown();
   return 0;
 }

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/generate_polynomial_trajectory_behavior_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/generate_polynomial_trajectory_behavior_gtest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Universidad Politécnica de Madrid
+// Copyright 2026 Universidad Politécnica de Madrid
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,8 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names
+//    of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //
@@ -27,26 +28,74 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 /**
-* @file generate_polynomial_trajectory_behavior_gtest.cpp
-*
-* @brief Class definition for the GeneratePolynomialTrajectoryBehavior gtest class.
-*
-* @author Miguel Fernández Cortizas
-*         Pedro Arias Pérez
-*         David Pérez Saura
-*         Rafael Pérez Seguí
-*/
+ * @file generate_polynomial_trajectory_behavior_gtest.cpp
+ *
+ * @brief Construction smoke test for GeneratePolynomialTrajectoryBehavior.
+ *
+ * Parametrized over every plugin declared in plugins.xml so a regression
+ * in the wrapper / plugin contract is caught for all backends, not just
+ * the default one.
+ *
+ * @authors Rafael Perez-Segui
+ */
 
 #include <gtest/gtest.h>
-#include <ament_index_cpp/get_package_share_directory.hpp>
-#include <generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp>
 
-std::shared_ptr<DynamicPolynomialTrajectoryGenerator> get_node(
-  const std::string & name_space = "as2_behaviors_trajectory_generation_test")
+#include <cctype>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp"
+
+namespace
 {
-  const std::string package_path =
-    ament_index_cpp::get_package_share_directory("as2_behaviors_trajectory_generation");
-  const std::string config_file = package_path +
+
+using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase;
+
+/// Returns plugin names declared by pluginlib (strips the trailing "::Plugin").
+std::vector<std::string> getAvailablePlugins()
+{
+  std::vector<std::string> names;
+  try {
+    pluginlib::ClassLoader<PluginBase> loader(
+      "as2_behaviors_trajectory_generation",
+      "generate_polynomial_trajectory_behavior_plugin_base::"
+      "GeneratePolynomialTrajectoryBase");
+    for (const auto & declared : loader.getDeclaredClasses()) {
+      const std::string suffix = "::Plugin";
+      if (declared.size() > suffix.size() &&
+        declared.compare(
+          declared.size() - suffix.size(), suffix.size(), suffix) == 0)
+      {
+        names.push_back(declared.substr(0, declared.size() - suffix.size()));
+      } else {
+        names.push_back(declared);
+      }
+    }
+  } catch (const std::exception & ex) {
+    std::fprintf(
+      stderr, "getAvailablePlugins: pluginlib query failed: %s\n", ex.what());
+  }
+  return names;
+}
+
+std::shared_ptr<GeneratePolynomialTrajectoryBehavior>
+makeBehaviorNode(
+  const std::string & plugin_name,
+  const std::string & name_space)
+{
+  const std::string package_path = ament_index_cpp::get_package_share_directory(
+    "as2_behaviors_trajectory_generation");
+  const std::string config_file =
+    package_path +
     "/generate_polynomial_trajectory_behavior/config/config_default.yaml";
 
   std::vector<std::string> node_args = {
@@ -55,29 +104,52 @@ std::shared_ptr<DynamicPolynomialTrajectoryGenerator> get_node(
     "__ns:=/" + name_space,
     "-p",
     "namespace:=" + name_space,
+    "-p",
+    "plugin_name:=" + plugin_name,
     "--params-file",
     config_file,
   };
-
   rclcpp::NodeOptions node_options;
   node_options.arguments(node_args);
 
-  return std::make_shared<DynamicPolynomialTrajectoryGenerator>(node_options);
+  return std::make_shared<GeneratePolynomialTrajectoryBehavior>(node_options);
 }
 
-TEST(DynamicPolynomialTrajectoryGenerator, test_constructor)
-{
+class GeneratePolynomialTrajectoryBehaviorTest
+  : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(GeneratePolynomialTrajectoryBehaviorTest, test_constructor) {
+  std::string sanitized = GetParam();
+  for (char & c : sanitized) {
+    if (!std::isalnum(static_cast<unsigned char>(c))) {c = '_';}
+  }
+  const std::string name_space =
+    "as2_behaviors_trajectory_generation_test_" + sanitized;
   EXPECT_NO_THROW(
-    std::shared_ptr<DynamicPolynomialTrajectoryGenerator> node =
-    get_node("test_constructor"));
+    {
+      auto node = makeBehaviorNode(GetParam(), name_space);
+      (void)node;
+    });
 }
 
+INSTANTIATE_TEST_SUITE_P(
+  AllPlugins, GeneratePolynomialTrajectoryBehaviorTest,
+  ::testing::ValuesIn(getAvailablePlugins()),
+  [](const ::testing::TestParamInfo<std::string> & info) {
+    std::string sanitized = info.param;
+    for (char & c : sanitized) {
+      if (!std::isalnum(static_cast<unsigned char>(c))) {c = '_';}
+    }
+    return sanitized;
+  });
+
+}  // namespace
 
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  auto result = RUN_ALL_TESTS();
+  const int result = RUN_ALL_TESTS();
   rclcpp::shutdown();
   return result;
 }

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/integration_test.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/integration_test.cpp
@@ -1,0 +1,613 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file integration_test.cpp
+ *
+ * @brief Single-process integration test for
+ * GeneratePolynomialTrajectoryBehavior. The behavior, a mock support node and
+ * an action client share a MultiThreadedExecutor. Parametrized over every
+ * plugin discovered via pluginlib so any future plugin is exercised without
+ * touching the test.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <std_srvs/srv/trigger.hpp>
+#include <tf2_ros/static_transform_broadcaster.h>  // NOLINT(build/include_order)
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "as2_core/node.hpp"
+#include "as2_msgs/action/generate_polynomial_trajectory.hpp"
+#include "as2_msgs/msg/behavior_status.hpp"
+#include "as2_msgs/msg/control_mode.hpp"
+#include "as2_msgs/msg/controller_info.hpp"
+#include "as2_msgs/msg/pose_stamped_with_id.hpp"
+#include "as2_msgs/msg/yaw_mode.hpp"
+#include "as2_msgs/srv/set_control_mode.hpp"
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp"
+
+namespace
+{
+
+using Action = as2_msgs::action::GeneratePolynomialTrajectory;
+using Goal = Action::Goal;
+using Feedback = Action::Feedback;
+using GoalHandle = rclcpp_action::ClientGoalHandle<Action>;
+using BehaviorStatus = as2_msgs::msg::BehaviorStatus;
+using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase;
+
+constexpr const char * kTestNamespace = "test_drone";
+constexpr const char * kBehaviorActionName = "TrajectoryGeneratorBehavior";
+constexpr double kHoverHeight = 2.0;
+constexpr double kMaxSpeed = 1.0;
+
+/**
+ * @brief Mock support node providing the minimum environment for the behavior
+ * to activate: static TF (earth → odom → base_link), a periodic
+ * TwistStamped on self_localization/twist, a ControllerInfo publisher and a
+ * controller/set_control_mode service that always succeeds. The motion
+ * reference handlers (trajectory + hover) used by the behavior issue a
+ * synchronous setMode call when the controller's reported mode does not match
+ * the desired one; without these mocks the behavior would block forever.
+ */
+class MockSupportNode : public as2::Node
+{
+public:
+  MockSupportNode()
+  : as2::Node("integration_test_mock", makeOptions())
+  {
+    static_tf_broadcaster_ =
+      std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+
+    publishStaticTransforms();
+
+    twist_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(
+      "self_localization/twist", rclcpp::SensorDataQoS());
+
+    controller_info_pub_ = this->create_publisher<as2_msgs::msg::ControllerInfo>(
+      "controller/info", rclcpp::QoS(1));
+
+    set_control_mode_srv_ =
+      this->create_service<as2_msgs::srv::SetControlMode>(
+      "controller/set_control_mode",
+      [this](
+        const std::shared_ptr<as2_msgs::srv::SetControlMode::Request> req,
+        std::shared_ptr<as2_msgs::srv::SetControlMode::Response> resp) {
+        resp->success = true;
+        // Echo the requested mode back via controller/info so any concurrent
+        // checkMode() observes the matching state.
+        as2_msgs::msg::ControllerInfo info;
+        info.input_control_mode = req->control_mode;
+        info.output_control_mode = req->control_mode;
+        controller_info_pub_->publish(info);
+      });
+
+    twist_timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(20),
+      [this]() {publishZeroTwist();});
+  }
+
+private:
+  static rclcpp::NodeOptions makeOptions()
+  {
+    rclcpp::NodeOptions options;
+    options.arguments(
+      {
+        "--ros-args",
+        "-r", std::string("__ns:=/") + kTestNamespace,
+        "-p", std::string("namespace:=") + kTestNamespace,
+      });
+    return options;
+  }
+
+  void publishStaticTransforms()
+  {
+    const std::string ns = kTestNamespace;
+    const auto stamp = this->now();
+
+    geometry_msgs::msg::TransformStamped earth_to_map;
+    earth_to_map.header.stamp = stamp;
+    earth_to_map.header.frame_id = "earth";
+    earth_to_map.child_frame_id = ns + "/map";
+    earth_to_map.transform.rotation.w = 1.0;
+    static_tf_broadcaster_->sendTransform(earth_to_map);
+
+    geometry_msgs::msg::TransformStamped map_to_odom;
+    map_to_odom.header.stamp = stamp;
+    map_to_odom.header.frame_id = ns + "/map";
+    map_to_odom.child_frame_id = ns + "/odom";
+    map_to_odom.transform.rotation.w = 1.0;
+    static_tf_broadcaster_->sendTransform(map_to_odom);
+
+    geometry_msgs::msg::TransformStamped odom_to_base;
+    odom_to_base.header.stamp = stamp;
+    odom_to_base.header.frame_id = ns + "/odom";
+    odom_to_base.child_frame_id = ns + "/base_link";
+    odom_to_base.transform.translation.z = kHoverHeight;
+    odom_to_base.transform.rotation.w = 1.0;
+    static_tf_broadcaster_->sendTransform(odom_to_base);
+  }
+
+  void publishZeroTwist()
+  {
+    geometry_msgs::msg::TwistStamped msg;
+    msg.header.stamp = this->now();
+    msg.header.frame_id = std::string(kTestNamespace) + "/base_link";
+    twist_pub_->publish(msg);
+  }
+
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
+  rclcpp::Publisher<as2_msgs::msg::ControllerInfo>::SharedPtr
+    controller_info_pub_;
+  rclcpp::Service<as2_msgs::srv::SetControlMode>::SharedPtr
+    set_control_mode_srv_;
+  rclcpp::TimerBase::SharedPtr twist_timer_;
+};
+
+/// Returns plugin names declared by pluginlib (strips the trailing "::Plugin").
+std::vector<std::string> getAvailablePlugins()
+{
+  std::vector<std::string> names;
+  try {
+    pluginlib::ClassLoader<PluginBase> loader(
+      "as2_behaviors_trajectory_generation",
+      "generate_polynomial_trajectory_behavior_plugin_base::"
+      "GeneratePolynomialTrajectoryBase");
+    for (const auto & declared : loader.getDeclaredClasses()) {
+      const std::string suffix = "::Plugin";
+      if (declared.size() > suffix.size() &&
+        declared.compare(
+          declared.size() - suffix.size(), suffix.size(), suffix) == 0)
+      {
+        names.push_back(declared.substr(0, declared.size() - suffix.size()));
+      } else {
+        names.push_back(declared);
+      }
+    }
+  } catch (const std::exception & ex) {
+    std::fprintf(
+      stderr, "getAvailablePlugins: pluginlib query failed: %s\n", ex.what());
+  }
+  return names;
+}
+
+/// Build a 3-waypoint goal in the namespaced odom frame at hover height.
+Goal makeBaseGoal()
+{
+  Goal goal;
+  goal.max_speed = kMaxSpeed;
+  goal.yaw.mode = as2_msgs::msg::YawMode::KEEP_YAW;
+  goal.yaw.angle = 0.0f;
+
+  const std::string frame = std::string(kTestNamespace) + "/odom";
+  const std::vector<std::pair<std::string, double>> wps = {
+    {"wp_a", 1.0}, {"wp_b", 2.0}, {"wp_c", 3.0}
+  };
+  for (const auto & [id, x] : wps) {
+    as2_msgs::msg::PoseStampedWithID wp;
+    wp.id = id;
+    wp.pose.header.frame_id = frame;
+    wp.pose.pose.position.x = x;
+    wp.pose.pose.position.z = kHoverHeight;
+    wp.pose.pose.orientation.w = 1.0;
+    goal.path.push_back(wp);
+  }
+  return goal;
+}
+
+/// Sleep helper that keeps spinning the executor while waiting.
+template<typename Predicate>
+bool waitFor(
+  Predicate pred, std::chrono::milliseconds timeout,
+  std::chrono::milliseconds poll = std::chrono::milliseconds(20))
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) {return true;}
+    std::this_thread::sleep_for(poll);
+  }
+  return pred();
+}
+
+class IntegrationTest : public ::testing::TestWithParam<std::string>
+{
+protected:
+  void SetUp() override
+  {
+    const std::string package_share = ament_index_cpp::get_package_share_directory(
+      "as2_behaviors_trajectory_generation");
+    const std::string config_file = package_share +
+      "/generate_polynomial_trajectory_behavior/config/config_default.yaml";
+
+    rclcpp::NodeOptions options;
+    options.arguments(
+      {
+        "--ros-args",
+        "-r", std::string("__ns:=/") + kTestNamespace,
+        "-p", std::string("namespace:=") + kTestNamespace,
+        "-p", std::string("plugin_name:=") + GetParam(),
+        "--params-file", config_file,
+      });
+    behavior_ = std::make_shared<GeneratePolynomialTrajectoryBehavior>(options);
+    mock_ = std::make_shared<MockSupportNode>();
+
+    rclcpp::NodeOptions client_options;
+    client_options.arguments(
+      {
+        "--ros-args",
+        "-r", std::string("__ns:=/") + kTestNamespace,
+      });
+    client_node_ = std::make_shared<rclcpp::Node>(
+      "integration_test_client", client_options);
+
+    action_client_ = rclcpp_action::create_client<Action>(
+      client_node_, kBehaviorActionName);
+    pause_client_ = client_node_->create_client<std_srvs::srv::Trigger>(
+      std::string(kBehaviorActionName) + "/_behavior/pause");
+    resume_client_ = client_node_->create_client<std_srvs::srv::Trigger>(
+      std::string(kBehaviorActionName) + "/_behavior/resume");
+    modify_client_ = client_node_->create_client<Action::Impl::SendGoalService>(
+      std::string(kBehaviorActionName) + "/_behavior/modify");
+
+    behavior_status_sub_ = client_node_->create_subscription<BehaviorStatus>(
+      std::string(kBehaviorActionName) + "/_behavior/behavior_status", 10,
+      [this](BehaviorStatus::SharedPtr msg) {
+        last_behavior_status_.store(msg->status);
+      });
+
+    executor_.add_node(behavior_);
+    executor_.add_node(mock_);
+    executor_.add_node(client_node_);
+    spin_thread_ = std::thread([this]() {executor_.spin();});
+
+    ASSERT_TRUE(action_client_->wait_for_action_server(std::chrono::seconds(5)))
+      << "action server not available for plugin " << GetParam();
+    ASSERT_TRUE(pause_client_->wait_for_service(std::chrono::seconds(5)));
+    ASSERT_TRUE(resume_client_->wait_for_service(std::chrono::seconds(5)));
+    ASSERT_TRUE(modify_client_->wait_for_service(std::chrono::seconds(5)));
+
+    // The behavior rejects activations until at least one twist message has
+    // arrived AND the static TF buffer is populated. The mock publishes twist
+    // at 50 Hz; give it a brief window before exercising the action.
+    ASSERT_TRUE(
+      waitFor(
+        [this]() {return sendProbeAndCheckAcceptance();},
+        std::chrono::seconds(5)))
+      << "behavior never reached a state where it accepts goals (plugin "
+      << GetParam() << ")";
+  }
+
+  /// Try sending a one-waypoint probe goal; if accepted, immediately deactivate
+  /// so we leave the behavior idle for the actual test. Returns true once the
+  /// probe is accepted (i.e. the behavior is ready).
+  bool sendProbeAndCheckAcceptance()
+  {
+    Goal probe;
+    probe.max_speed = kMaxSpeed;
+    probe.yaw.mode = as2_msgs::msg::YawMode::KEEP_YAW;
+    as2_msgs::msg::PoseStampedWithID wp;
+    wp.id = "probe";
+    wp.pose.header.frame_id = std::string(kTestNamespace) + "/odom";
+    wp.pose.pose.position.x = 0.5;
+    wp.pose.pose.position.z = kHoverHeight;
+    wp.pose.pose.orientation.w = 1.0;
+    probe.path.push_back(wp);
+
+    auto future = action_client_->async_send_goal(probe);
+    if (future.wait_for(std::chrono::milliseconds(500)) !=
+      std::future_status::ready)
+    {
+      return false;
+    }
+    auto handle = future.get();
+    if (!handle) {return false;}
+
+    // Cancel the probe goal so the behavior returns to IDLE.
+    auto cancel_future = action_client_->async_cancel_goal(handle);
+    cancel_future.wait_for(std::chrono::seconds(1));
+    {
+      std::lock_guard<std::mutex> lk(feedback_mutex_);
+      feedbacks_.clear();
+    }
+    last_behavior_status_.store(BehaviorStatus::IDLE);
+    return true;
+  }
+
+  void TearDown() override
+  {
+    executor_.cancel();
+    if (spin_thread_.joinable()) {spin_thread_.join();}
+    behavior_status_sub_.reset();
+    pause_client_.reset();
+    resume_client_.reset();
+    action_client_.reset();
+    client_node_.reset();
+    mock_.reset();
+    behavior_.reset();
+  }
+
+  /// Send the goal through the action client and start collecting feedbacks.
+  GoalHandle::SharedPtr sendGoal(const Goal & goal)
+  {
+    rclcpp_action::Client<Action>::SendGoalOptions opts;
+    opts.feedback_callback =
+      [this](GoalHandle::SharedPtr, const std::shared_ptr<const Feedback> fb) {
+        std::lock_guard<std::mutex> lk(feedback_mutex_);
+        feedbacks_.push_back(*fb);
+      };
+    auto future = action_client_->async_send_goal(goal, opts);
+    if (future.wait_for(std::chrono::seconds(2)) != std::future_status::ready) {
+      return nullptr;
+    }
+    return future.get();
+  }
+
+  /// Wait until at least one feedback satisfies @p pred.
+  template<typename Pred>
+  bool waitForFeedback(Pred pred, std::chrono::milliseconds timeout)
+  {
+    return waitFor(
+      [&]() {
+        std::lock_guard<std::mutex> lk(feedback_mutex_);
+        for (const auto & fb : feedbacks_) {
+          if (pred(fb)) {return true;}
+        }
+        return false;
+      }, timeout);
+  }
+
+  std::vector<Feedback> snapshotFeedbacks()
+  {
+    std::lock_guard<std::mutex> lk(feedback_mutex_);
+    return feedbacks_;
+  }
+
+  void clearFeedbacks()
+  {
+    std::lock_guard<std::mutex> lk(feedback_mutex_);
+    feedbacks_.clear();
+  }
+
+  bool callTrigger(rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client)
+  {
+    auto req = std::make_shared<std_srvs::srv::Trigger::Request>();
+    auto fut = client->async_send_request(req);
+    if (fut.wait_for(std::chrono::seconds(2)) != std::future_status::ready) {
+      return false;
+    }
+    return fut.get()->success;
+  }
+
+  /// Call the BehaviorServer modify service synchronously.
+  bool callModify(const Goal & goal)
+  {
+    auto req = std::make_shared<Action::Impl::SendGoalService::Request>();
+    req->goal = goal;
+    auto fut = modify_client_->async_send_request(req);
+    if (fut.wait_for(std::chrono::seconds(2)) != std::future_status::ready) {
+      return false;
+    }
+    return fut.get()->accepted;
+  }
+
+  bool waitForBehaviorStatus(uint8_t expected, std::chrono::milliseconds timeout)
+  {
+    return waitFor(
+      [&]() {return last_behavior_status_.load() == expected;}, timeout);
+  }
+
+  // Members.
+  std::shared_ptr<GeneratePolynomialTrajectoryBehavior> behavior_;
+  std::shared_ptr<MockSupportNode> mock_;
+  std::shared_ptr<rclcpp::Node> client_node_;
+  rclcpp_action::Client<Action>::SharedPtr action_client_;
+  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr pause_client_;
+  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr resume_client_;
+  rclcpp::Client<Action::Impl::SendGoalService>::SharedPtr modify_client_;
+  rclcpp::Subscription<BehaviorStatus>::SharedPtr behavior_status_sub_;
+  std::atomic<uint8_t> last_behavior_status_{BehaviorStatus::IDLE};
+
+  rclcpp::executors::MultiThreadedExecutor executor_;
+  std::thread spin_thread_;
+
+  std::mutex feedback_mutex_;
+  std::vector<Feedback> feedbacks_;
+};
+
+TEST_P(IntegrationTest, BasicGoalCompletes)
+{
+  auto goal_handle = sendGoal(makeBaseGoal());
+  ASSERT_NE(goal_handle, nullptr);
+
+  ASSERT_TRUE(
+    waitForFeedback(
+      [](const Feedback & fb) {return fb.next_waypoint_id == "wp_a";},
+      std::chrono::seconds(3)));
+
+  auto result_future = action_client_->async_get_result(goal_handle);
+  ASSERT_EQ(
+    result_future.wait_for(std::chrono::seconds(20)),
+    std::future_status::ready);
+  const auto wrapped = result_future.get();
+  EXPECT_EQ(wrapped.code, rclcpp_action::ResultCode::SUCCEEDED);
+  EXPECT_TRUE(wrapped.result->trajectory_generator_success);
+
+  const auto fbs = snapshotFeedbacks();
+  ASSERT_FALSE(fbs.empty());
+  // The terminal feedback may still report 1 (the last waypoint about to be
+  // reached at SUCCESS time). The invariant is that the queue is non-growing
+  // and ends near zero pending entries.
+  EXPECT_LE(fbs.back().remaining_waypoints, 1u);
+  // The queue should have been observed at least at "wp_b" along the way.
+  bool saw_wp_b = false;
+  for (const auto & fb : fbs) {
+    if (fb.next_waypoint_id == "wp_b") {saw_wp_b = true; break;}
+  }
+  EXPECT_TRUE(saw_wp_b);
+}
+
+TEST_P(IntegrationTest, ModifyMidFlightPreservesProgress)
+{
+  if (!behavior_) {GTEST_SKIP();}
+
+  // The behavior delegates each modify to plugin_->updateWaypoints().
+  // Plugins that override the contract stitch smoothly (preserve t0);
+  // plugins that rely on the base default regenerate from the live
+  // pose+twist as boundary conditions. In both cases the merge logic in
+  // the wrapper drops already-passed waypoints; the modify request must
+  // therefore include only ids that are still pending — sending an
+  // already-passed id (e.g. "wp_a") would make the merge append it at
+  // the tail and the trajectory would visit it again.
+
+  auto goal_handle = sendGoal(makeBaseGoal());
+  ASSERT_NE(goal_handle, nullptr);
+
+  // Wait until the queue advances past wp_a so we can observe progress.
+  ASSERT_TRUE(
+    waitForFeedback(
+      [](const Feedback & fb) {return fb.next_waypoint_id == "wp_b";},
+      std::chrono::seconds(5)));
+
+  // Capture the index marker BEFORE the modify request so we can assert on
+  // post-modify feedback only.
+  const std::size_t modify_marker = snapshotFeedbacks().size();
+
+  // Send a modify with the still-pending ids only, tweaked in X. After
+  // the modify the trajectory must continue forward; feedback after the
+  // modify should never report "wp_a" (the cleared waypoint).
+  Goal modify = makeBaseGoal();
+  modify.path.erase(
+    std::remove_if(
+      modify.path.begin(), modify.path.end(),
+      [](const as2_msgs::msg::PoseStampedWithID & wp) {
+        return wp.id == "wp_a";
+      }),
+    modify.path.end());
+  for (auto & wp : modify.path) {
+    wp.pose.pose.position.x += 0.2;
+  }
+  ASSERT_TRUE(callModify(modify));
+
+  // Run a bit longer to collect post-modify feedback samples.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  const auto fbs = snapshotFeedbacks();
+  ASSERT_GT(fbs.size(), modify_marker);
+  for (std::size_t i = modify_marker; i < fbs.size(); ++i) {
+    EXPECT_NE(fbs[i].next_waypoint_id, "wp_a")
+      << "next_waypoint_id reverted to wp_a after dynamic modify";
+  }
+
+  // Let the goal finish.
+  auto result_future = action_client_->async_get_result(goal_handle);
+  ASSERT_EQ(
+    result_future.wait_for(std::chrono::seconds(20)),
+    std::future_status::ready);
+  EXPECT_EQ(result_future.get().code, rclcpp_action::ResultCode::SUCCEEDED);
+}
+
+TEST_P(IntegrationTest, PauseAndResumeCompletes)
+{
+  auto goal_handle = sendGoal(makeBaseGoal());
+  ASSERT_NE(goal_handle, nullptr);
+
+  // Wait until execution has progressed to wp_b before pausing.
+  ASSERT_TRUE(
+    waitForFeedback(
+      [](const Feedback & fb) {return fb.next_waypoint_id == "wp_b";},
+      std::chrono::seconds(5)));
+
+  ASSERT_TRUE(callTrigger(pause_client_));
+  ASSERT_TRUE(
+    waitForBehaviorStatus(
+      BehaviorStatus::PAUSED, std::chrono::seconds(2)));
+
+  const std::size_t pause_marker = snapshotFeedbacks().size();
+
+  ASSERT_TRUE(callTrigger(resume_client_));
+  ASSERT_TRUE(
+    waitForBehaviorStatus(
+      BehaviorStatus::RUNNING, std::chrono::seconds(2)));
+
+  auto result_future = action_client_->async_get_result(goal_handle);
+  ASSERT_EQ(
+    result_future.wait_for(std::chrono::seconds(20)),
+    std::future_status::ready);
+  EXPECT_EQ(result_future.get().code, rclcpp_action::ResultCode::SUCCEEDED);
+
+  // Feedback after resume must never report a waypoint earlier than wp_b.
+  const auto fbs = snapshotFeedbacks();
+  for (std::size_t i = pause_marker; i < fbs.size(); ++i) {
+    EXPECT_NE(fbs[i].next_waypoint_id, "wp_a")
+      << "next_waypoint_id rewinded to wp_a after resume";
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  AllPlugins, IntegrationTest,
+  ::testing::ValuesIn(getAvailablePlugins()),
+  [](const ::testing::TestParamInfo<std::string> & info) {
+    std::string sanitized = info.param;
+    for (char & c : sanitized) {
+      if (!std::isalnum(static_cast<unsigned char>(c))) {c = '_';}
+    }
+    return sanitized;
+  });
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  const int rc = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return rc;
+}

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/mock_drone_node.py
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/tests/mock_drone_node.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+r"""
+Mock support node for the polynomial trajectory generator behavior.
+
+Replaces the rest of the aerostack2 stack so the behavior can be exercised
+end-to-end with only the action client. Intended to be launched manually
+together with the behavior:
+
+    ros2 launch as2_behaviors_trajectory_generation \
+        generate_polynomial_trajectory_behavior_launch.py namespace:=drone0
+
+    python3 mock_drone_node.py        # this file
+    python3 behavior_test.py          # the action client
+
+Provided by this node (all under ``/{NAMESPACE}/``):
+
+* TF tree ``earth → {ns}/map → {ns}/odom → {ns}/base_link``. The first two
+  links are static identity. The ``odom → base_link`` link is dynamic: its
+  pose tracks the latest ``motion_reference/trajectory`` setpoint received.
+* Service ``controller/set_control_mode`` (``as2_msgs/srv/SetControlMode``)
+  that always succeeds and echoes the requested mode on ``controller/info``.
+* Periodic ``controller/info`` (``as2_msgs/ControllerInfo``) so late
+  subscribers see the latest mode.
+* Periodic ``self_localization/twist`` (``geometry_msgs/TwistStamped``).
+  Twist values mirror the latest setpoint twist (zeros until the first
+  setpoint arrives).
+
+Frame and unit conventions:
+
+* Setpoint position/twist are taken in the behavior's ``desired_frame_id``
+  (``{ns}/odom`` by default). The mock applies them as the
+  ``odom → base_link`` transform and as the published twist (header
+  ``frame_id`` set to ``{ns}/odom`` to match).
+* Yaw is encoded as a Z-axis quaternion in the TF.
+
+Tweak the configuration block at the top of this file to change namespace,
+initial pose, or rates.
+"""
+
+__authors__ = 'Rafael Pérez Seguí'
+__copyright__ = 'Copyright (c) 2026 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import math
+import sys
+import threading
+
+from as2_msgs.msg import ControllerInfo, ControlMode
+from as2_msgs.msg import TrajectorySetpoints
+from as2_msgs.srv import SetControlMode
+
+from geometry_msgs.msg import TransformStamped, TwistStamped
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+
+from tf2_ros import StaticTransformBroadcaster, TransformBroadcaster
+
+
+# ───────────────────────────── Configuration ────────────────────────────────
+NAMESPACE = 'drone0'
+
+# Initial state of the simulated vehicle (before any setpoint is received).
+INITIAL_X = 0.0     # m, in {NAMESPACE}/odom
+INITIAL_Y = 0.0     # m
+INITIAL_Z = 0.0     # m
+INITIAL_YAW = 0.0   # rad, around Z
+
+# Publishing rates
+TF_DYNAMIC_RATE_HZ = 100.0
+TWIST_RATE_HZ = 100.0
+CONTROLLER_INFO_RATE_HZ = 10.0
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def yaw_to_quaternion_z(yaw: float):
+    """Return (qx, qy, qz, qw) for a rotation of ``yaw`` rad around +Z."""
+    half = 0.5 * yaw
+    return (0.0, 0.0, math.sin(half), math.cos(half))
+
+
+class MockDroneNode(Node):
+    """
+    Mock of the rest of the aerostack2 stack required by the behavior.
+
+    Holds the latest commanded vehicle state behind a lock and republishes
+    it on TF and ``self_localization/twist`` on fixed-rate timers. The lock
+    is required because the trajectory subscription, the service callback
+    and the timer callbacks may all run concurrently under a multi-threaded
+    executor — even though the default executor is single-threaded the lock
+    keeps the contract explicit and cheap.
+    """
+
+    def __init__(self):
+        """Set up TF, pub/sub, the service and the periodic timers."""
+        super().__init__('mock_drone_support', namespace=NAMESPACE)
+
+        self._lock = threading.Lock()
+        self._pose_x = float(INITIAL_X)
+        self._pose_y = float(INITIAL_Y)
+        self._pose_z = float(INITIAL_Z)
+        self._pose_yaw = float(INITIAL_YAW)
+        self._twist_lin = [0.0, 0.0, 0.0]
+        self._twist_ang = [0.0, 0.0, 0.0]
+        self._control_mode = ControlMode()  # all-zero = UNSET / NONE
+
+        self._ns = self.get_namespace().lstrip('/')
+        self._earth_frame = 'earth'
+        self._map_frame = f'{self._ns}/map'
+        self._odom_frame = f'{self._ns}/odom'
+        self._base_link_frame = f'{self._ns}/base_link'
+
+        # TF: two static identity links and one dynamic odom → base_link.
+        self._static_tf = StaticTransformBroadcaster(self)
+        self._publish_static_transforms()
+        self._tf_broadcaster = TransformBroadcaster(self)
+
+        # Self-localization twist (matches as2_names::topics::self_localization::qos
+        # which is SensorDataQoS).
+        self._twist_pub = self.create_publisher(
+            TwistStamped, 'self_localization/twist', qos_profile_sensor_data)
+
+        # Controller info: the motion reference handlers subscribe to this to
+        # confirm the mode they requested via set_control_mode is active.
+        info_qos = QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE)
+        self._info_pub = self.create_publisher(
+            ControllerInfo, 'controller/info', info_qos)
+
+        # Trajectory setpoints arriving from the behavior's trajectory motion
+        # handler. We mirror them onto the TF and twist topics. The publisher
+        # uses SensorDataQoS (BEST_EFFORT, depth 10), so we must match it on
+        # the subscription side or the messages are dropped on QoS mismatch.
+        self._traj_sub = self.create_subscription(
+            TrajectorySetpoints, 'motion_reference/trajectory',
+            self._on_trajectory, qos_profile_sensor_data)
+
+        # set_control_mode service: always succeeds and immediately echoes
+        # the requested mode on controller/info.
+        self._mode_srv = self.create_service(
+            SetControlMode, 'controller/set_control_mode',
+            self._on_set_control_mode)
+
+        # Periodic publishers
+        self.create_timer(1.0 / TF_DYNAMIC_RATE_HZ, self._publish_dynamic_tf)
+        self.create_timer(1.0 / TWIST_RATE_HZ, self._publish_twist)
+        self.create_timer(
+            1.0 / CONTROLLER_INFO_RATE_HZ, self._publish_controller_info)
+
+        self.get_logger().info(
+            f'Mock drone support up: ns="{self._ns}" '
+            f'tf_root="{self._earth_frame}" base="{self._base_link_frame}"')
+
+    def _publish_static_transforms(self) -> None:
+        """Send identity ``earth→map`` and ``map→odom`` transforms once."""
+        stamp = self.get_clock().now().to_msg()
+        transforms = []
+        for parent, child in (
+            (self._earth_frame, self._map_frame),
+            (self._map_frame, self._odom_frame),
+        ):
+            tf = TransformStamped()
+            tf.header.stamp = stamp
+            tf.header.frame_id = parent
+            tf.child_frame_id = child
+            tf.transform.rotation.w = 1.0
+            transforms.append(tf)
+        self._static_tf.sendTransform(transforms)
+
+    def _publish_dynamic_tf(self) -> None:
+        """Broadcast the current ``odom → base_link`` transform."""
+        with self._lock:
+            x, y, z, yaw = (
+                self._pose_x, self._pose_y, self._pose_z, self._pose_yaw)
+        qx, qy, qz, qw = yaw_to_quaternion_z(yaw)
+        tf = TransformStamped()
+        tf.header.stamp = self.get_clock().now().to_msg()
+        tf.header.frame_id = self._odom_frame
+        tf.child_frame_id = self._base_link_frame
+        tf.transform.translation.x = x
+        tf.transform.translation.y = y
+        tf.transform.translation.z = z
+        tf.transform.rotation.x = qx
+        tf.transform.rotation.y = qy
+        tf.transform.rotation.z = qz
+        tf.transform.rotation.w = qw
+        self._tf_broadcaster.sendTransform(tf)
+
+    def _publish_twist(self) -> None:
+        """
+        Publish the current twist on ``self_localization/twist``.
+
+        The twist values are taken verbatim from the last setpoint, in the
+        behavior's desired frame (``{ns}/odom``). The header ``frame_id``
+        matches that frame so the behavior's TF-aware state callback can
+        consume it directly.
+        """
+        with self._lock:
+            lin = list(self._twist_lin)
+            ang = list(self._twist_ang)
+        msg = TwistStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self._odom_frame
+        msg.twist.linear.x, msg.twist.linear.y, msg.twist.linear.z = lin
+        msg.twist.angular.x, msg.twist.angular.y, msg.twist.angular.z = ang
+        self._twist_pub.publish(msg)
+
+    def _publish_controller_info(self) -> None:
+        """Publish the most recently set control mode on ``controller/info``."""
+        with self._lock:
+            mode = self._control_mode
+        msg = ControllerInfo()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.input_control_mode = mode
+        msg.output_control_mode = mode
+        self._info_pub.publish(msg)
+
+    def _on_trajectory(self, msg: TrajectorySetpoints) -> None:
+        """
+        Copy the first setpoint into the simulated vehicle state.
+
+        The behavior's trajectory motion handler always populates at least
+        one setpoint per message; we ignore the rest. We assume the message
+        is expressed in ``{ns}/odom`` (the behavior's ``desired_frame_id``).
+        """
+        if not msg.setpoints:
+            return
+        sp = msg.setpoints[0]
+        with self._lock:
+            self._pose_x = float(sp.position.x)
+            self._pose_y = float(sp.position.y)
+            self._pose_z = float(sp.position.z)
+            self._pose_yaw = float(sp.yaw_angle)
+            self._twist_lin = [
+                float(sp.twist.x), float(sp.twist.y), float(sp.twist.z)]
+            # Trajectory setpoints carry no angular velocity; keep it zero.
+            self._twist_ang = [0.0, 0.0, 0.0]
+
+    def _on_set_control_mode(self, request, response):
+        """Accept the requested mode, store it and echo it on ``controller/info``."""
+        with self._lock:
+            self._control_mode = request.control_mode
+        response.success = True
+        # Immediate echo so the calling motion handler sees the new mode
+        # without waiting for the next periodic publish.
+        info = ControllerInfo()
+        info.header.stamp = self.get_clock().now().to_msg()
+        info.input_control_mode = request.control_mode
+        info.output_control_mode = request.control_mode
+        self._info_pub.publish(info)
+        self.get_logger().info(
+            f'set_control_mode: mode={request.control_mode.control_mode} '
+            f'yaw={request.control_mode.yaw_mode} '
+            f'frame={request.control_mode.reference_frame}')
+        return response
+
+
+def main():
+    """Spin the mock until interrupted."""
+    rclpy.init(args=sys.argv)
+    node = MockDroneNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/package.xml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/package.xml
@@ -6,13 +6,17 @@
   <description>Aerostack behaviors collection for trajectory generation</description>
 
   <maintainer email="cvar.upm3@gmail.com">CVAR-UPM</maintainer>
+  <author email="r.psegui@upm.es">Rafael Perez-Segui</author>
+  <author email="miguel.fernandez.cortizas@upm.es">Miguel Fernandez-Cortizas</author>
 
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_cmake</depend>
+  <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>as2_core</depend>
@@ -22,6 +26,7 @@
 
   <depend>trajectory_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>eigen</depend>
   <depend>rclcpp_components</depend>
@@ -30,6 +35,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>
+  <test_depend>benchmark</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/package.xml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/package.xml
@@ -6,10 +6,9 @@
   <description>Aerostack behaviors collection for trajectory generation</description>
 
   <maintainer email="cvar.upm3@gmail.com">CVAR-UPM</maintainer>
+  <license>BSD-3-Clause</license>
   <author email="r.psegui@upm.es">Rafael Perez-Segui</author>
   <author email="miguel.fernandez.cortizas@upm.es">Miguel Fernandez-Cortizas</author>
-
-  <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

Refactors `generate_polynomial_trajectory_behavior` from a monolithic backend
into a **`pluginlib`-based architecture**. The `BehaviorServer` node becomes a
thin wrapper; trajectory generation lives behind a stable plugin interface.

This PR introduces the base architecture and the `dynamic_mav_trajectory_generator`
plugin (same backend as the previous monolithic behavior).

## Motivation

The previous behavior hard-wired a single trajectory backend into the node.
Adding or evaluating alternative generators required duplicating all the ROS
orchestration (waypoint ingestion, TF, yaw computation, horizon sampling,
debug topics, pause/resume…) that has nothing to do with the math.

The plugin split isolates the **algorithm** from the **service**, lets each
backend keep its own dependencies, and enables runtime selection via a launch
argument.

## Architecture

```
generate_polynomial_trajectory_behavior/
├── include/.../
│   ├── generate_polynomial_trajectory_base.hpp   # plugin contract
│   └── generate_polynomial_trajectory_behavior.hpp
├── src/
│   ├── generate_polynomial_trajectory_base.cpp
│   ├── generate_polynomial_trajectory_behavior.cpp
│   └── generate_polynomial_trajectory_behavior_node.cpp
├── config/config_default.yaml   # wrapper-only params
├── launch/
├── plugins.xml                  # pluginlib registry
└── plugins/<plugin_name>/
    ├── CMakeLists.txt
    ├── include/<plugin_name>/<plugin_name>.hpp
    ├── src/<plugin_name>.cpp
    ├── config/<plugin_name>.yaml
    ├── tests/
    └── thirdparties/            # gitignored; AMENT_IGNORE auto-written at configure time
```

### Plugin contract (`GeneratePolynomialTrajectoryBase`)

Minimal interface the wrapper needs to drive any backend:

- `initialize(node, plugin_name)` / `ownInitialize()` — init hook.
- `setVehicleState(pose, twist)` — called once per state message; stored in
  protected `vehicle_pose_` / `vehicle_twist_` for plugin entry points to read.
- `generateTrajectory(waypoints, max_speed, t_now)` — fresh trajectory; plugin
  anchors a private `internal_offset_` so the wrapper's `t_trajectory` maps to
  the backend start.
- `updateWaypoints(waypoints, max_speed, t_now)` — update active trajectory.
  Default: `reset()` + `generateTrajectory()` (full regenerate). Plugins that
  support online stitching override to keep `internal_offset_` unchanged.
- `evaluate(t, out, is_horizon)` — sample at host time `t`.
- `isFinished(t)` / `isTrajectoryGenerated()` / `reset()` / `getNextWaypointId()`.
- `consumeRegeneratedFlag()` — `false` by default; async plugins override to
  signal when a deferred regeneration has been swapped in.

Vehicle state flows through base members rather than method arguments, keeping
the contract narrow. Each plugin owns `internal_offset_` to map the wrapper's
monotonic `t_trajectory` onto the backend's native time axis.

### Wrapper responsibilities

Everything **not specific to a generator**:

- Action lifecycle (`on_activate`, `on_modify`, `on_deactivate`, `on_pause`,
  `on_resume`, `on_run`, `on_execution_end`).
- Plugin loading via `pluginlib::ClassLoader`.
- TF / frame conversion, waypoint validation, yaw policies (`KEEP_YAW`,
  `PATH_FACING`, `FIXED_YAW`, `YAW_FROM_TOPIC`, `FACE_REFERENCE`).
- Horizon sampling and forwarding to `TrajectoryMotion`.
- Frame-drift watchdog and debug topics.
- **`start_on_paused`**: generate + hold `PAUSED` until an explicit `resume`;
  every plugin gets this for free.
- **`path_length`**: sliding-window waypoint feed (`0` = send all at once).

### Configuration

| Layer | File | Keys |
|-------|------|------|
| Wrapper | `config/config_default.yaml` | `desired_frame_id`, `sampling_n/dt`, `path_length`, yaw thresholds, TF watchdog, debug topic names |
| Plugin | `plugins/<name>/config/<name>.yaml` | backend-specific params under the plugin namespace (no collision possible) |

Launch argument `plugin_name` defaults to `dynamic_mav_trajectory_generator`;
choices are autocompleted from the `pluginlib` registry.

## `dynamic_mav_trajectory_generator` plugin

Wraps [`dynamic_trajectory_generator`](https://github.com/miferco97/dynamic_trajectory_generator)
(fetched automatically at configure time).

Overrides `updateWaypoints()` for **smooth stitching**: the backend keeps its
continuous time axis, so `internal_offset_` stays unchanged after a modify.
Regeneration is asynchronous (`std::async`); overrides `consumeRegeneratedFlag()`
to expose the swap event so the wrapper refreshes `debug/traj_generated` at the
right moment rather than polling.