### PR TITLE
[as2_behaviors_trajectory_generation] Add no yaw management to face reference mode

### DIFF
--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
@@ -872,17 +872,26 @@ GeneratePolynomialTrajectoryBehavior::getNextReferenceWaypoint() const
   }
 
   const std::string next_id = plugin_->getNextWaypointId();
-  if (!next_id.empty()) {
-    const auto it = std::find_if(
-      goal_.path.begin(), goal_.path.end(),
-      [&next_id](const as2_msgs::msg::PoseStampedWithID & wp) {
-        return wp.id == next_id;
-      });
-    if (it != goal_.path.end()) {
-      return &(*it);
-    }
+  if (next_id.empty()) {
+    return nullptr;
   }
-  return &goal_.path.front();
+
+  const auto cursor = std::find_if(
+    goal_.path.begin(), goal_.path.end(),
+    [&next_id](const as2_msgs::msg::PoseStampedWithID & wp) {
+      return wp.id == next_id;
+    });
+  if (cursor == goal_.path.end()) {
+    return nullptr;
+  }
+
+  // Skip waypoints whose id contains the "ny" substring
+  const auto it = std::find_if(
+    cursor, goal_.path.end(),
+    [](const as2_msgs::msg::PoseStampedWithID & wp) {
+      return wp.id.find("ny") == std::string::npos;
+    });
+  return (it != goal_.path.end()) ? &(*it) : nullptr;
 }
 
 double GeneratePolynomialTrajectoryBehavior::computeYawFaceReference()


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo, Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Add a key "ny" to waypoints id in order to not look at them when using face reference mode