### PR TITLE
[as2_behaviors_trajectory_generation] Add plugin gcopter trajectory generator

### DIFF
--- a/as2_behaviors/as2_behaviors_trajectory_generation/README.md
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/README.md
@@ -9,3 +9,4 @@ are gitignored and never committed to this repository.
 
 - Dynamic Trajectory Generator: <https://github.com/miferco97/dynamic_trajectory_generator>, based on <https://github.com/ethz-asl/mav_trajectory_generation>
 - Mav Trajectory Generation: <https://github.com/aerostack2/mav_trajectory_generation_library>, based on <https://github.com/ethz-asl/mav_trajectory_generation>
+- GCOPTER Trajectory Generator: <https://github.com/aerostack2/gcopter_trajectory_generator_lib>, based on <https://github.com/ZJU-FAST-Lab/GCOPTER>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
@@ -76,6 +76,7 @@ ament_export_targets(export_${BEHAVIOR_NAME})
 set(PLUGIN_LIST
   dynamic_mav_trajectory_generator
   mav_trajectory_generator
+  gcopter_trajectory_generator
 )
 
 foreach(PLUGIN ${PLUGIN_LIST})

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
@@ -11,4 +11,10 @@
       <description>Static polynomial trajectory generator built on the ETH-ASL mav_trajectory_generation core.</description>
     </class>
   </library>
+  <library path="gcopter_trajectory_generator">
+    <class type="gcopter_trajectory_generator::Plugin"
+           base_class_type="generate_polynomial_trajectory_behavior_plugin_base::GeneratePolynomialTrajectoryBase">
+      <description>GCOPTER-based polynomial trajectory generator with safe-flight-corridor optimization.</description>
+    </class>
+  </library>
 </class_libraries>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/CMakeLists.txt
