### PR TITLE
[as2_behaviors_trajectory_generation] Add plugin mav trajectory generator

### DIFF
--- a/as2_behaviors/as2_behaviors_trajectory_generation/README.md
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/README.md
@@ -8,3 +8,4 @@ time (`find_package` → local clone → `FetchContent`). The directories
 are gitignored and never committed to this repository.
 
 - Dynamic Trajectory Generator: <https://github.com/miferco97/dynamic_trajectory_generator>, based on <https://github.com/ethz-asl/mav_trajectory_generation>
+- Mav Trajectory Generation: <https://github.com/aerostack2/mav_trajectory_generation_library>, based on <https://github.com/ethz-asl/mav_trajectory_generation>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
@@ -75,6 +75,7 @@ ament_export_targets(export_${BEHAVIOR_NAME})
 # --- Plugins ---------------------------------------------------------------
 set(PLUGIN_LIST
   dynamic_mav_trajectory_generator
+  mav_trajectory_generator
 )
 
 foreach(PLUGIN ${PLUGIN_LIST})

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/composable_generate_polynomial_trajectory_behavior.launch.py
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/composable_generate_polynomial_trajectory_behavior.launch.py
@@ -133,7 +133,7 @@ def generate_launch_description():
                               default_value='false'),
         DeclareLaunchArgument(
             'plugin_name',
-            default_value='dynamic_mav_trajectory_generator',
+            default_value='',
             description='Trajectory generator plugin to load. '
                         'If empty, it must be declared in config_file.',
             choices=plugin_choices),

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/generate_polynomial_trajectory_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/launch/generate_polynomial_trajectory_behavior_launch.py
@@ -146,7 +146,7 @@ def generate_launch_description() -> LaunchDescription:
                                   'AEROSTACK2_SIMULATION_DRONE_ID')),
         DeclareLaunchArgument(
             'plugin_name',
-            default_value='dynamic_mav_trajectory_generator',
+            default_value='',
             description='Trajectory generator plugin to load. '
                         'If empty, it must be declared in config_file.',
             choices=plugin_choices),

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
@@ -5,4 +5,10 @@
       <description>Dynamic (runtime-modifiable) polynomial trajectory generator built on top of mav_trajectory_generation.</description>
     </class>
   </library>
+  <library path="mav_trajectory_generator">
+    <class type="mav_trajectory_generator::Plugin"
+           base_class_type="generate_polynomial_trajectory_behavior_plugin_base::GeneratePolynomialTrajectoryBase">
+      <description>Static polynomial trajectory generator built on the ETH-ASL mav_trajectory_generation core.</description>
+    </class>
+  </library>
 </class_libraries>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/CMakeLists.txt
