### PR TITLE
[as2_behaviors_motion] Fix go_to reporting success on a stale distance at goal activation

### DIFF
--- a/as2_behaviors/as2_behaviors_motion/go_to_behavior/include/go_to_behavior/go_to_base.hpp
+++ b/as2_behaviors/as2_behaviors_motion/go_to_behavior/include/go_to_behavior/go_to_base.hpp
@@ -118,6 +118,15 @@ public:
 
     if (own_activate(goal_candidate)) {
       goal_ = goal_candidate;
+      // Refresh the distance-to-goal against the new goal
+      feedback_.actual_distance_to_goal =
+        (Eigen::Vector3d(
+          actual_pose_.pose.position.x, actual_pose_.pose.position.y,
+          actual_pose_.pose.position.z) -
+        Eigen::Vector3d(
+          goal_.target_pose.point.x, goal_.target_pose.point.y,
+          goal_.target_pose.point.z))
+        .norm();
       return true;
     }
     return false;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo, Multirotor Simulator |

---

## Description of contribution in a few bullet points

**Bug: `GoToWaypoint` can report success without moving, skipping the goal.**

The `go_to` position plugin decides the goal is reached with:

```cpp
fabs(feedback_.actual_distance_to_goal) < params_.go_to_threshold
```

`feedback_.actual_distance_to_goal` is updated only asynchronously, in `GoToBase::state_callback` (driven by the `self_localization/twist` subscription). On a new goal, `on_activate` sets `goal_` but does **not** refresh that distance, and `BehaviorServer::activate()` starts the run timer (`own_run` → `checkGoalCondition`) immediately after `on_activate` returns. So the **first** `own_run` can read a distance still computed against the **previous** goal.

When goals are issued back-to-back while the drone hovers on the previous goal (cached distance ~0), the first `own_run` sees `~0 < threshold` and returns `SUCCESS` instantly — the drone never moves toward the new goal and the waypoint is skipped. It is intermittent: it happens only when the run-timer tick wins the race against the next `state_callback`. A higher `run_frequency` makes it more likely, because the first tick fires sooner after activation.

**Fix:** in `GoToBase::on_activate`, right after `goal_` is set, recompute `feedback_.actual_distance_to_goal` from the current pose and the new goal. Because the run timer is started only after `on_activate` returns, the first `own_run` is guaranteed to see the correct distance.

* `go_to_behavior`: refresh `actual_distance_to_goal` against the new goal in `on_activate` (`go_to_base.hpp`), fixing the false success at goal activation.

**How it was tested** (Gazebo, simulation, humble): a 3-waypoint mission issuing back-to-back `go_to` goals.
* Before: 5 skipped goals out of 16 activations (~31%), each with cached distance ~0.04 m while the true distance to the new goal was 5–9 m.
* After: 0 skips out of 21 activations; the drone reaches every waypoint (residual < 0.05 m).

For reference, `follow_path` does not show this because its `reset()` sets `actual_distance_to_next_waypoint = 2 * threshold` on teardown/init and its `state_callback` is gated by `goal_accepted_`, so the safe value survives to the next activation. `go_to` has neither, hence the minimal refresh-on-activation fix.

### Documentation Updates

None. Correct cases are unchanged; only the erroneous early success is removed.

### Future Work

* Optionally align `go_to`'s state handling with `follow_path`'s (`goal_accepted_` gate + `reset()`) so both behaviors share the same lifecycle pattern. Not required for this fix.