@@ -1,0 +1,129 @@
+cmake_minimum_required(VERSION 3.5)
+set(PLUGIN_NAME gcopter_trajectory_generator)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# Set Release as default
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Plugin dependencies (mostly inherited from the package).
+set(PLUGIN_DEPENDENCIES
+  ament_cmake
+  rclcpp
+  pluginlib
+  as2_core
+  as2_msgs
+  geometry_msgs
+  nav_msgs
+  visualization_msgs
+  Eigen3
+)
+
+foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
+  find_package(${DEPENDENCY} REQUIRED)
+endforeach()
+
+# --- Sanitize upstream BUILD_* options inherited via cache.
+# When the user (or an IDE like VSCode CMake Tools) passes
+# -DBUILD_PYBIND=ON we honour it as long as the required tools are present
+# on the host. Otherwise we downgrade the option to OFF (with a warning) so
+# the configure step still succeeds. Keeps the wrapper plugin tolerant to
+# heterogeneous environments without touching package.xml dependencies.
+if(BUILD_PYBIND)
+  find_package(Python3 COMPONENTS Interpreter Development QUIET)
+  find_package(pybind11 QUIET)
+  if(NOT Python3_FOUND OR NOT pybind11_FOUND)
+    message(WARNING
+      "[gcopter_trajectory_generator] BUILD_PYBIND=ON but Python3 "
+      "Development or pybind11 not found; disabling BUILD_PYBIND for "
+      "upstream gcopter_lib. Install python3-dev and pybind11-dev to "
+      "re-enable.")
+    set(BUILD_PYBIND OFF CACHE BOOL "" FORCE)
+  endif()
+endif()
+
+# --- gcopter_lib: prefer system → local clone → FetchContent
+# The local clone lives in plugins/<plugin>/thirdparties/<lib>/ so it is fetched
+# only the first time and reused on subsequent builds. The parent thirdparties/
+# directory is gitignored repo-wide; we drop an AMENT_IGNORE there at configure
+# time so colcon never indexes the upstream package.xml files as ROS packages
+# and so the ament file-walking linters (cpplint, uncrustify, ...) skip the
+# vendored sources.
+set(_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
+file(MAKE_DIRECTORY ${_THIRDPARTIES_DIR})
+file(WRITE ${_THIRDPARTIES_DIR}/AMENT_IGNORE "")
+
+find_package(gcopter_lib QUIET)
+if(${gcopter_lib_FOUND})
+  message(STATUS "gcopter_lib found system-wide")
+else()
+  set(LOCAL_GCOPTER_SRC ${_THIRDPARTIES_DIR}/gcopter_trajectory_generator_lib)
+  if(EXISTS ${LOCAL_GCOPTER_SRC}/CMakeLists.txt)
+    message(STATUS "gcopter_trajectory_generator_lib: using local clone at ${LOCAL_GCOPTER_SRC}")
+    add_subdirectory(${LOCAL_GCOPTER_SRC} ${CMAKE_BINARY_DIR}/gcopter_trajectory_generator_lib_build)
+  else()
+    message(STATUS "gcopter_trajectory_generator_lib: cloning into ${LOCAL_GCOPTER_SRC}")
+    include(FetchContent)
+    fetchcontent_declare(
+      gcopter_trajectory_generator_lib
+      GIT_REPOSITORY https://github.com/aerostack2/gcopter_trajectory_generator_lib.git
+      GIT_TAG main
+      SOURCE_DIR ${LOCAL_GCOPTER_SRC}
+    )
+    fetchcontent_makeavailable(gcopter_trajectory_generator_lib)
+  endif()
+endif()
+
+include_directories(
+  include
+  include/${PLUGIN_NAME}
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
+set(SOURCE_CPP_FILES
+  src/${PLUGIN_NAME}.cpp
+)
+
+# Plugin shared library (loaded by pluginlib::ClassLoader).
+add_library(${PLUGIN_NAME} SHARED ${SOURCE_CPP_FILES})
+target_link_libraries(${PLUGIN_NAME}
+  ${BEHAVIOR_NAME}_plugin_base
+  gcopter_lib
+)
+ament_target_dependencies(${PLUGIN_NAME} ${PLUGIN_DEPENDENCIES})
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PLUGIN_NAME})
+ament_export_targets(export_${PLUGIN_NAME})
+
+install(
+  TARGETS ${PLUGIN_NAME}
+  EXPORT export_${PLUGIN_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Re-export upstream target so downstream packages can resolve it.
+install(
+  TARGETS gcopter_lib
+  EXPORT export_gcopter_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/config/gcopter_trajectory_generator.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/config/gcopter_trajectory_generator.yaml
@@ -1,0 +1,41 @@
+/**:
+  ros__parameters:
+    gcopter_trajectory_generator:
+      # Vehicle physical parameters consumed by GCOPTER's flatness model.
+      drone:
+        mass: 1.0                  # kg
+        gravity: 9.81              # m/s^2
+        horizontal_drag: 0.1       # -
+        vertical_drag: 0.1         # -
+        parasitic_drag: 0.01       # -
+        speed_smooth_factor: 0.01  # -
+      # Hard magnitude bounds enforced by GCOPTER. The behavior goal's
+      # max_speed transiently overrides limits.max_velocity for a single call.
+      limits:
+        max_velocity: 5.0          # m/s
+        max_body_rate: 6.0         # rad/s
+        max_tilt_angle: 0.785      # rad
+        min_thrust: 0.1            # N
+        max_thrust: 30.0           # N
+      # L-BFGS optimizer tuning. Defaults match gcopter_lib's struct defaults.
+      optimization:
+        time_weight: 512.0
+        position_weight: 10000.0
+        velocity_weight: 10000.0
+        body_rate_weight: 10000.0
+        tilt_weight: 10000.0
+        thrust_weight: 10000.0
+        smoothing_eps: 0.01
+        integral_resolution: 16
+        rel_cost_tol: 0.001
+        corridor_margin: 0.1       # m (loose AABB half-margin per face used
+                                   # between anchors and on segments without
+                                   # intermediate waypoints)
+      # Waypoint adherence: insert anchor points around each intermediate
+      # waypoint and tighten the AABB corridor on the two pinch segments that
+      # touch them. This forces the optimised trajectory to pass close to the
+      # user waypoints; without it the corridor's overlap region lets the
+      # solver cut corners. Setting either knob <=0 disables anchoring.
+      waypoints:
+        waypoint_margin: 0.1          # m (tight pinch-segment AABB half-margin)
+        waypoint_anchor_radius: 0.5   # m (offset of each anchor along the path)

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/include/gcopter_trajectory_generator/gcopter_trajectory_generator.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/include/gcopter_trajectory_generator/gcopter_trajectory_generator.hpp
@@ -1,0 +1,170 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file gcopter_trajectory_generator.hpp
+ *
+ * @brief Plugin wrapper around gcopter_lib::TrajectoryGenerator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#ifndef GCOPTER_TRAJECTORY_GENERATOR__GCOPTER_TRAJECTORY_GENERATOR_HPP_
+#define GCOPTER_TRAJECTORY_GENERATOR__GCOPTER_TRAJECTORY_GENERATOR_HPP_
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+#include "gcopter_lib/trajectory_generator.hpp"
+#include "gcopter_lib/types.hpp"
+
+namespace gcopter_trajectory_generator
+{
+
+/**
+ * @brief Plugin wrapper for gcopter_lib::TrajectoryGenerator backend.
+ *
+ * The optimizer is offline and produces a piecewise polynomial spline
+ * that can be evaluated continuously. The plugin does not override
+ * updateWaypoints(): each modify request goes through the base class
+ * default, which calls reset() + generateTrajectory() with the live
+ * vehicle pose and twist as boundary conditions, so the resulting
+ * trajectory is C1-continuous with the drone state at the time of the
+ * re-plan.
+ */
+class Plugin : public generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase
+{
+public:
+  Plugin();
+  ~Plugin() override = default;
+
+  bool generateTrajectory(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed,
+    double t_trajectory_now) override;
+
+  bool evaluate(
+    double t_trajectory,
+    as2_msgs::msg::TrajectoryPoint & out,
+    bool is_horizon_sample) override;
+
+  bool isFinished(double t_trajectory) const override;
+  double getDuration() const override;
+  bool isTrajectoryGenerated() override;
+  void reset() override;
+
+  std::string getNextWaypointId() override;
+
+  /**
+   * @brief Path with waypoint anchors and per-segment corridor margins.
+   *
+   * Used internally to insert anchor points around each user waypoint to
+   * tighten the AABB Safe Flight Corridor near them, while keeping a loose
+   * margin between anchors. `original_indices` stores the position of each
+   * input waypoint inside @ref positions so the host can map mission ids
+   * back to backend breakpoints.
+   */
+  struct ExpandedPath
+  {
+    std::vector<Eigen::Vector3d> positions;
+    std::vector<double> margins;
+    std::vector<std::size_t> original_indices;
+  };
+
+  /**
+   * @brief Insert anchor points around intermediate waypoints.
+   *
+   * For N >= 3 input waypoints, places one anchor at distance min(@p
+   * anchor_radius, 0.45 * leg_length) before and after each intermediate
+   * waypoint along the entry/exit directions. The two pinch segments that
+   * touch each waypoint receive @p tight_margin while the rest of the
+   * corridor uses @p loose_margin. For coincident consecutive waypoints
+   * the anchor is skipped (no useful direction). For N < 3 or when
+   * anchoring is disabled, returns the original waypoints with a uniform
+   * @p loose_margin per segment.
+   *
+   * Exposed publicly to keep it unit-testable without instantiating the
+   * full ROS plugin.
+   *
+   * @param waypoints     Ordered waypoint positions [m].
+   * @param loose_margin  Default AABB half-margin per face [m].
+   * @param tight_margin  Half-margin for the pinch segments [m]. <=0
+   *                      disables anchoring.
+   * @param anchor_radius Offset of each anchor along the path [m]. <=0
+   *                      disables anchoring.
+   * @return Expanded path with per-segment margins and a mapping back to
+   *         the original waypoint indices.
+   */
+  static ExpandedPath expandPathWithAnchors(
+    const std::vector<Eigen::Vector3d> & waypoints,
+    double loose_margin,
+    double tight_margin,
+    double anchor_radius);
+
+protected:
+  void ownInitialize() override;
+
+private:
+  void readConfigParameters();
+
+  static gcopter_lib::Waypoint toGcopterWaypoint(
+    const as2_msgs::msg::PoseStampedWithID & wp);
+
+  gcopter_lib::GeneratorConfig generator_config_;
+  std::unique_ptr<gcopter_lib::TrajectoryGenerator> trajectory_generator_;
+
+  // Anchor expansion knobs read from the YAML configuration. Both must be
+  // strictly positive for anchoring to engage; otherwise the plugin falls
+  // back to a uniform corridor margin.
+  double waypoint_margin_{0.1};
+  double waypoint_anchor_radius_{0.5};
+
+  // Mission progress: ordered (waypoint_id, t_arrival) for each waypoint
+  // beyond the implicit start. Walked by getNextWaypointId() against
+  // last_eval_backend_time_, which tracks the latest non-horizon
+  // evaluation time in the backend's own time axis (anchored at
+  // minTime()=0 for gcopter, so t_arrival = bps[i] directly).
+  std::vector<std::pair<std::string, double>> waypoint_arrival_times_;
+  double last_eval_backend_time_{0.0};
+
+  // Maps host trajectory time to backend time:
+  //   t_backend = t_trajectory + internal_offset_.
+  // Anchored on every generateTrajectory() so the host's t_trajectory_now
+  // maps to the backend's minTime() == 0.
+  double internal_offset_{0.0};
+};
+
+}  // namespace gcopter_trajectory_generator
+
+#endif  // GCOPTER_TRAJECTORY_GENERATOR__GCOPTER_TRAJECTORY_GENERATOR_HPP_

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/src/gcopter_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/src/gcopter_trajectory_generator.cpp
@@ -1,0 +1,393 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file gcopter_trajectory_generator.cpp
+ *
+ * @brief Plugin wrapper around gcopter_lib::TrajectoryGenerator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include "gcopter_trajectory_generator/gcopter_trajectory_generator.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace gcopter_trajectory_generator
+{
+
+Plugin::Plugin() = default;
+
+void Plugin::ownInitialize()
+{
+  readConfigParameters();
+}
+
+void Plugin::readConfigParameters()
+{
+  // DroneParameters has no struct-level defaults, so seed reasonable values
+  // before reading. They survive the read when the user does not override.
+  auto & params = generator_config_.params;
+  params.mass = 1.5;
+  params.gravity = 9.81;
+  params.horizontal_drag = 0.1;
+  params.vertical_drag = 0.1;
+  params.parasitic_drag = 0.01;
+  params.speed_smooth_factor = 0.01;
+  getParameter<double>("drone.mass", params.mass, true);
+  getParameter<double>("drone.gravity", params.gravity, true);
+  getParameter<double>("drone.horizontal_drag", params.horizontal_drag, true);
+  getParameter<double>("drone.vertical_drag", params.vertical_drag, true);
+  getParameter<double>("drone.parasitic_drag", params.parasitic_drag, true);
+  getParameter<double>(
+    "drone.speed_smooth_factor", params.speed_smooth_factor, true);
+
+  auto & limits = generator_config_.limits;
+  limits.max_velocity = 5.0;
+  limits.max_body_rate = 6.0;
+  limits.max_tilt_angle = 0.785;
+  limits.min_thrust = 0.1;
+  limits.max_thrust = 30.0;
+  getParameter<double>("limits.max_velocity", limits.max_velocity, true);
+  getParameter<double>("limits.max_body_rate", limits.max_body_rate, true);
+  getParameter<double>("limits.max_tilt_angle", limits.max_tilt_angle, true);
+  getParameter<double>("limits.min_thrust", limits.min_thrust, true);
+  getParameter<double>("limits.max_thrust", limits.max_thrust, true);
+
+  auto & opt = generator_config_.optimization;
+  // OptimizationConfig already has reasonable struct-level defaults; only
+  // expose the knobs that callers typically tune.
+  getParameter<double>("optimization.time_weight", opt.time_weight, true);
+  getParameter<double>(
+    "optimization.position_weight", opt.position_weight, true);
+  getParameter<double>(
+    "optimization.velocity_weight", opt.velocity_weight, true);
+  getParameter<double>(
+    "optimization.body_rate_weight", opt.body_rate_weight, true);
+  getParameter<double>("optimization.tilt_weight", opt.tilt_weight, true);
+  getParameter<double>("optimization.thrust_weight", opt.thrust_weight, true);
+  getParameter<double>("optimization.smoothing_eps", opt.smoothing_eps, true);
+  getParameter<int>(
+    "optimization.integral_resolution", opt.integral_resolution, true);
+  getParameter<double>("optimization.rel_cost_tol", opt.rel_cost_tol, true);
+  getParameter<double>(
+    "optimization.corridor_margin", opt.corridor_margin, true);
+  // length_per_piece intentionally omitted: keep INF default so each segment
+  // maps to one waypoint pair (assumed by the arrival-time bookkeeping below).
+
+  // Anchor-expansion knobs. Inserting anchor points around each intermediate
+  // waypoint and using a tighter margin on the pinch segments forces the
+  // optimised trajectory to pass close to every user waypoint, which
+  // otherwise are only used to grow the AABB Safe Flight Corridor.
+  // Setting either to <= 0 disables anchoring and falls back to a uniform
+  // corridor margin (`optimization.corridor_margin`).
+  getParameter<double>(
+    "waypoints.waypoint_margin", waypoint_margin_, true);
+  getParameter<double>(
+    "waypoints.waypoint_anchor_radius", waypoint_anchor_radius_, true);
+}
+
+gcopter_lib::Waypoint Plugin::toGcopterWaypoint(
+  const as2_msgs::msg::PoseStampedWithID & wp)
+{
+  gcopter_lib::Waypoint out;
+  out.position = Eigen::Vector3d(
+    wp.pose.pose.position.x,
+    wp.pose.pose.position.y,
+    wp.pose.pose.position.z);
+  // velocity / acceleration left as nullopt → zero at endpoints, free at
+  // intermediates (gcopter_lib::Waypoint contract).
+  return out;
+}
+
+Plugin::ExpandedPath Plugin::expandPathWithAnchors(
+  const std::vector<Eigen::Vector3d> & waypoints,
+  double loose_margin,
+  double tight_margin,
+  double anchor_radius)
+{
+  ExpandedPath out;
+  const std::size_t n_wps = waypoints.size();
+
+  // Bail out early when anchoring cannot or should not run: not enough
+  // waypoints to have intermediates, or one of the knobs is disabled.
+  if (n_wps < 3 || tight_margin <= 0.0 || anchor_radius <= 0.0) {
+    out.positions = waypoints;
+    out.original_indices.resize(n_wps);
+    for (std::size_t i = 0; i < n_wps; ++i) {
+      out.original_indices[i] = i;
+    }
+    if (n_wps >= 2) {
+      out.margins.assign(n_wps - 1, loose_margin);
+    }
+    return out;
+  }
+
+  out.positions.reserve(3 * (n_wps - 2) + 2);
+  out.original_indices.reserve(n_wps);
+
+  out.positions.emplace_back(waypoints.front());
+  out.original_indices.emplace_back(0);
+
+  for (std::size_t i = 1; i + 1 < n_wps; ++i) {
+    const Eigen::Vector3d & prev = waypoints[i - 1];
+    const Eigen::Vector3d & curr = waypoints[i];
+    const Eigen::Vector3d & next = waypoints[i + 1];
+
+    const Eigen::Vector3d in_vec = curr - prev;
+    const Eigen::Vector3d out_vec = next - curr;
+    const double in_norm = in_vec.norm();
+    const double out_norm = out_vec.norm();
+    if (in_norm <= 0.0 || out_norm <= 0.0) {
+      // Degenerate: two consecutive waypoints coincide. Skip anchoring
+      // around this waypoint and keep the waypoint itself in the path.
+      out.positions.emplace_back(curr);
+      out.original_indices.emplace_back(out.positions.size() - 1);
+      continue;
+    }
+    // Skip anchoring when the entry and exit directions are (nearly)
+    // collinear: there is no corner to cut, the waypoint sits on the
+    // straight line and the AABB Safe Flight Corridor of the surrounding
+    // segments already passes through its vicinity. Anchoring collinear
+    // waypoints would otherwise generate stacks of thin pinch corridors
+    // (e.g. on a chain of purely vertical waypoints) that the L-BFGS
+    // solver tends to reject as ill-conditioned.
+    constexpr double kCollinearSinThreshold = 0.05;  // ~3 deg
+    const double sin_corner =
+      in_vec.cross(out_vec).norm() / (in_norm * out_norm);
+    if (sin_corner < kCollinearSinThreshold) {
+      out.positions.emplace_back(curr);
+      out.original_indices.emplace_back(out.positions.size() - 1);
+      continue;
+    }
+    // Clamp the radius so consecutive anchors never cross each other.
+    const double r_in = std::min(anchor_radius, 0.45 * in_norm);
+    const double r_out = std::min(anchor_radius, 0.45 * out_norm);
+
+    out.positions.emplace_back(curr - in_vec * (r_in / in_norm));
+    out.positions.emplace_back(curr);
+    out.original_indices.emplace_back(out.positions.size() - 1);
+    out.positions.emplace_back(curr + out_vec * (r_out / out_norm));
+  }
+
+  out.positions.emplace_back(waypoints.back());
+  out.original_indices.emplace_back(out.positions.size() - 1);
+
+  // Per-segment margins. With at least one anchor inserted, the layout is:
+  //   [loose] (wp_0 -> first anchor)
+  //   for each intermediate wp i: [tight, tight] then a [loose] in between.
+  //   [loose] (last anchor -> wp_{N-1})
+  // Use the actual emitted positions to derive segment margins so the
+  // skipped-anchor case (coincident waypoints) is handled correctly.
+  const std::size_t n_segments = out.positions.size() - 1;
+  out.margins.reserve(n_segments);
+
+  // For each emitted segment, mark it tight if either endpoint is an
+  // intermediate user waypoint position. The tight margin should apply to
+  // exactly the two pinch segments (anchor->wp and wp->anchor) around each
+  // intermediate waypoint.
+  std::vector<bool> is_intermediate(out.positions.size(), false);
+  for (std::size_t k = 1; k + 1 < out.original_indices.size(); ++k) {
+    is_intermediate[out.original_indices[k]] = true;
+  }
+  for (std::size_t s = 0; s < n_segments; ++s) {
+    const bool tight = is_intermediate[s] || is_intermediate[s + 1];
+    out.margins.emplace_back(tight ? tight_margin : loose_margin);
+  }
+  return out;
+}
+
+bool Plugin::generateTrajectory(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+  double max_speed,
+  double t_trajectory_now)
+{
+  waypoint_arrival_times_.clear();
+  last_eval_backend_time_ = 0.0;
+
+  if (waypoints.empty() || max_speed <= 0.0) {
+    trajectory_generator_.reset();
+    return false;
+  }
+
+  // Recreate backend per goal to avoid stale trajectory state.
+  trajectory_generator_ =
+    std::make_unique<gcopter_lib::TrajectoryGenerator>(generator_config_);
+
+  // Build the raw position list: the live vehicle pose is prepended as the
+  // trajectory start so the new plan is C1-continuous with the drone state.
+  // The end velocity at the last waypoint defaults to zero (rest at goal).
+  std::vector<Eigen::Vector3d> raw_positions;
+  raw_positions.reserve(waypoints.size() + 1);
+  raw_positions.emplace_back(
+    vehicle_pose_.pose.position.x,
+    vehicle_pose_.pose.position.y,
+    vehicle_pose_.pose.position.z);
+  for (const auto & wp : waypoints) {
+    raw_positions.emplace_back(
+      wp.pose.pose.position.x,
+      wp.pose.pose.position.y,
+      wp.pose.pose.position.z);
+  }
+
+  // Insert anchor points around each intermediate waypoint and assign per
+  // segment corridor margins (tight on pinch segments). The host's wide
+  // AABB Safe Flight Corridor leaves the trajectory free to cut corners
+  // through intermediate waypoints; anchoring forces it to pass close to
+  // each one. A single uniform margin is used as a fallback when anchoring
+  // is disabled or the path has fewer than three points.
+  const ExpandedPath expanded = expandPathWithAnchors(
+    raw_positions,
+    generator_config_.optimization.corridor_margin,
+    waypoint_margin_,
+    waypoint_anchor_radius_);
+
+  std::vector<gcopter_lib::Waypoint> wps;
+  wps.reserve(expanded.positions.size());
+  // Pin the velocity boundary condition only on the very first waypoint
+  // (the synthetic start), matching the live vehicle twist. All other
+  // waypoints — including the goal — keep the default rest constraint.
+  for (std::size_t i = 0; i < expanded.positions.size(); ++i) {
+    gcopter_lib::Waypoint wp;
+    wp.position = expanded.positions[i];
+    if (i == 0) {
+      wp.velocity = Eigen::Vector3d(
+        vehicle_twist_.twist.linear.x,
+        vehicle_twist_.twist.linear.y,
+        vehicle_twist_.twist.linear.z);
+    }
+    wps.emplace_back(std::move(wp));
+  }
+
+  const bool ok = trajectory_generator_->generate(
+    wps, max_speed, expanded.margins);
+  if (!ok) {
+    return false;
+  }
+
+  // Map mission waypoint ids to backend spline breakpoint times. The
+  // expansion may have inserted anchor points, so the indices held by
+  // expanded.original_indices identify the breakpoints that correspond
+  // to actual user waypoints. expanded.original_indices[0] is the
+  // synthetic vehicle start; entries [1..N] map to waypoints[0..N-1].
+  const auto bps = trajectory_generator_->spline().breakpoints();
+  if (!bps.empty() && expanded.original_indices.size() == waypoints.size() + 1) {
+    const double t0 = bps.front();
+    for (std::size_t i = 0; i < waypoints.size(); ++i) {
+      const std::size_t bp_idx = expanded.original_indices[i + 1];
+      if (bp_idx < bps.size()) {
+        waypoint_arrival_times_.emplace_back(
+          waypoints[i].id, bps[bp_idx] - t0);
+      }
+    }
+  }
+
+  // Anchor host axis to backend axis: t_trajectory_now -> minTime() == 0.
+  internal_offset_ = trajectory_generator_->minTime() - t_trajectory_now;
+  return true;
+}
+
+bool Plugin::evaluate(
+  double t_trajectory,
+  as2_msgs::msg::TrajectoryPoint & out,
+  bool is_horizon_sample)
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return false;
+  }
+
+  const double t_backend = std::clamp(
+    t_trajectory + internal_offset_,
+    trajectory_generator_->minTime(), trajectory_generator_->maxTime());
+
+  const auto sample = trajectory_generator_->evaluate(t_backend);
+  out.position.x = sample.position.x();
+  out.position.y = sample.position.y();
+  out.position.z = sample.position.z();
+  out.twist.x = sample.velocity.x();
+  out.twist.y = sample.velocity.y();
+  out.twist.z = sample.velocity.z();
+  out.acceleration.x = sample.acceleration.x();
+  out.acceleration.y = sample.acceleration.y();
+  out.acceleration.z = sample.acceleration.z();
+
+  if (!is_horizon_sample) {
+    last_eval_backend_time_ = t_backend;
+  }
+  return true;
+}
+
+bool Plugin::isFinished(double t_trajectory) const
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return true;
+  }
+  return (t_trajectory + internal_offset_) >= trajectory_generator_->maxTime();
+}
+
+double Plugin::getDuration() const
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return 0.0;
+  }
+  return trajectory_generator_->maxTime() - trajectory_generator_->minTime();
+}
+
+bool Plugin::isTrajectoryGenerated()
+{
+  return trajectory_generator_ && trajectory_generator_->isValid();
+}
+
+void Plugin::reset()
+{
+  trajectory_generator_.reset();
+  waypoint_arrival_times_.clear();
+  last_eval_backend_time_ = 0.0;
+  internal_offset_ = 0.0;
+}
+
+std::string Plugin::getNextWaypointId()
+{
+  for (const auto & [id, t_arrival] : waypoint_arrival_times_) {
+    if (t_arrival > last_eval_backend_time_) {
+      return id;
+    }
+  }
+  return {};
+}
+
+}  // namespace gcopter_trajectory_generator
+
+PLUGINLIB_EXPORT_CLASS(
+  gcopter_trajectory_generator::Plugin,
+  generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase)

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+# GTest of the gcopter_trajectory_generator plugin.
+# Loads the plugin via pluginlib and exercises the public base API.
+file(GLOB GTEST_SOURCES "*_gtest.cpp")
+file(GLOB BENCHMARK_SOURCES "*_benchmark.cpp")
+
+if(GTEST_SOURCES)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
+
+  foreach(TEST_SOURCE ${GTEST_SOURCES})
+    get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+
+    ament_add_gtest(${TEST_NAME} ${TEST_SOURCE})
+    ament_target_dependencies(${TEST_NAME} ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${TEST_NAME}
+      ament_index_cpp::ament_index_cpp
+      gtest_main
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()
+
+# Per-plugin Google-Benchmark binaries. Each source owns its main() and
+# registers whichever plugin it wants to exercise.
+find_package(benchmark QUIET)
+if(benchmark_FOUND AND BENCHMARK_SOURCES)
+  set(BENCHMARK_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/common)
+
+  foreach(BENCHMARK_SOURCE ${BENCHMARK_SOURCES})
+    get_filename_component(BENCHMARK_NAME ${BENCHMARK_SOURCE} NAME_WE)
+
+    add_executable(${PROJECT_NAME}_${BENCHMARK_NAME} ${BENCHMARK_SOURCE})
+    target_include_directories(${PROJECT_NAME}_${BENCHMARK_NAME} PRIVATE
+      ${BENCHMARK_COMMON_DIR})
+    ament_target_dependencies(${PROJECT_NAME}_${BENCHMARK_NAME}
+      ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${PROJECT_NAME}_${BENCHMARK_NAME}
+      benchmark::benchmark
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/gcopter_trajectory_generator_benchmark.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/gcopter_trajectory_generator_benchmark.cpp
@@ -1,0 +1,46 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <benchmark/benchmark.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "generate_polynomial_trajectory_benchmark_common.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  generate_polynomial_trajectory_benchmark::silenceRosLogging();
+  benchmark::Initialize(&argc, argv);
+  generate_polynomial_trajectory_benchmark::registerPluginBenchmarks(
+    "gcopter_trajectory_generator");
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/gcopter_trajectory_generator_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/gcopter_trajectory_generator_gtest.cpp
@@ -1,0 +1,223 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file gcopter_trajectory_generator_gtest.cpp
+ *
+ * @brief Plugin-level tests for gcopter_trajectory_generator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "as2_core/node.hpp"
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase;
+
+namespace
+{
+as2_msgs::msg::PoseStampedWithID makeWaypoint(
+  const std::string & id, double x, double y, double z)
+{
+  as2_msgs::msg::PoseStampedWithID wp;
+  wp.id = id;
+  wp.pose.header.frame_id = "earth";
+  wp.pose.pose.position.x = x;
+  wp.pose.pose.position.y = y;
+  wp.pose.pose.position.z = z;
+  wp.pose.pose.orientation.w = 1.0;
+  return wp;
+}
+
+geometry_msgs::msg::PoseStamped makePose(double x, double y, double z)
+{
+  geometry_msgs::msg::PoseStamped p;
+  p.header.frame_id = "earth";
+  p.pose.position.x = x;
+  p.pose.position.y = y;
+  p.pose.position.z = z;
+  p.pose.orientation.w = 1.0;
+  return p;
+}
+
+struct PluginFixture
+{
+  std::shared_ptr<as2::Node> node;
+  std::shared_ptr<pluginlib::ClassLoader<PluginBase>> loader;
+  std::shared_ptr<PluginBase> plugin;
+};
+
+PluginFixture makePluginFixture(
+  const std::string & node_name,
+  const std::vector<rclcpp::Parameter> & parameter_overrides)
+{
+  PluginFixture f;
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(parameter_overrides);
+  f.node = std::make_shared<as2::Node>(node_name, options);
+  f.loader = std::make_shared<pluginlib::ClassLoader<PluginBase>>(
+    "as2_behaviors_trajectory_generation",
+    "generate_polynomial_trajectory_behavior_plugin_base::"
+    "GeneratePolynomialTrajectoryBase");
+  f.plugin = f.loader->createSharedInstance(
+    "gcopter_trajectory_generator::Plugin");
+  f.plugin->initialize(f.node.get(), "gcopter_trajectory_generator");
+  return f;
+}
+}  // namespace
+
+TEST(GcopterTrajectoryGenerator, load_generate_evaluate_reset) {
+  auto fx = makePluginFixture("gcopter_traj_gen_test", {});
+
+  // Mission waypoints only — the plugin auto-prepends the current
+  // vehicle pose (read from vehicle_pose_) as the trajectory start.
+  std::vector<as2_msgs::msg::PoseStampedWithID> waypoints = {
+    makeWaypoint("waypoint_000", 2.0, 0.0, 1.0),
+    makeWaypoint("waypoint_001", 4.0, 0.0, 1.0),
+  };
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), zero_twist);
+
+  ASSERT_TRUE(
+    fx.plugin->generateTrajectory(
+      waypoints, /*max_speed=*/ 1.0, /*t_trajectory_now=*/ 0.0));
+  ASSERT_TRUE(fx.plugin->isTrajectoryGenerated());
+  // Fresh trajectory: t_trajectory_now = 0 must not be finished, and the
+  // duration must be strictly positive (we walk it to find the end below).
+  ASSERT_FALSE(fx.plugin->isFinished(0.0));
+  ASSERT_TRUE(fx.plugin->isFinished(1e6));
+
+  // At t_trajectory = 0, the next pending waypoint is the first mission
+  // waypoint after the implicit start.
+  as2_msgs::msg::TrajectoryPoint p_start;
+  EXPECT_TRUE(fx.plugin->evaluate(0.0, p_start, false));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_000");
+
+  // Walk t_trajectory until isFinished flips, then sample at the midpoint
+  // to advance past the first mission segment.
+  double t_end = 0.0;
+  for (double t = 0.0; t < 1e3; t += 0.05) {
+    if (fx.plugin->isFinished(t)) {
+      t_end = t;
+      break;
+    }
+  }
+  ASSERT_GT(t_end, 0.0);
+  const double t_mid = 0.5 * t_end;
+  as2_msgs::msg::TrajectoryPoint p_mid;
+  EXPECT_TRUE(fx.plugin->evaluate(t_mid, p_mid, false));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_001");
+
+  fx.plugin->reset();
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+  EXPECT_TRUE(fx.plugin->getNextWaypointId().empty());
+}
+
+TEST(GcopterTrajectoryGenerator, update_waypoints_re_anchors_offset) {
+  // Regression test for the gcopter t_min == 0 issue: after the host
+  // advances the trajectory time and triggers an updateWaypoints() that
+  // falls back to regeneration, the plugin must re-anchor its internal
+  // offset against the new t_trajectory_now so subsequent evaluations
+  // stay within the valid window.
+  auto fx = makePluginFixture("gcopter_traj_gen_reanchor", {});
+
+  std::vector<as2_msgs::msg::PoseStampedWithID> waypoints = {
+    makeWaypoint("waypoint_000", 2.0, 0.0, 1.0),
+    makeWaypoint("waypoint_001", 4.0, 0.0, 1.0),
+  };
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), zero_twist);
+
+  ASSERT_TRUE(
+    fx.plugin->generateTrajectory(waypoints, 1.0, /*t_trajectory_now=*/ 0.0));
+
+  // Simulate the host advancing trajectory_time_ to 5.0 s while still
+  // executing the previous trajectory, then triggering an update.
+  constexpr double kTNow = 5.0;
+  std::vector<as2_msgs::msg::PoseStampedWithID> updated = {
+    makeWaypoint("waypoint_010", 6.0, 0.0, 1.0),
+    makeWaypoint("waypoint_011", 8.0, 0.0, 1.0),
+  };
+  ASSERT_TRUE(
+    fx.plugin->updateWaypoints(updated, 1.0, kTNow));
+
+  // After the regen, isFinished(t_trajectory) must be false at kTNow and
+  // become true some time later (not immediately, which is the bug).
+  EXPECT_FALSE(fx.plugin->isFinished(kTNow));
+  EXPECT_TRUE(fx.plugin->isFinished(kTNow + 1e3));
+
+  as2_msgs::msg::TrajectoryPoint p;
+  EXPECT_TRUE(fx.plugin->evaluate(kTNow, p, false));
+}
+
+TEST(GcopterTrajectoryGenerator, rejects_degenerate_inputs) {
+  auto fx = makePluginFixture("gcopter_traj_gen_degenerate", {});
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), zero_twist);
+
+  // Empty mission waypoints: nothing to plan toward.
+  std::vector<as2_msgs::msg::PoseStampedWithID> empty;
+  EXPECT_FALSE(
+    fx.plugin->generateTrajectory(empty, 1.0, /*t_trajectory_now=*/ 0.0));
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+
+  // Non-positive max_speed is invalid regardless of waypoint count.
+  std::vector<as2_msgs::msg::PoseStampedWithID> one = {
+    makeWaypoint("end", 1.0, 0.0, 1.0),
+  };
+  EXPECT_FALSE(
+    fx.plugin->generateTrajectory(
+      one, /*max_speed=*/ 0.0, /*t_trajectory_now=*/ 0.0));
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/gcopter_waypoint_fidelity_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/tests/gcopter_waypoint_fidelity_gtest.cpp
@@ -1,0 +1,218 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file waypoint_fidelity_gtest.cpp
+ *
+ * @brief Standalone fidelity tests for the gcopter trajectory plugin.
+ *
+ * Drives gcopter_lib through the same anchor expansion the plugin uses,
+ * without instantiating the pluginlib runtime. Validates that:
+ *
+ *   - With anchoring enabled, the optimised trajectory passes within a
+ *     reasonable tolerance of every user waypoint (including intermediates
+ *     in zigzag-like paths) — the issue that the wide AABB corridor lets
+ *     the solver cut corners unless anchors pin the trajectory near each
+ *     waypoint.
+ *
+ *   - The L-BFGS optimisation converges when consecutive waypoints share
+ *     xy and only differ in z (purely vertical segment), thanks to the
+ *     epsilon padding of degenerate AABB axes in the corridor builder.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "gcopter_lib/trajectory_generator.hpp"
+#include "gcopter_lib/types.hpp"
+#include "gcopter_trajectory_generator/gcopter_trajectory_generator.hpp"
+
+namespace
+{
+
+constexpr double kFinalWaypointTolerance = 0.20;         // [m]
+constexpr double kIntermediateWaypointTolerance = 0.40;  // [m]
+
+constexpr double kCorridorMargin = 0.5;        // [m] loose corridor
+constexpr double kWaypointMargin = 0.05;       // [m] tight pinch margin
+constexpr double kWaypointAnchorRadius = 0.5;  // [m] offset for anchors
+
+gcopter_lib::GeneratorConfig defaultConfig()
+{
+  gcopter_lib::GeneratorConfig cfg;
+  cfg.params.mass = 1.0;
+  cfg.params.gravity = 9.81;
+  cfg.params.horizontal_drag = 0.1;
+  cfg.params.vertical_drag = 0.1;
+  cfg.params.parasitic_drag = 0.01;
+  cfg.params.speed_smooth_factor = 0.01;
+
+  cfg.limits.max_velocity = 5.0;
+  cfg.limits.max_body_rate = 6.0;
+  cfg.limits.max_tilt_angle = 0.785;
+  cfg.limits.min_thrust = 0.1;
+  cfg.limits.max_thrust = 30.0;
+
+  cfg.optimization.time_weight = 512.0;
+  cfg.optimization.position_weight = 1.0e4;
+  cfg.optimization.velocity_weight = 1.0e4;
+  cfg.optimization.body_rate_weight = 1.0e4;
+  cfg.optimization.tilt_weight = 1.0e4;
+  cfg.optimization.thrust_weight = 1.0e4;
+  cfg.optimization.smoothing_eps = 1.0e-2;
+  cfg.optimization.integral_resolution = 16;
+  cfg.optimization.rel_cost_tol = 1.0e-3;
+  cfg.optimization.corridor_margin = kCorridorMargin;
+  return cfg;
+}
+
+double minDistanceToTarget(
+  const gcopter_lib::TrajectoryGenerator & gen,
+  const Eigen::Vector3d & target)
+{
+  const double t0 = gen.minTime();
+  const double t1 = gen.maxTime();
+  const double dt = 0.01;
+  double best = std::numeric_limits<double>::infinity();
+  for (double t = t0; t <= t1; t += dt) {
+    const Eigen::Vector3d p = gen.position(t);
+    best = std::min(best, (p - target).norm());
+  }
+  const Eigen::Vector3d p_end = gen.position(t1);
+  best = std::min(best, (p_end - target).norm());
+  return best;
+}
+
+void runWithAnchors(
+  const std::vector<Eigen::Vector3d> & raw_path,
+  const std::string & label,
+  const std::vector<Eigen::Vector3d> & expected_waypoints)
+{
+  using Plugin = gcopter_trajectory_generator::Plugin;
+  const Plugin::ExpandedPath expanded = Plugin::expandPathWithAnchors(
+    raw_path, kCorridorMargin, kWaypointMargin, kWaypointAnchorRadius);
+  ASSERT_EQ(expanded.positions.size() - 1, expanded.margins.size()) << label;
+  ASSERT_EQ(expanded.original_indices.size(), raw_path.size()) << label;
+
+  std::vector<gcopter_lib::Waypoint> wps;
+  wps.reserve(expanded.positions.size());
+  for (const auto & p : expanded.positions) {
+    gcopter_lib::Waypoint wp;
+    wp.position = p;
+    wps.emplace_back(std::move(wp));
+  }
+
+  gcopter_lib::TrajectoryGenerator gen(defaultConfig());
+  ASSERT_TRUE(
+    gen.generate(wps, defaultConfig().limits.max_velocity, expanded.margins))
+    << label << ": generate() returned false";
+
+  for (std::size_t i = 0; i < expected_waypoints.size(); ++i) {
+    const double d = minDistanceToTarget(gen, expected_waypoints[i]);
+    const bool is_endpoint =
+      (i == 0) || (i + 1 == expected_waypoints.size());
+    const double tol = is_endpoint ?
+      kFinalWaypointTolerance :
+      kIntermediateWaypointTolerance;
+    EXPECT_LE(d, tol)
+      << label << ": waypoint #" << i
+      << " (" << expected_waypoints[i].transpose() << ") was missed by "
+      << d << " m (tol " << tol << " m)";
+  }
+}
+
+}  // namespace
+
+TEST(GcopterFidelity, DiagonalClimb)
+{
+  // Two-waypoint diagonal climb. GCOPTER's L-BFGS solver fails on a fully
+  // 1-D 2-waypoint path (line-search divergence on the trivial univariate
+  // problem); the test moves a small horizontal distance as well so the
+  // optimisation is genuinely 3-D and converges.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 0.0},
+    {1.0, 0.0, 2.0},
+  };
+  runWithAnchors(path, "DiagonalClimb", path);
+}
+
+TEST(GcopterFidelity, HorizontalZigzag)
+{
+  // Five waypoints zig-zagging in y at constant z. Without anchors the AABB
+  // overlap between consecutive segments is wide (almost the full y range)
+  // and the solver cuts corners. The anchored expansion must keep the
+  // trajectory near each user waypoint. Legs and amplitude leave the
+  // anchor pinch corridors numerically well-behaved.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 1.0},
+    {5.0, 1.0, 1.0},
+    {10.0, -1.0, 1.0},
+    {15.0, 1.0, 1.0},
+    {20.0, 0.0, 1.0},
+  };
+  runWithAnchors(path, "HorizontalZigzag", path);
+}
+
+TEST(GcopterFidelity, ColinearVerticalSegment)
+{
+  // Three waypoints where the first leg is purely vertical (xy unchanged)
+  // and the second leg moves sideways. Without the AABB epsilon padding
+  // applied in corridor_builder.cpp, the solver returned a "negative
+  // line-search step" error for the vertical leg and generate() failed.
+  // With the fix it must converge.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 0.0},
+    {0.0, 0.0, 2.0},
+    {2.0, 0.0, 2.0},
+  };
+  runWithAnchors(path, "ColinearVerticalSegment", path);
+}
+
+TEST(GcopterFidelity, MultipleColinearVerticalWaypoints)
+{
+  // Four waypoints sharing xy across two consecutive vertical segments,
+  // followed by a horizontal leg. Without the AABB epsilon padding the
+  // solver could fail at the first vertical segment; with the fix it
+  // should converge.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 0.0},
+    {0.0, 0.0, 1.0},
+    {0.0, 0.0, 2.0},
+    {2.0, 0.0, 2.0},
+  };
+  runWithAnchors(path, "MultipleColinearVerticalWaypoints", path);
+}


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