@@ -1,0 +1,143 @@
+cmake_minimum_required(VERSION 3.16)
+set(PLUGIN_NAME mav_trajectory_generator)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# Set Release as default
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Plugin dependencies (mostly inherited from the package).
+set(PLUGIN_DEPENDENCIES
+  ament_cmake
+  rclcpp
+  pluginlib
+  as2_core
+  as2_msgs
+  geometry_msgs
+  nav_msgs
+  visualization_msgs
+  Eigen3
+)
+
+foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
+  find_package(${DEPENDENCY} REQUIRED)
+endforeach()
+
+# --- Sanitize upstream BUILD_* options inherited via cache.
+# When the user (or an IDE like VSCode CMake Tools) passes
+# -DBUILD_PYBIND=ON / -DBUILD_DEVELOPER_TESTS=ON we honour them as long as
+# the required tools are present on the host. Otherwise we downgrade the
+# option to OFF (with a warning) so the configure step still succeeds.
+# Keeps the wrapper plugin tolerant to heterogeneous environments without
+# touching package.xml dependencies.
+if(BUILD_PYBIND)
+  find_package(Python3 COMPONENTS Interpreter Development QUIET)
+  find_package(pybind11 QUIET)
+  if(NOT Python3_FOUND OR NOT pybind11_FOUND)
+    message(WARNING
+      "[mav_trajectory_generator] BUILD_PYBIND=ON but Python3 Development "
+      "or pybind11 not found; disabling BUILD_PYBIND for upstream "
+      "mav_trajectory_generation_cpp. Install python3-dev and pybind11-dev "
+      "to re-enable.")
+    set(BUILD_PYBIND OFF CACHE BOOL "" FORCE)
+  endif()
+endif()
+
+if(BUILD_DEVELOPER_TESTS)
+  find_program(_MTG_CPPLINT       NAMES cpplint)
+  find_program(_MTG_CLANG_FORMAT  NAMES clang-format)
+  find_program(_MTG_LCOV          NAMES lcov)
+  if(NOT _MTG_CPPLINT OR NOT _MTG_CLANG_FORMAT OR NOT _MTG_LCOV)
+    message(WARNING
+      "[mav_trajectory_generator] BUILD_DEVELOPER_TESTS=ON but cpplint/"
+      "clang-format/lcov are not all available; disabling "
+      "BUILD_DEVELOPER_TESTS for upstream mav_trajectory_generation_cpp.")
+    set(BUILD_DEVELOPER_TESTS OFF CACHE BOOL "" FORCE)
+  endif()
+endif()
+
+# --- mav_trajectory_generation_cpp: prefer system → local clone → FetchContent
+# The local clone lives in plugins/<plugin>/thirdparties/<lib>/ so it is fetched
+# only the first time and reused on subsequent builds. The parent thirdparties/
+# directory is gitignored repo-wide; we drop an AMENT_IGNORE there at configure
+# time so colcon never indexes the upstream package.xml files as ROS packages
+# and so the ament file-walking linters (cpplint, uncrustify, ...) skip the
+# vendored sources.
+set(_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
+file(MAKE_DIRECTORY ${_THIRDPARTIES_DIR})
+file(WRITE ${_THIRDPARTIES_DIR}/AMENT_IGNORE "")
+
+find_package(mav_trajectory_generation_cpp QUIET)
+if(${mav_trajectory_generation_cpp_FOUND})
+  message(STATUS "mav_trajectory_generation_cpp found system-wide")
+else()
+  set(LOCAL_MTG_SRC ${_THIRDPARTIES_DIR}/mav_trajectory_generation_lib)
+  if(EXISTS ${LOCAL_MTG_SRC}/CMakeLists.txt)
+    message(STATUS "mav_trajectory_generation_cpp: using local clone at ${LOCAL_MTG_SRC}")
+    add_subdirectory(${LOCAL_MTG_SRC} ${CMAKE_BINARY_DIR}/mav_trajectory_generation_lib_build)
+  else()
+    message(STATUS "mav_trajectory_generation_cpp: cloning into ${LOCAL_MTG_SRC}")
+    include(FetchContent)
+    fetchcontent_declare(
+      mav_trajectory_generation_cpp
+      GIT_REPOSITORY https://github.com/aerostack2/mav_trajectory_generation_lib.git
+      GIT_TAG v1.0
+      SOURCE_DIR ${LOCAL_MTG_SRC}
+    )
+    fetchcontent_makeavailable(mav_trajectory_generation_cpp)
+  endif()
+endif()
+
+include_directories(
+  include
+  include/${PLUGIN_NAME}
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
+set(SOURCE_CPP_FILES
+  src/${PLUGIN_NAME}.cpp
+)
+
+# Plugin shared library (loaded by pluginlib::ClassLoader).
+add_library(${PLUGIN_NAME} SHARED ${SOURCE_CPP_FILES})
+target_link_libraries(${PLUGIN_NAME}
+  ${BEHAVIOR_NAME}_plugin_base
+  mav_trajectory_generation_cpp
+)
+ament_target_dependencies(${PLUGIN_NAME} ${PLUGIN_DEPENDENCIES})
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PLUGIN_NAME})
+ament_export_targets(export_${PLUGIN_NAME})
+
+install(
+  TARGETS ${PLUGIN_NAME}
+  EXPORT export_${PLUGIN_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Re-export upstream target so downstream packages can resolve it.
+install(
+  TARGETS mav_trajectory_generation_cpp
+  EXPORT export_mav_trajectory_generation_cpp
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/config/mav_trajectory_generator.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/config/mav_trajectory_generator.yaml
@@ -1,0 +1,15 @@
+/**:
+  ros__parameters:
+    mav_trajectory_generator:
+      # Defaults aligned with the hard-coded configuration of the
+      # dynamic_mav_trajectory_generator plugin so trajectories match.
+      optimization:
+        derivative_to_optimize: 2              # 0=POS, 1=VEL, 2=ACC, 3=JERK, 4=SNAP
+        solver: 'nonlinear'                    # 'linear' | 'nonlinear'
+        a_max: 9.81                            # m/s^2 (MAV_MAX_ACCEL = 1.0 * g)
+        nl_max_iterations: 2000                # NLopt iteration cap (nonlinear only)
+        nl_f_rel: 0.05                         # NLopt relative cost tolerance
+        nl_x_rel: 0.1                          # NLopt relative parameter tolerance
+        nl_time_penalty: 1000.0                # NLopt time penalty
+        nl_initial_stepsize_rel: 0.1           # NLopt initial step size
+        nl_inequality_constraint_tolerance: 0.2  # NLopt inequality tolerance

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/include/mav_trajectory_generator/mav_trajectory_generator.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/include/mav_trajectory_generator/mav_trajectory_generator.hpp
@@ -1,0 +1,116 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file mav_trajectory_generator.hpp
+ *
+ * @brief Plugin wrapper around mav_trajectory_generation_cpp::TrajectoryGenerator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#ifndef MAV_TRAJECTORY_GENERATOR__MAV_TRAJECTORY_GENERATOR_HPP_
+#define MAV_TRAJECTORY_GENERATOR__MAV_TRAJECTORY_GENERATOR_HPP_
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+#include "mav_trajectory_generation_cpp/trajectory_generator.hpp"
+#include "mav_trajectory_generation_cpp/types.hpp"
+
+namespace mav_trajectory_generator
+{
+
+/**
+ * @brief Plugin wrapper for the static (offline) ETH-ASL
+ * mav_trajectory_generation backend.
+ *
+ * The plugin does not override updateWaypoints(): each modify request
+ * goes through the base class default, which calls reset() +
+ * generateTrajectory() with the live vehicle pose and twist as
+ * boundary conditions, so the resulting trajectory is C1-continuous
+ * with the drone state at the time of the re-plan.
+ */
+class Plugin : public generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase
+{
+public:
+  Plugin();
+  ~Plugin() override = default;
+
+  bool generateTrajectory(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed,
+    double t_trajectory_now) override;
+
+  bool evaluate(
+    double t_trajectory,
+    as2_msgs::msg::TrajectoryPoint & out,
+    bool is_horizon_sample) override;
+
+  bool isFinished(double t_trajectory) const override;
+  double getDuration() const override;
+  bool isTrajectoryGenerated() override;
+  void reset() override;
+
+  std::string getNextWaypointId() override;
+
+protected:
+  void ownInitialize() override;
+
+private:
+  void readConfigParameters();
+
+  static mav_trajectory_generation_cpp::Waypoint toMavWaypoint(
+    const as2_msgs::msg::PoseStampedWithID & wp);
+
+  mav_trajectory_generation_cpp::GeneratorConfig generator_config_;
+  std::unique_ptr<mav_trajectory_generation_cpp::TrajectoryGenerator>
+  trajectory_generator_;
+
+  // Mission progress: ordered (waypoint_id, t_arrival) for each waypoint
+  // beyond the implicit start. Walked by getNextWaypointId() against
+  // last_eval_backend_time_, which tracks the latest non-horizon
+  // evaluation time in the backend's own time axis.
+  std::vector<std::pair<std::string, double>> waypoint_arrival_times_;
+  double last_eval_backend_time_{0.0};
+
+  // Maps host trajectory time to backend time:
+  //   t_backend = t_trajectory + internal_offset_.
+  // Anchored on every generateTrajectory().
+  double internal_offset_{0.0};
+};
+
+}  // namespace mav_trajectory_generator
+
+#endif  // MAV_TRAJECTORY_GENERATOR__MAV_TRAJECTORY_GENERATOR_HPP_

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/src/mav_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/src/mav_trajectory_generator.cpp
@@ -1,0 +1,241 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file mav_trajectory_generator.cpp
+ *
+ * @brief Plugin wrapper around mav_trajectory_generation_cpp::TrajectoryGenerator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include "mav_trajectory_generator/mav_trajectory_generator.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace mav_trajectory_generator
+{
+
+namespace
+{
+mav_trajectory_generation_cpp::Solver parseSolver(const std::string & raw)
+{
+  std::string s = raw;
+  std::transform(
+    s.begin(), s.end(), s.begin(),
+    [](unsigned char c) {return std::tolower(c);});
+  if (s == "nonlinear") {
+    return mav_trajectory_generation_cpp::Solver::Nonlinear;
+  }
+  return mav_trajectory_generation_cpp::Solver::Linear;
+}
+}  // namespace
+
+Plugin::Plugin() = default;
+
+void Plugin::ownInitialize()
+{
+  readConfigParameters();
+}
+
+void Plugin::readConfigParameters()
+{
+  auto & opt = generator_config_.optimization;
+
+  std::string solver_str = "linear";
+  getParameter<std::string>("optimization.solver", solver_str, true);
+  opt.solver = parseSolver(solver_str);
+
+  getParameter<int>(
+    "optimization.derivative_to_optimize", opt.derivative_to_optimize, true);
+  getParameter<double>("optimization.a_max", opt.a_max, true);
+  getParameter<int>(
+    "optimization.nl_max_iterations", opt.nl_max_iterations, true);
+  getParameter<double>("optimization.nl_f_rel", opt.nl_f_rel, true);
+  getParameter<double>("optimization.nl_x_rel", opt.nl_x_rel, true);
+  getParameter<double>(
+    "optimization.nl_time_penalty", opt.nl_time_penalty, true);
+  getParameter<double>(
+    "optimization.nl_initial_stepsize_rel", opt.nl_initial_stepsize_rel, true);
+  getParameter<double>(
+    "optimization.nl_inequality_constraint_tolerance",
+    opt.nl_inequality_constraint_tolerance, true);
+}
+
+mav_trajectory_generation_cpp::Waypoint Plugin::toMavWaypoint(
+  const as2_msgs::msg::PoseStampedWithID & wp)
+{
+  mav_trajectory_generation_cpp::Waypoint out;
+  out.position = Eigen::Vector3d(
+    wp.pose.pose.position.x,
+    wp.pose.pose.position.y,
+    wp.pose.pose.position.z);
+  // Endpoints default to zero velocity / acceleration when fields are unset
+  // (mav_trajectory_generation_cpp::Waypoint contract).
+  return out;
+}
+
+bool Plugin::generateTrajectory(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+  double max_speed,
+  double t_trajectory_now)
+{
+  waypoint_arrival_times_.clear();
+  last_eval_backend_time_ = 0.0;
+
+  if (waypoints.empty() || max_speed <= 0.0) {
+    trajectory_generator_.reset();
+    return false;
+  }
+
+  // Recreate backend per goal to avoid stale trajectory state.
+  trajectory_generator_ =
+    std::make_unique<mav_trajectory_generation_cpp::TrajectoryGenerator>(
+    generator_config_);
+
+  // Prepend the current vehicle state as the trajectory start. Position
+  // and velocity become hard boundary conditions for the optimizer (the
+  // optional velocity field is honored when set on the first waypoint).
+  // This guarantees C1 continuity at the start when re-planning while
+  // the drone is already in motion.
+  std::vector<mav_trajectory_generation_cpp::Waypoint> wps;
+  wps.reserve(waypoints.size() + 1);
+  mav_trajectory_generation_cpp::Waypoint start;
+  start.position = Eigen::Vector3d(
+    vehicle_pose_.pose.position.x,
+    vehicle_pose_.pose.position.y,
+    vehicle_pose_.pose.position.z);
+  start.velocity = Eigen::Vector3d(
+    vehicle_twist_.twist.linear.x,
+    vehicle_twist_.twist.linear.y,
+    vehicle_twist_.twist.linear.z);
+  wps.emplace_back(std::move(start));
+  for (const auto & wp : waypoints) {
+    wps.emplace_back(toMavWaypoint(wp));
+  }
+
+  if (!trajectory_generator_->generate(wps, max_speed)) {
+    return false;
+  }
+
+  // Map mission waypoint ids to spline breakpoint times. wps[0] is the
+  // synthetic start, so bps[i+1] corresponds to waypoints[i].
+  const auto bps = trajectory_generator_->spline().breakpoints();
+  if (!bps.empty()) {
+    const double t0 = bps.front();
+    for (std::size_t i = 1; i < bps.size() && (i - 1) < waypoints.size();
+      ++i)
+    {
+      waypoint_arrival_times_.emplace_back(
+        waypoints[i - 1].id, bps[i] - t0);
+    }
+  }
+  // Anchor host axis to backend axis: t_trajectory_now -> minTime().
+  internal_offset_ = trajectory_generator_->minTime() - t_trajectory_now;
+  return true;
+}
+
+bool Plugin::evaluate(
+  double t_trajectory,
+  as2_msgs::msg::TrajectoryPoint & out,
+  bool is_horizon_sample)
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return false;
+  }
+
+  const double t_backend = std::clamp(
+    t_trajectory + internal_offset_,
+    trajectory_generator_->minTime(), trajectory_generator_->maxTime());
+
+  const auto sample = trajectory_generator_->evaluate(t_backend);
+  out.position.x = sample.position.x();
+  out.position.y = sample.position.y();
+  out.position.z = sample.position.z();
+  out.twist.x = sample.velocity.x();
+  out.twist.y = sample.velocity.y();
+  out.twist.z = sample.velocity.z();
+  out.acceleration.x = sample.acceleration.x();
+  out.acceleration.y = sample.acceleration.y();
+  out.acceleration.z = sample.acceleration.z();
+
+  if (!is_horizon_sample) {
+    last_eval_backend_time_ = t_backend;
+  }
+  return true;
+}
+
+bool Plugin::isFinished(double t_trajectory) const
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return true;
+  }
+  return (t_trajectory + internal_offset_) >= trajectory_generator_->maxTime();
+}
+
+double Plugin::getDuration() const
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return 0.0;
+  }
+  return trajectory_generator_->maxTime() - trajectory_generator_->minTime();
+}
+
+bool Plugin::isTrajectoryGenerated()
+{
+  return trajectory_generator_ && trajectory_generator_->isValid();
+}
+
+void Plugin::reset()
+{
+  trajectory_generator_.reset();
+  waypoint_arrival_times_.clear();
+  last_eval_backend_time_ = 0.0;
+  internal_offset_ = 0.0;
+}
+
+std::string Plugin::getNextWaypointId()
+{
+  for (const auto & [id, t_arrival] : waypoint_arrival_times_) {
+    if (t_arrival > last_eval_backend_time_) {
+      return id;
+    }
+  }
+  return {};
+}
+
+}  // namespace mav_trajectory_generator
+
+PLUGINLIB_EXPORT_CLASS(
+  mav_trajectory_generator::Plugin,
+  generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase)

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+# GTest of the mav_trajectory_generator plugin.
+# Loads the plugin via pluginlib and exercises the public base API.
+file(GLOB GTEST_SOURCES "*_gtest.cpp")
+file(GLOB BENCHMARK_SOURCES "*_benchmark.cpp")
+
+if(GTEST_SOURCES)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
+
+  foreach(TEST_SOURCE ${GTEST_SOURCES})
+    get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+
+    ament_add_gtest(${TEST_NAME} ${TEST_SOURCE})
+    ament_target_dependencies(${TEST_NAME} ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${TEST_NAME}
+      ament_index_cpp::ament_index_cpp
+      gtest_main
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()
+
+# Per-plugin Google-Benchmark binaries. Each source owns its main() and
+# registers whichever plugin it wants to exercise.
+find_package(benchmark QUIET)
+if(benchmark_FOUND AND BENCHMARK_SOURCES)
+  set(BENCHMARK_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/common)
+
+  foreach(BENCHMARK_SOURCE ${BENCHMARK_SOURCES})
+    get_filename_component(BENCHMARK_NAME ${BENCHMARK_SOURCE} NAME_WE)
+
+    add_executable(${PROJECT_NAME}_${BENCHMARK_NAME} ${BENCHMARK_SOURCE})
+    target_include_directories(${PROJECT_NAME}_${BENCHMARK_NAME} PRIVATE
+      ${BENCHMARK_COMMON_DIR})
+    ament_target_dependencies(${PROJECT_NAME}_${BENCHMARK_NAME}
+      ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${PROJECT_NAME}_${BENCHMARK_NAME}
+      benchmark::benchmark
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/tests/mav_trajectory_generator_benchmark.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/tests/mav_trajectory_generator_benchmark.cpp
@@ -1,0 +1,46 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <benchmark/benchmark.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "generate_polynomial_trajectory_benchmark_common.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  generate_polynomial_trajectory_benchmark::silenceRosLogging();
+  benchmark::Initialize(&argc, argv);
+  generate_polynomial_trajectory_benchmark::registerPluginBenchmarks(
+    "mav_trajectory_generator");
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/tests/mav_trajectory_generator_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/tests/mav_trajectory_generator_gtest.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file mav_trajectory_generator_gtest.cpp
+ *
+ * @brief Plugin-level tests for mav_trajectory_generator.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "as2_core/node.hpp"
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase;
+
+namespace
+{
+as2_msgs::msg::PoseStampedWithID makeWaypoint(
+  const std::string & id, double x, double y, double z)
+{
+  as2_msgs::msg::PoseStampedWithID wp;
+  wp.id = id;
+  wp.pose.header.frame_id = "earth";
+  wp.pose.pose.position.x = x;
+  wp.pose.pose.position.y = y;
+  wp.pose.pose.position.z = z;
+  wp.pose.pose.orientation.w = 1.0;
+  return wp;
+}
+
+geometry_msgs::msg::PoseStamped makePose(double x, double y, double z)
+{
+  geometry_msgs::msg::PoseStamped p;
+  p.header.frame_id = "earth";
+  p.pose.position.x = x;
+  p.pose.position.y = y;
+  p.pose.position.z = z;
+  p.pose.orientation.w = 1.0;
+  return p;
+}
+
+struct PluginFixture
+{
+  std::shared_ptr<as2::Node> node;
+  std::shared_ptr<pluginlib::ClassLoader<PluginBase>> loader;
+  std::shared_ptr<PluginBase> plugin;
+};
+
+PluginFixture makePluginFixture(
+  const std::string & node_name,
+  const std::vector<rclcpp::Parameter> & parameter_overrides)
+{
+  PluginFixture f;
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(parameter_overrides);
+  f.node = std::make_shared<as2::Node>(node_name, options);
+  f.loader = std::make_shared<pluginlib::ClassLoader<PluginBase>>(
+    "as2_behaviors_trajectory_generation",
+    "generate_polynomial_trajectory_behavior_plugin_base::"
+    "GeneratePolynomialTrajectoryBase");
+  f.plugin = f.loader->createSharedInstance(
+    "mav_trajectory_generator::Plugin");
+  f.plugin->initialize(f.node.get(), "mav_trajectory_generator");
+  return f;
+}
+}  // namespace
+
+TEST(MavTrajectoryGenerator, load_generate_evaluate_reset) {
+  auto fx = makePluginFixture("mav_traj_gen_test", {});
+
+  // Mission waypoints only — the plugin auto-prepends the current
+  // vehicle pose as the trajectory start.
+  std::vector<as2_msgs::msg::PoseStampedWithID> waypoints = {
+    makeWaypoint("waypoint_000", 2.0, 0.0, 1.0),
+    makeWaypoint("waypoint_001", 4.0, 0.0, 1.0),
+  };
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), zero_twist);
+
+  ASSERT_TRUE(
+    fx.plugin->generateTrajectory(
+      waypoints, /*max_speed=*/ 1.0, /*t_trajectory_now=*/ 0.0));
+  ASSERT_TRUE(fx.plugin->isTrajectoryGenerated());
+  ASSERT_FALSE(fx.plugin->isFinished(0.0));
+  ASSERT_TRUE(fx.plugin->isFinished(1e6));
+
+  // At t_trajectory = 0, the next pending waypoint is the first mission
+  // waypoint after the implicit start.
+  as2_msgs::msg::TrajectoryPoint p_start;
+  EXPECT_TRUE(fx.plugin->evaluate(0.0, p_start, false));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_000");
+
+  double t_end = 0.0;
+  for (double t = 0.0; t < 1e3; t += 0.05) {
+    if (fx.plugin->isFinished(t)) {
+      t_end = t;
+      break;
+    }
+  }
+  ASSERT_GT(t_end, 0.0);
+  const double t_mid = 0.5 * t_end;
+  as2_msgs::msg::TrajectoryPoint p_mid;
+  EXPECT_TRUE(fx.plugin->evaluate(t_mid, p_mid, false));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_001");
+
+  fx.plugin->reset();
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+  EXPECT_TRUE(fx.plugin->getNextWaypointId().empty());
+}
+
+TEST(MavTrajectoryGenerator, rejects_degenerate_inputs) {
+  auto fx = makePluginFixture("mav_traj_gen_degenerate", {});
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), zero_twist);
+
+  std::vector<as2_msgs::msg::PoseStampedWithID> empty;
+  EXPECT_FALSE(
+    fx.plugin->generateTrajectory(empty, 1.0, /*t_trajectory_now=*/ 0.0));
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+
+  std::vector<as2_msgs::msg::PoseStampedWithID> one = {
+    makeWaypoint("end", 1.0, 0.0, 1.0),
+  };
+  EXPECT_FALSE(
+    fx.plugin->generateTrajectory(
+      one, /*max_speed=*/ 0.0, /*t_trajectory_now=*/ 0.0));
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

