### PR TITLE
[as2_behaviors_trajectory_generation] Add plugin jerk limited trajectory generator

### DIFF
--- a/as2_behaviors/as2_behaviors_trajectory_generation/README.md
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/README.md
@@ -10,3 +10,4 @@ are gitignored and never committed to this repository.
 - Dynamic Trajectory Generator: <https://github.com/miferco97/dynamic_trajectory_generator>, based on <https://github.com/ethz-asl/mav_trajectory_generation>
 - Mav Trajectory Generation: <https://github.com/aerostack2/mav_trajectory_generation_library>, based on <https://github.com/ethz-asl/mav_trajectory_generation>
 - GCOPTER Trajectory Generator: <https://github.com/aerostack2/gcopter_trajectory_generator_lib>, based on <https://github.com/ZJU-FAST-Lab/GCOPTER>
+- Jerk-Limited Trajectory Generator: <https://github.com/aerostack2/jerk_limited_trajectory_generator_lib>, based on <https://github.com/PX4/PX4-Autopilot>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/CMakeLists.txt
@@ -77,6 +77,7 @@ set(PLUGIN_LIST
   dynamic_mav_trajectory_generator
   mav_trajectory_generator
   gcopter_trajectory_generator
+  jerk_limited_trajectory_generator
 )
 
 foreach(PLUGIN ${PLUGIN_LIST})

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins.xml
@@ -17,4 +17,10 @@
       <description>GCOPTER-based polynomial trajectory generator with safe-flight-corridor optimization.</description>
     </class>
   </library>