Adds a new `gcopter_trajectory_generator` plugin that wraps the
[`gcopter_lib`](https://github.com/aerostack2/gcopter_trajectory_generator_lib) optimiser (GCOPTER with safe-flight-corridor support)

## Plugin specifics

- **Backend**: [`gcopter_lib`](https://github.com/aerostack2/gcopter_trajectory_generator_lib)
  (`main`). Resolution policy in `CMakeLists.txt`:
  `find_package(gcopter_lib QUIET)` → local clone under
  `plugins/gcopter_trajectory_generator/thirdparties/gcopter_trajectory_generator_lib/` →
  `FetchContent`. The local clone is reused on subsequent builds.
- **Time-axis**: relies on the **base default** `updateWaypoints()`
  (regenerate via `reset()` + `generateTrajectory(t_trajectory_now)`).
  Each `generateTrajectory(t)` re-anchors the plugin's
  `internal_offset_` so the host's `t_trajectory` keeps mapping to a
  valid backend time after a regeneration.
- **Initial state**: honours `vehicle_pose_` and the linear part of
  `vehicle_twist_` as a hard initial-velocity boundary on the first
  waypoint, so re-plans in flight stay C¹-continuous against the
  current vehicle state.
- **Configuration**: backend-only keys live under the plugin
  namespace in
  `config/gcopter_trajectory_generator.yaml`
  and are read with the protected `getParameter<T>()` helper from the
  base class (auto-prefixed with the plugin name).