Adds a new `mav_trajectory_generator` plugin that wraps the
[`mav_trajectory_generation_cpp`](https://github.com/aerostack2/mav_trajectory_generation_lib.git)
upstream (ETH-ASL static polynomial trajectory generator).

## Plugin specifics

- **Backend**:
  [`mav_trajectory_generation_cpp`](https://github.com/aerostack2/mav_trajectory_generation_lib.git)
  (`main`). Resolution policy in `CMakeLists.txt`:
  `find_package(mav_trajectory_generation_cpp QUIET)` → local clone
  under
  `plugins/mav_trajectory_generator/thirdparties/mav_trajectory_generation_lib/`
  → `FetchContent`. The local clone is reused on subsequent builds.
- **Time-axis**: relies on the **base default** `updateWaypoints()`
  (regenerate via `reset()` + `generateTrajectory(t_trajectory_now)`).
  Each `generateTrajectory(t)` re-anchors the plugin's
  `internal_offset_` so the host's `t_trajectory` keeps mapping to a
  valid backend time after a regeneration.
- **Initial state**: uses the upstream `Waypoint::velocity` optional
  to inject `vehicle_twist_.linear` into the first waypoint, so
  re-plans during flight stay C¹-continuous against the current
  vehicle twist.
- **Configuration**: backend-only keys live under the plugin
  namespace in
  `config/mav_trajectory_generator.yaml`
  and are read with the protected `getParameter<T>()` helper from the
  base class (auto-prefixed with the plugin name).