+  <library path="jerk_limited_trajectory_generator">
+    <class type="jerk_limited_trajectory_generator::Plugin"
+           base_class_type="generate_polynomial_trajectory_behavior_plugin_base::GeneratePolynomialTrajectoryBase">
+      <description>Jerk-limited S-curve trajectory generator with optional L1 corner-cut multi-waypoint smoothing.</description>
+    </class>
+  </library>
 </class_libraries>

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/CMakeLists.txt
@@ -1,0 +1,114 @@
+cmake_minimum_required(VERSION 3.5)
+set(PLUGIN_NAME jerk_limited_trajectory_generator)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# Set Release as default
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Plugin dependencies (mostly inherited from the package).
+set(PLUGIN_DEPENDENCIES
+  ament_cmake
+  rclcpp
+  pluginlib
+  as2_core
+  as2_msgs
+  geometry_msgs
+  nav_msgs
+  visualization_msgs
+  Eigen3
+)
+
+foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
+  find_package(${DEPENDENCY} REQUIRED)
+endforeach()
+
+# --- trajectory_generator_jerk_limited: prefer system → local clone → FetchContent
+# The local clone lives in plugins/<plugin>/thirdparties/<lib>/ so it is fetched
+# only the first time and reused on subsequent builds. The parent thirdparties/
+# directory is gitignored repo-wide; we drop an AMENT_IGNORE there at configure
+# time so colcon never indexes any nested package.xml files as ROS packages
+# and so the ament file-walking linters (cpplint, uncrustify, ...) skip the
+# vendored sources.
+set(_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
+file(MAKE_DIRECTORY ${_THIRDPARTIES_DIR})
+file(WRITE ${_THIRDPARTIES_DIR}/AMENT_IGNORE "")
+
+find_package(trajectory_generator_jerk_limited QUIET)
+if(${trajectory_generator_jerk_limited_FOUND})
+  message(STATUS "trajectory_generator_jerk_limited found system-wide")
+else()
+  set(LOCAL_TGJL_SRC
+    ${_THIRDPARTIES_DIR}/trajectory_generator_jerk_limited)
+  if(EXISTS ${LOCAL_TGJL_SRC}/CMakeLists.txt)
+    message(STATUS
+      "trajectory_generator_jerk_limited: using local clone at ${LOCAL_TGJL_SRC}")
+    add_subdirectory(${LOCAL_TGJL_SRC}
+      ${CMAKE_BINARY_DIR}/trajectory_generator_jerk_limited_build)
+  else()
+    message(STATUS
+      "trajectory_generator_jerk_limited: cloning into ${LOCAL_TGJL_SRC}")
+    include(FetchContent)
+    fetchcontent_declare(
+      trajectory_generator_jerk_limited
+      GIT_REPOSITORY https://github.com/aerostack2/jerk_limited_trajectory_generator_lib.git
+      GIT_TAG main
+      SOURCE_DIR ${LOCAL_TGJL_SRC}
+    )
+    fetchcontent_makeavailable(trajectory_generator_jerk_limited)
+  endif()
+endif()
+
+include_directories(
+  include
+  include/${PLUGIN_NAME}
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
+set(SOURCE_CPP_FILES
+  src/${PLUGIN_NAME}.cpp
+)
+
+# Plugin shared library (loaded by pluginlib::ClassLoader).
+add_library(${PLUGIN_NAME} SHARED ${SOURCE_CPP_FILES})
+target_link_libraries(${PLUGIN_NAME}
+  ${BEHAVIOR_NAME}_plugin_base
+  trajectory_generator_jerk_limited
+)
+ament_target_dependencies(${PLUGIN_NAME} ${PLUGIN_DEPENDENCIES})
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PLUGIN_NAME})
+ament_export_targets(export_${PLUGIN_NAME})
+
+install(
+  TARGETS ${PLUGIN_NAME}
+  EXPORT export_${PLUGIN_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Re-export upstream target so downstream packages can resolve it.
+install(
+  TARGETS trajectory_generator_jerk_limited
+  EXPORT export_trajectory_generator_jerk_limited
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/config/jerk_limited_trajectory_generator.yaml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/config/jerk_limited_trajectory_generator.yaml
@@ -1,0 +1,34 @@
+/**:
+  ros__parameters:
+    jerk_limited_trajectory_generator:
+      # Cinematic bounds. The 3D speed and acceleration limits are enforced as
+      # 3D norms (||v||, ||a||); the jerk bound is per-axis. The behavior goal's
+      # max_speed transiently overrides limits.max_speed for a single call.
+      # Set <= 0 to disable an individual bound; at least one of
+      # max_speed / max_acceleration / max_jerk must remain > 0.
+      limits:
+        max_speed: 1.0                 # m/s
+        max_acceleration: 10.0         # m/s^2
+        max_jerk: 20.0                 # m/s^3
+        acceptance_radius: 0.01        # m  (>0 enables L1 corner-cut at intermediate waypoints; 0 makes the drone stop at every intermediate waypoint)
+        final_acceptance_radius: 0.01  # m  (tight position tolerance for stopping at the LAST waypoint; <=0 reuses acceptance_radius)
+        trajectory_gain: 0.1           # -  (scales acceleration for corner-speed cap)
+      # Internal simulator knobs. step_dt drives the integration tick.
+      simulator:
+        step_dt: 0.01                 # s
+        max_simulation_time: 600.0    # s   (hard horizon before generate() fails)
+        settle_velocity: 0.05         # m/s (||v|| threshold to consider rest)
+        advance_radius_min: 0.1       # m   (floor of the per-waypoint advance threshold;
+                                      #     effective threshold is max(acceptance_radius,
+                                      #     advance_radius_min). Lower it for tighter
+                                      #     intermediate-waypoint tracking. Recall the
+                                      #     corner-speed cap is
+                                      #       v_corner = sqrt(max_acceleration *
+                                      #                       trajectory_gain *
+                                      #                       max(acceptance_radius,
+                                      #                           advance_radius_min) *
+                                      #                       tan(alpha/2))
+                                      #     so if you reduce this floor, raise
+                                      #     trajectory_gain to keep v_corner near
+                                      #     max_speed and avoid slowing down at corners.)
+        polynomial_order: 16          # coefficients per axis/segment in spline()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/include/jerk_limited_trajectory_generator/jerk_limited_trajectory_generator.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/include/jerk_limited_trajectory_generator/jerk_limited_trajectory_generator.hpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file jerk_limited_trajectory_generator.hpp
+ *
+ * @brief Plugin wrapper around
+ *        trajectory_generator_jerk_limited::TrajectoryGenerator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#ifndef JERK_LIMITED_TRAJECTORY_GENERATOR__JERK_LIMITED_TRAJECTORY_GENERATOR_HPP_
+#define JERK_LIMITED_TRAJECTORY_GENERATOR__JERK_LIMITED_TRAJECTORY_GENERATOR_HPP_
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+#include "trajectory_generator_jerk_limited/trajectory_generator.hpp"
+#include "trajectory_generator_jerk_limited/types.hpp"
+
+namespace jerk_limited_trajectory_generator
+{
+
+/**
+ * @brief Plugin wrapper for trajectory_generator_jerk_limited backend.
+ *
+ * The optimizer is a one-shot jerk-limited S-curve simulator that emits a
+ * piecewise polynomial spline plus an exact in-memory sample sequence. The
+ * plugin does not override updateWaypoints(): each modify request goes
+ * through the base class default, which calls reset() + generateTrajectory()
+ * with the live vehicle pose and twist as boundary conditions, so the
+ * resulting trajectory is C^1-continuous with the drone state at the time
+ * of the re-plan.
+ *
+ * The initial acceleration boundary condition is left at zero because the
+ * host behavior does not expose a vehicle acceleration estimate; in
+ * practice this only relaxes the smoothness of the splice from C^2 to C^1
+ * and the controller absorbs the residual jerk transient.
+ */
+class Plugin : public generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase
+{
+public:
+  Plugin();
+  ~Plugin() override = default;
+
+  bool generateTrajectory(
+    const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+    double max_speed,
+    double t_trajectory_now) override;
+
+  bool evaluate(
+    double t_trajectory,
+    as2_msgs::msg::TrajectoryPoint & out,
+    bool is_horizon_sample) override;
+
+  bool isFinished(double t_trajectory) const override;
+  double getDuration() const override;
+  bool isTrajectoryGenerated() override;
+  void reset() override;
+
+  std::string getNextWaypointId() override;
+
+protected:
+  void ownInitialize() override;
+
+private:
+  void readConfigParameters();
+
+  static trajectory_generator_jerk_limited::Waypoint toJlWaypoint(
+    const as2_msgs::msg::PoseStampedWithID & wp);
+
+  trajectory_generator_jerk_limited::GeneratorConfig generator_config_;
+  std::unique_ptr<trajectory_generator_jerk_limited::TrajectoryGenerator>
+  trajectory_generator_;
+
+  // Mission progress: ordered (waypoint_id, t_arrival) for each waypoint
+  // beyond the implicit start. Walked by getNextWaypointId() against
+  // last_eval_backend_time_, which tracks the latest non-horizon
+  // evaluation time in the backend's own time axis (anchored at
+  // minTime()=0, so t_arrival = bps[i] - bps.front() == bps[i]).
+  std::vector<std::pair<std::string, double>> waypoint_arrival_times_;
+  double last_eval_backend_time_{0.0};
+
+  // Maps host trajectory time to backend time:
+  //   t_backend = t_trajectory + internal_offset_.
+  // Anchored on every generateTrajectory().
+  double internal_offset_{0.0};
+};
+
+}  // namespace jerk_limited_trajectory_generator
+
+#endif  // JERK_LIMITED_TRAJECTORY_GENERATOR__JERK_LIMITED_TRAJECTORY_GENERATOR_HPP_

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/src/jerk_limited_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/src/jerk_limited_trajectory_generator.cpp
@@ -1,0 +1,248 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file jerk_limited_trajectory_generator.cpp
+ *
+ * @brief Plugin wrapper around
+ *        trajectory_generator_jerk_limited::TrajectoryGenerator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include "jerk_limited_trajectory_generator/jerk_limited_trajectory_generator.hpp"
+
+#include <algorithm>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace jerk_limited_trajectory_generator
+{
+
+namespace tgjl = trajectory_generator_jerk_limited;
+
+Plugin::Plugin() = default;
+
+void Plugin::ownInitialize()
+{
+  readConfigParameters();
+}
+
+void Plugin::readConfigParameters()
+{
+  // Cinematic bounds. The struct defaults are zero (= disabled), so seed the
+  // typical values before reading; the YAML can override or disable each
+  // bound individually by setting it <= 0.
+  auto & params = generator_config_.params;
+  params.max_speed = 5.0;
+  params.max_acceleration = 4.0;
+  params.max_jerk = 20.0;
+  params.acceptance_radius = 1.0;
+  params.final_acceptance_radius = 0.05;
+  params.trajectory_gain = 1.0;
+  getParameter<double>("limits.max_speed", params.max_speed, true);
+  getParameter<double>(
+    "limits.max_acceleration", params.max_acceleration, true);
+  getParameter<double>("limits.max_jerk", params.max_jerk, true);
+  getParameter<double>(
+    "limits.acceptance_radius", params.acceptance_radius, true);
+  getParameter<double>(
+    "limits.final_acceptance_radius", params.final_acceptance_radius, true);
+  getParameter<double>(
+    "limits.trajectory_gain", params.trajectory_gain, true);
+
+  // Simulator knobs. Reasonable defaults are already present in the upstream
+  // SimulatorConfig struct; expose them so they can be tuned from YAML.
+  auto & sim = generator_config_.simulator;
+  getParameter<double>("simulator.step_dt", sim.step_dt, true);
+  getParameter<double>(
+    "simulator.max_simulation_time", sim.max_simulation_time, true);
+  getParameter<double>(
+    "simulator.settle_velocity", sim.settle_velocity, true);
+  getParameter<double>(
+    "simulator.advance_radius_min", sim.advance_radius_min, true);
+  getParameter<int>(
+    "simulator.polynomial_order", sim.polynomial_order, true);
+}
+
+tgjl::Waypoint Plugin::toJlWaypoint(
+  const as2_msgs::msg::PoseStampedWithID & wp)
+{
+  tgjl::Waypoint out;
+  out.position = Eigen::Vector3d(
+    wp.pose.pose.position.x,
+    wp.pose.pose.position.y,
+    wp.pose.pose.position.z);
+  // velocity / acceleration intentionally left as nullopt: the upstream API
+  // currently ignores them on intermediate waypoints and forces v=0, a=0 at
+  // the endpoints.
+  return out;
+}
+
+bool Plugin::generateTrajectory(
+  const std::vector<as2_msgs::msg::PoseStampedWithID> & waypoints,
+  double max_speed,
+  double t_trajectory_now)
+{
+  waypoint_arrival_times_.clear();
+  last_eval_backend_time_ = 0.0;
+
+  if (waypoints.empty() || max_speed <= 0.0) {
+    trajectory_generator_.reset();
+    return false;
+  }
+
+  // Apply the goal max_speed as a transient override on top of the YAML
+  // configuration, mirroring the contract used by the gcopter plugin.
+  tgjl::GeneratorConfig cfg = generator_config_;
+  cfg.params.max_speed = max_speed;
+
+  // Recreate backend per goal to avoid stale trajectory state.
+  trajectory_generator_ =
+    std::make_unique<tgjl::TrajectoryGenerator>(cfg);
+
+  // Prepend the current vehicle state as the trajectory start so the new
+  // plan is C^1-continuous with the drone's live motion: position pins the
+  // start vertex and velocity is honored by the upstream library as the
+  // integrator's initial kinematic state. The acceleration boundary
+  // condition is left as nullopt (= zero) because the host does not expose
+  // a vehicle acceleration estimate; this is consistent with the resting
+  // case and only loses C^2 continuity, which the controller absorbs.
+  std::vector<tgjl::Waypoint> wps;
+  wps.reserve(waypoints.size() + 1);
+  tgjl::Waypoint start;
+  start.position = Eigen::Vector3d(
+    vehicle_pose_.pose.position.x,
+    vehicle_pose_.pose.position.y,
+    vehicle_pose_.pose.position.z);
+  start.velocity = Eigen::Vector3d(
+    vehicle_twist_.twist.linear.x,
+    vehicle_twist_.twist.linear.y,
+    vehicle_twist_.twist.linear.z);
+  wps.emplace_back(std::move(start));
+  for (const auto & wp : waypoints) {
+    wps.emplace_back(toJlWaypoint(wp));
+  }
+
+  if (!trajectory_generator_->generate(wps, max_speed)) {
+    return false;
+  }
+
+  // Map mission waypoint ids to spline breakpoint times. wps[0] is the
+  // synthetic start, so bps[i+1] corresponds to waypoints[i].
+  const auto bps = trajectory_generator_->spline().breakpoints();
+  if (!bps.empty()) {
+    const double t0 = bps.front();
+    for (std::size_t i = 1; i < bps.size() && (i - 1) < waypoints.size();
+      ++i)
+    {
+      waypoint_arrival_times_.emplace_back(
+        waypoints[i - 1].id, bps[i] - t0);
+    }
+  }
+  // Anchor host axis to backend axis: t_trajectory_now -> minTime().
+  internal_offset_ = trajectory_generator_->minTime() - t_trajectory_now;
+  return true;
+}
+
+bool Plugin::evaluate(
+  double t_trajectory,
+  as2_msgs::msg::TrajectoryPoint & out,
+  bool is_horizon_sample)
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return false;
+  }
+
+  const double t_backend = std::clamp(
+    t_trajectory + internal_offset_,
+    trajectory_generator_->minTime(), trajectory_generator_->maxTime());
+
+  const auto sample = trajectory_generator_->evaluate(t_backend);
+  out.position.x = sample.position.x();
+  out.position.y = sample.position.y();
+  out.position.z = sample.position.z();
+  out.twist.x = sample.velocity.x();
+  out.twist.y = sample.velocity.y();
+  out.twist.z = sample.velocity.z();
+  out.acceleration.x = sample.acceleration.x();
+  out.acceleration.y = sample.acceleration.y();
+  out.acceleration.z = sample.acceleration.z();
+
+  if (!is_horizon_sample) {
+    last_eval_backend_time_ = t_backend;
+  }
+  return true;
+}
+
+bool Plugin::isFinished(double t_trajectory) const
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return true;
+  }
+  return (t_trajectory + internal_offset_) >= trajectory_generator_->maxTime();
+}
+
+double Plugin::getDuration() const
+{
+  if (!trajectory_generator_ || !trajectory_generator_->isValid()) {
+    return 0.0;
+  }
+  return trajectory_generator_->maxTime() - trajectory_generator_->minTime();
+}
+
+bool Plugin::isTrajectoryGenerated()
+{
+  return trajectory_generator_ && trajectory_generator_->isValid();
+}
+
+void Plugin::reset()
+{
+  trajectory_generator_.reset();
+  waypoint_arrival_times_.clear();
+  last_eval_backend_time_ = 0.0;
+  internal_offset_ = 0.0;
+}
+
+std::string Plugin::getNextWaypointId()
+{
+  for (const auto & [id, t_arrival] : waypoint_arrival_times_) {
+    if (t_arrival > last_eval_backend_time_) {
+      return id;
+    }
+  }
+  return {};
+}
+
+}  // namespace jerk_limited_trajectory_generator
+
+PLUGINLIB_EXPORT_CLASS(
+  jerk_limited_trajectory_generator::Plugin,
+  generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase)

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+# GTest of the jerk_limited_trajectory_generator plugin.
+# Loads the plugin via pluginlib and exercises the public base API.
+file(GLOB GTEST_SOURCES "*_gtest.cpp")
+file(GLOB BENCHMARK_SOURCES "*_benchmark.cpp")
+
+if(GTEST_SOURCES)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
+
+  foreach(TEST_SOURCE ${GTEST_SOURCES})
+    get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+
+    ament_add_gtest(${TEST_NAME} ${TEST_SOURCE})
+    ament_target_dependencies(${TEST_NAME} ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${TEST_NAME}
+      ament_index_cpp::ament_index_cpp
+      gtest_main
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()
+
+# Per-plugin Google-Benchmark binaries. Each source owns its main() and
+# registers whichever plugin it wants to exercise.
+find_package(benchmark QUIET)
+if(benchmark_FOUND AND BENCHMARK_SOURCES)
+  set(BENCHMARK_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/common)
+
+  foreach(BENCHMARK_SOURCE ${BENCHMARK_SOURCES})
+    get_filename_component(BENCHMARK_NAME ${BENCHMARK_SOURCE} NAME_WE)
+
+    add_executable(${PROJECT_NAME}_${BENCHMARK_NAME} ${BENCHMARK_SOURCE})
+    target_include_directories(${PROJECT_NAME}_${BENCHMARK_NAME} PRIVATE
+      ${BENCHMARK_COMMON_DIR})
+    ament_target_dependencies(${PROJECT_NAME}_${BENCHMARK_NAME}
+      ${PLUGIN_DEPENDENCIES})
+    target_link_libraries(${PROJECT_NAME}_${BENCHMARK_NAME}
+      benchmark::benchmark
+      ${PLUGIN_NAME}
+      ${BEHAVIOR_NAME}_plugin_base
+    )
+  endforeach()
+endif()

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/jerk_limited_trajectory_generator_benchmark.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/jerk_limited_trajectory_generator_benchmark.cpp
@@ -1,0 +1,54 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file jerk_limited_trajectory_generator_benchmark.cpp
+ *
+ * @brief Benchmarks for jerk_limited_trajectory_generator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include <benchmark/benchmark.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "generate_polynomial_trajectory_benchmark_common.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  generate_polynomial_trajectory_benchmark::silenceRosLogging();
+  benchmark::Initialize(&argc, argv);
+  generate_polynomial_trajectory_benchmark::registerPluginBenchmarks(
+    "jerk_limited_trajectory_generator");
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/jerk_limited_trajectory_generator_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/jerk_limited_trajectory_generator_gtest.cpp
@@ -1,0 +1,215 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file jerk_limited_trajectory_generator_gtest.cpp
+ *
+ * @brief Plugin-level tests for jerk_limited_trajectory_generator.
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "as2_core/node.hpp"
+#include "generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp"
+
+using PluginBase = generate_polynomial_trajectory_behavior_plugin_base::
+  GeneratePolynomialTrajectoryBase;
+
+namespace
+{
+as2_msgs::msg::PoseStampedWithID makeWaypoint(
+  const std::string & id, double x, double y, double z)
+{
+  as2_msgs::msg::PoseStampedWithID wp;
+  wp.id = id;
+  wp.pose.header.frame_id = "earth";
+  wp.pose.pose.position.x = x;
+  wp.pose.pose.position.y = y;
+  wp.pose.pose.position.z = z;
+  wp.pose.pose.orientation.w = 1.0;
+  return wp;
+}
+
+geometry_msgs::msg::PoseStamped makePose(double x, double y, double z)
+{
+  geometry_msgs::msg::PoseStamped p;
+  p.header.frame_id = "earth";
+  p.pose.position.x = x;
+  p.pose.position.y = y;
+  p.pose.position.z = z;
+  p.pose.orientation.w = 1.0;
+  return p;
+}
+
+struct PluginFixture
+{
+  std::shared_ptr<as2::Node> node;
+  std::shared_ptr<pluginlib::ClassLoader<PluginBase>> loader;
+  std::shared_ptr<PluginBase> plugin;
+};
+
+PluginFixture makePluginFixture(
+  const std::string & node_name,
+  const std::vector<rclcpp::Parameter> & parameter_overrides)
+{
+  PluginFixture f;
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(parameter_overrides);
+  f.node = std::make_shared<as2::Node>(node_name, options);
+  f.loader = std::make_shared<pluginlib::ClassLoader<PluginBase>>(
+    "as2_behaviors_trajectory_generation",
+    "generate_polynomial_trajectory_behavior_plugin_base::"
+    "GeneratePolynomialTrajectoryBase");
+  f.plugin = f.loader->createSharedInstance(
+    "jerk_limited_trajectory_generator::Plugin");
+  f.plugin->initialize(f.node.get(), "jerk_limited_trajectory_generator");
+  return f;
+}
+}  // namespace
+
+TEST(JerkLimitedTrajectoryGenerator, load_generate_evaluate_reset) {
+  auto fx = makePluginFixture("jerk_limited_traj_gen_test", {});
+
+  // Mission waypoints only — the plugin auto-prepends the current vehicle
+  // pose (read from vehicle_pose_) as the trajectory start.
+  std::vector<as2_msgs::msg::PoseStampedWithID> waypoints = {
+    makeWaypoint("waypoint_000", 2.0, 0.0, 1.0),
+    makeWaypoint("waypoint_001", 4.0, 0.0, 1.0),
+  };
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), zero_twist);
+
+  ASSERT_TRUE(
+    fx.plugin->generateTrajectory(
+      waypoints, /*max_speed=*/ 1.0, /*t_trajectory_now=*/ 0.0));
+  ASSERT_TRUE(fx.plugin->isTrajectoryGenerated());
+  ASSERT_FALSE(fx.plugin->isFinished(0.0));
+  ASSERT_TRUE(fx.plugin->isFinished(1e6));
+
+  // At t_trajectory = 0, the next pending waypoint is the first mission
+  // waypoint after the implicit start.
+  as2_msgs::msg::TrajectoryPoint p_start;
+  EXPECT_TRUE(fx.plugin->evaluate(0.0, p_start, false));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_000");
+
+  double t_end = 0.0;
+  for (double t = 0.0; t < 1e3; t += 0.05) {
+    if (fx.plugin->isFinished(t)) {
+      t_end = t;
+      break;
+    }
+  }
+  ASSERT_GT(t_end, 0.0);
+  const double t_mid = 0.5 * t_end;
+  as2_msgs::msg::TrajectoryPoint p_mid;
+  EXPECT_TRUE(fx.plugin->evaluate(t_mid, p_mid, false));
+  EXPECT_EQ(fx.plugin->getNextWaypointId(), "waypoint_001");
+
+  fx.plugin->reset();
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+  EXPECT_TRUE(fx.plugin->getNextWaypointId().empty());
+}
+
+TEST(JerkLimitedTrajectoryGenerator, honors_initial_velocity_boundary_condition) {
+  // Re-plan while the drone is moving: setVehicleState carries a non-zero
+  // twist and the resulting trajectory must start at exactly that velocity
+  // so the splice is C^1-continuous (no instantaneous velocity jump at
+  // t = t_min).
+  auto fx = makePluginFixture("jerk_limited_traj_gen_v0", {});
+
+  geometry_msgs::msg::TwistStamped twist;
+  twist.twist.linear.x = 0.5;  // m/s along +X
+  twist.twist.linear.y = 0.0;
+  twist.twist.linear.z = 0.0;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), twist);
+
+  std::vector<as2_msgs::msg::PoseStampedWithID> waypoints = {
+    makeWaypoint("waypoint_000", 4.0, 0.0, 1.0),
+  };
+
+  ASSERT_TRUE(
+    fx.plugin->generateTrajectory(
+      waypoints, /*max_speed=*/ 1.0, /*t_trajectory_now=*/ 0.0));
+  ASSERT_TRUE(fx.plugin->isTrajectoryGenerated());
+
+  as2_msgs::msg::TrajectoryPoint p_start;
+  ASSERT_TRUE(fx.plugin->evaluate(0.0, p_start, false));
+  // Position pinned to the vehicle pose, velocity pinned to the vehicle
+  // twist passed in through setVehicleState.
+  EXPECT_DOUBLE_EQ(p_start.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(p_start.position.y, 0.0);
+  EXPECT_DOUBLE_EQ(p_start.position.z, 1.0);
+  EXPECT_NEAR(p_start.twist.x, 0.5, 1e-9);
+  EXPECT_NEAR(p_start.twist.y, 0.0, 1e-9);
+  EXPECT_NEAR(p_start.twist.z, 0.0, 1e-9);
+}
+
+TEST(JerkLimitedTrajectoryGenerator, rejects_degenerate_inputs) {
+  auto fx = makePluginFixture("jerk_limited_traj_gen_degenerate", {});
+
+  geometry_msgs::msg::TwistStamped zero_twist;
+  fx.plugin->setVehicleState(makePose(0.0, 0.0, 1.0), zero_twist);
+
+  // Empty mission waypoints: nothing to plan toward.
+  std::vector<as2_msgs::msg::PoseStampedWithID> empty;
+  EXPECT_FALSE(
+    fx.plugin->generateTrajectory(empty, 1.0, /*t_trajectory_now=*/ 0.0));
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+
+  // Non-positive max_speed is invalid regardless of waypoint count.
+  std::vector<as2_msgs::msg::PoseStampedWithID> one = {
+    makeWaypoint("end", 1.0, 0.0, 1.0),
+  };
+  EXPECT_FALSE(
+    fx.plugin->generateTrajectory(
+      one, /*max_speed=*/ 0.0, /*t_trajectory_now=*/ 0.0));
+  EXPECT_FALSE(fx.plugin->isTrajectoryGenerated());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/jerk_limited_waypoint_fidelity_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/tests/jerk_limited_waypoint_fidelity_gtest.cpp
@@ -1,0 +1,265 @@
+// Copyright 2026 Universidad Politecnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politecnica de Madrid nor the names
+//    of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file waypoint_fidelity_gtest.cpp
+ *
+ * @brief Standalone fidelity tests for trajectory_generator_jerk_limited.
+ *
+ * Exercises the upstream library directly (no ROS 2, no pluginlib) on the
+ * geometries that fail in the user-facing setup: a vertical climb in a
+ * straight line and a horizontal zigzag. For each waypoint provided, checks
+ * the minimum distance from the sampled trajectory to that waypoint and
+ * fails if the trajectory does not pass within a small tolerance.
+ *
+ * The tolerance is intentionally separated for the LAST waypoint (which the
+ * generator is now required to reach tightly via final_acceptance_radius)
+ * and for intermediate waypoints (which are subject to the L1 corner-cut
+ * controlled by acceptance_radius).
+ *
+ * @authors Rafael Perez-Segui
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "trajectory_generator_jerk_limited/trajectory_generator.hpp"
+#include "trajectory_generator_jerk_limited/types.hpp"
+
+namespace tg = trajectory_generator_jerk_limited;
+
+namespace
+{
+
+// Tolerances for waypoint adherence. The last waypoint must be reached
+// tightly thanks to final_acceptance_radius; intermediate waypoints are
+// allowed a wider margin since acceptance_radius drives the L1 corner-cut.
+constexpr double kFinalWaypointTolerance = 0.10;         // [m]
+constexpr double kIntermediateWaypointTolerance = 1.10;  // [m]
+
+tg::GeneratorConfig defaultConfig()
+{
+  tg::GeneratorConfig cfg;
+  cfg.params.max_speed = 5.0;
+  cfg.params.max_acceleration = 4.0;
+  cfg.params.max_jerk = 20.0;
+  cfg.params.acceptance_radius = 1.0;          // L1 corner-cut on intermediates.
+  cfg.params.final_acceptance_radius = 0.05;   // tight stop at the goal.
+  cfg.params.trajectory_gain = 1.0;
+  cfg.simulator.step_dt = 0.01;
+  cfg.simulator.max_simulation_time = 60.0;
+  cfg.simulator.settle_velocity = 0.05;
+  cfg.simulator.polynomial_order = 16;
+  return cfg;
+}
+
+// Returns the minimum Euclidean distance from any sample of the trajectory
+// to the given target position over the [0, duration] horizon.
+double minDistanceToTarget(
+  const tg::TrajectoryGenerator & gen, const Eigen::Vector3d & target)
+{
+  const double t0 = gen.minTime();
+  const double t1 = gen.maxTime();
+  const double dt = 0.01;
+  double best = std::numeric_limits<double>::infinity();
+  for (double t = t0; t <= t1; t += dt) {
+    const Eigen::Vector3d p = gen.position(t);
+    best = std::min(best, (p - target).norm());
+  }
+  // Always sample the exact endpoint as well so the final waypoint is
+  // captured even when (t1 - t0) is not an integer multiple of dt.
+  const Eigen::Vector3d p_end = gen.position(t1);
+  best = std::min(best, (p_end - target).norm());
+  return best;
+}
+
+void assertFidelity(
+  const tg::TrajectoryGenerator & gen,
+  const std::vector<Eigen::Vector3d> & user_waypoints,
+  const std::string & label)
+{
+  ASSERT_FALSE(user_waypoints.empty()) << label;
+  for (std::size_t i = 0; i < user_waypoints.size(); ++i) {
+    const double d = minDistanceToTarget(gen, user_waypoints[i]);
+    const bool is_last = (i + 1 == user_waypoints.size());
+    const double tol =
+      is_last ? kFinalWaypointTolerance : kIntermediateWaypointTolerance;
+    EXPECT_LE(d, tol)
+      << label << ": waypoint #" << i
+      << " (" << user_waypoints[i].transpose() << ") was missed by "
+      << d << " m (tol " << tol << " m)";
+  }
+}
+
+}  // namespace
+
+TEST(JerkLimitedFidelity, StraightLineVerticalClimb)
+{
+  // The drone takes off near (0,0,0) and must reach (0,0,2). With the legacy
+  // single-knob behaviour and acceptance_radius = 1.0, the integrator could
+  // declare itself settled barely off the ground; the new
+  // final_acceptance_radius forces it to actually reach the goal.
+  const Eigen::Vector3d start(0.0, 0.0, 0.0);
+  const Eigen::Vector3d goal(0.0, 0.0, 2.0);
+  std::vector<tg::Waypoint> wps;
+  wps.emplace_back(tg::EndWaypoint(start));
+  wps.emplace_back(tg::EndWaypoint(goal));
+
+  tg::TrajectoryGenerator gen(defaultConfig());
+  ASSERT_TRUE(gen.generate(wps, defaultConfig().params.max_speed));
+
+  assertFidelity(gen, {goal}, "StraightLineVerticalClimb");
+}
+
+TEST(JerkLimitedFidelity, HorizontalZigzag)
+{
+  // Five waypoints zig-zagging in y at constant z. With acceptance_radius=1.0
+  // the L1 corner-cut rounds intermediate corners, so the path geometry must
+  // give the cut some room (legs >= 5 m, amplitude <= 1 m) — tighter zigzags
+  // are outside the well-behaved regime of the upstream L1 corner-cut. The
+  // last waypoint must still be reached within kFinalWaypointTolerance even
+  // though the L1 path through the previous corner ends ~1 m off the
+  // straight line.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 1.0},
+    {5.0, 1.0, 1.0},
+    {10.0, -1.0, 1.0},
+    {15.0, 1.0, 1.0},
+    {20.0, 0.0, 1.0},
+  };
+  std::vector<tg::Waypoint> wps;
+  wps.emplace_back(tg::EndWaypoint(path.front()));
+  for (std::size_t i = 1; i + 1 < path.size(); ++i) {
+    wps.emplace_back(tg::Waypoint(path[i]));
+  }
+  wps.emplace_back(tg::EndWaypoint(path.back()));
+
+  tg::TrajectoryGenerator gen(defaultConfig());
+  ASSERT_TRUE(gen.generate(wps, defaultConfig().params.max_speed));
+
+  assertFidelity(gen, path, "HorizontalZigzag");
+}
+
+TEST(JerkLimitedFidelity, SquareFourCorner)
+{
+  // Closed 10 m square at constant altitude — resembles the user's
+  // mission.py PATH issued as a sequence of go_to_point calls. Verifies the
+  // generator handles 90 deg turns and returns to the start.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 1.0},
+    {10.0, 0.0, 1.0},
+    {10.0, 10.0, 1.0},
+    {0.0, 10.0, 1.0},
+    {0.0, 0.0, 1.0},
+  };
+  std::vector<tg::Waypoint> wps;
+  wps.emplace_back(tg::EndWaypoint(path.front()));
+  for (std::size_t i = 1; i + 1 < path.size(); ++i) {
+    wps.emplace_back(tg::Waypoint(path[i]));
+  }
+  wps.emplace_back(tg::EndWaypoint(path.back()));
+
+  tg::TrajectoryGenerator gen(defaultConfig());
+  ASSERT_TRUE(gen.generate(wps, defaultConfig().params.max_speed));
+
+  assertFidelity(gen, path, "SquareFourCorner");
+}
+
+TEST(JerkLimitedFidelity, ColinearVerticalSegment)
+{
+  // Two consecutive waypoints share xy (purely vertical motion) before
+  // moving sideways. The integrator must terminate at the actual goal and
+  // not mistake "near the intermediate vertical waypoint" for completion.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 0.0},
+    {0.0, 0.0, 2.0},
+    {2.0, 0.0, 2.0},
+  };
+  std::vector<tg::Waypoint> wps;
+  wps.emplace_back(tg::EndWaypoint(path.front()));
+  wps.emplace_back(tg::Waypoint(path[1]));
+  wps.emplace_back(tg::EndWaypoint(path.back()));
+
+  tg::TrajectoryGenerator gen(defaultConfig());
+  ASSERT_TRUE(gen.generate(wps, defaultConfig().params.max_speed));
+
+  assertFidelity(gen, path, "ColinearVerticalSegment");
+}
+
+TEST(JerkLimitedFidelity, TightTrackingZigzag)
+{
+  // Regression guard for the `simulator.advance_radius_min` parameter.
+  // The default 0.1 m floor is what makes intermediate waypoints get missed
+  // by ~10 cm even with `acceptance_radius` set to 1 cm. By lowering the
+  // floor to 5 mm and raising `trajectory_gain` to keep the corner-speed
+  // cap near `max_speed`, the trajectory must pass close to every
+  // intermediate waypoint.
+  tg::GeneratorConfig cfg = defaultConfig();
+  cfg.params.acceptance_radius = 0.01;
+  cfg.params.trajectory_gain = 10.0;
+  cfg.simulator.advance_radius_min = 0.005;
+
+  // Mild zigzag: 5 m legs, 0.5 m amplitude. The corner-speed cap with this
+  // config is sqrt(max_a * gain * R * tan(alpha/2)) >> max_speed, so the
+  // bottleneck on corner velocity is `max_speed` itself.
+  const std::vector<Eigen::Vector3d> path = {
+    {0.0, 0.0, 1.0},
+    {5.0, 0.5, 1.0},
+    {10.0, -0.5, 1.0},
+    {15.0, 0.5, 1.0},
+    {20.0, 0.0, 1.0},
+  };
+  std::vector<tg::Waypoint> wps;
+  wps.emplace_back(tg::EndWaypoint(path.front()));
+  for (std::size_t i = 1; i + 1 < path.size(); ++i) {
+    wps.emplace_back(tg::Waypoint(path[i]));
+  }
+  wps.emplace_back(tg::EndWaypoint(path.back()));
+
+  tg::TrajectoryGenerator gen(cfg);
+  ASSERT_TRUE(gen.generate(wps, cfg.params.max_speed));
+
+  // Tighter than the legacy intermediate tolerance: with the floor lowered,
+  // every intermediate must be within 0.05 m of the trajectory.
+  for (std::size_t i = 0; i < path.size(); ++i) {
+    const double d = minDistanceToTarget(gen, path[i]);
+    const bool is_last = (i + 1 == path.size());
+    const double tol = is_last ? 0.05 : 0.05;
+    EXPECT_LE(d, tol)
+      << "TightTrackingZigzag: waypoint #" << i
+      << " (" << path[i].transpose() << ") was missed by "
+      << d << " m (tol " << tol << " m)";
+  }
+}


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

