### PR TITLE
[as2_motion_controller] Use last TF transform for fast lookup

### DIFF
--- a/as2_core/tests/tf_utils_gtest.cpp
+++ b/as2_core/tests/tf_utils_gtest.cpp
@@ -38,7 +38,9 @@
 
 #include <tf2_ros/static_transform_broadcaster.h>
 
+#include <chrono>
 #include <cmath>
+#include <thread>
 #include <std_msgs/msg/bool.hpp>
 #include "gtest/gtest.h"
 
@@ -181,6 +183,12 @@ TEST(TFHandlerTest, convertTrajectorySetpointsIdentity) {
   // This holds even if no TF buffer is available (no broadcasters needed).
   auto node = std::make_shared<as2::Node>("test_traj_identity_node");
   auto tf_handler = std::make_shared<TfHandler>(node.get());
+
+  // Let tf initialize
+  for (int i = 0; i < 30; ++i) {
+    rclcpp::spin_some(node);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
 
   as2_msgs::msg::TrajectorySetpoints traj;
   traj.header.frame_id = "odom";

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -213,8 +213,12 @@ void ControllerHandler::stateCallback(
   }
 
   try {
+    // Use the latest cached transform (`tf2::TimePointZero` via timeout==0)
+    // Either this change have more error, is more efficient to ensure the 
+    // controller frequency
     auto [pose_msg, twist_msg] = tf_handler_->getState(
-      *_twist_msg, input_twist_frame_id_, input_pose_frame_id_, flu_frame_id_);
+      *_twist_msg, input_twist_frame_id_, input_pose_frame_id_, flu_frame_id_,
+      std::chrono::nanoseconds::zero());
 
     state_acquired_ = true;
     state_pose_ = pose_msg;
@@ -749,7 +753,10 @@ void ControllerHandler::publishCommand()
     control_mode_out_.control_mode == as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE ||
     control_mode_out_.control_mode == as2_msgs::msg::ControlMode::ATTITUDE)
   {
-    if (!tf_handler_->tryConvert(command_pose_, output_pose_frame_id_)) {
+    if (command_pose_.header.frame_id != output_pose_frame_id_ &&
+      !tf_handler_->tryConvert(command_pose_, output_pose_frame_id_,
+        std::chrono::nanoseconds::zero()))
+    {
       auto & clk = *node_ptr_->get_clock();
       RCLCPP_ERROR_THROTTLE(
         node_ptr_->get_logger(), clk, 1000,
@@ -763,7 +770,10 @@ void ControllerHandler::publishCommand()
     control_mode_out_.control_mode == as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE ||
     control_mode_out_.control_mode == as2_msgs::msg::ControlMode::ACRO)
   {
-    if (!tf_handler_->tryConvert(command_twist_, output_twist_frame_id_)) {
+    if (command_twist_.header.frame_id != output_twist_frame_id_ &&
+      !tf_handler_->tryConvert(command_twist_, output_twist_frame_id_,
+        std::chrono::nanoseconds::zero()))
+    {
       auto & clk = *node_ptr_->get_clock();
       RCLCPP_ERROR_THROTTLE(
         node_ptr_->get_logger(), clk, 1000,

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -214,7 +214,7 @@ void ControllerHandler::stateCallback(
 
   try {
     // Use the latest cached transform (`tf2::TimePointZero` via timeout==0)
-    // Either this change have more error, is more efficient to ensure the 
+    // Either this change have more error, is more efficient to ensure the
     // controller frequency
     auto [pose_msg, twist_msg] = tf_handler_->getState(
       *_twist_msg, input_twist_frame_id_, input_pose_frame_id_, flu_frame_id_,
@@ -754,7 +754,8 @@ void ControllerHandler::publishCommand()
     control_mode_out_.control_mode == as2_msgs::msg::ControlMode::ATTITUDE)
   {
     if (command_pose_.header.frame_id != output_pose_frame_id_ &&
-      !tf_handler_->tryConvert(command_pose_, output_pose_frame_id_,
+      !tf_handler_->tryConvert(
+        command_pose_, output_pose_frame_id_,
         std::chrono::nanoseconds::zero()))
     {
       auto & clk = *node_ptr_->get_clock();
@@ -771,7 +772,8 @@ void ControllerHandler::publishCommand()
     control_mode_out_.control_mode == as2_msgs::msg::ControlMode::ACRO)
   {
     if (command_twist_.header.frame_id != output_twist_frame_id_ &&
-      !tf_handler_->tryConvert(command_twist_, output_twist_frame_id_,
+      !tf_handler_->tryConvert(
+        command_twist_, output_twist_frame_id_,
         std::chrono::nanoseconds::zero()))
     {
       auto & clk = *node_ptr_->get_clock();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo, Multirotor Simulator |

---

## Description of contribution in a few bullet points


* `[as2_motion_controller]` Use the latest cached transform (`tf2::TimePointZero`, via `timeout == 0`) for the controller state and command frame conversions, and skip the conversion when source and target frames already match.
* This avoids per-stamp TF lookups that, under sim time, can block up to `tf_timeout_threshold` and stall the control loop / `state_acquired_`.
* `[as2_core]` Fix the `tf_utils` gtest hang (`convertTrajectorySetpointsIdentity`): creating and destroying a `TfHandler` too fast hit the `tf2_ros::TransformListener` teardown race (lost `executor->cancel()` → `join()` blocks forever → 60 s timeout). The listener is now allowed to settle before teardown.