Adds a new `jerk_limited_trajectory_generator` plugin that wraps the
[`trajectory_generator_jerk_limited`](https://github.com/aerostack2/jerk_limited_trajectory_generator_lib)
S-curve simulator (jerk-limited per-axis profile, optional L1
corner-cut multi-waypoint smoothing) on top of the plugin contract.

- **Backend**:
  [`trajectory_generator_jerk_limited`](https://github.com/aerostack2/jerk_limited_trajectory_generator_lib)
  (`main`). Resolution policy in `CMakeLists.txt`:
  `find_package(trajectory_generator_jerk_limited QUIET)` → local
  clone under
  `plugins/jerk_limited_trajectory_generator/thirdparties/trajectory_generator_jerk_limited/`
  → `FetchContent`.
- **Time-axis**: relies on the **base default** `updateWaypoints()`
  (regenerate via `reset()` + `generateTrajectory(t_trajectory_now)`).
  Each `generateTrajectory(t)` re-anchors the plugin's
  `internal_offset_` so the host's `t_trajectory` keeps mapping to a
  valid backend time after a regeneration.
- **Initial state**: honours `vehicle_pose_` and the linear part of
  `vehicle_twist_` as the initial-velocity boundary condition for the
  S-curve profile, so re-plans during flight keep velocity continuity.
- **Configuration**: backend-only keys live under the plugin
  namespace in `config/jerk_limited_trajectory_generator.yaml`
  and are read with the protected `getParameter<T>()` helper from the
  base class (auto-prefixed with the plugin name).