### PR TITLE
[aerostack2] Fix main build and test regressions

### DIFF
--- a/.github/workflows/build-humble.yaml
+++ b/.github/workflows/build-humble.yaml
@@ -2,12 +2,12 @@ name: humble
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [opened, synchronize, reopened, review_requested, ready_for_review]
     branches:
       - main
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build-jazzy.yaml
+++ b/.github/workflows/build-jazzy.yaml
@@ -2,7 +2,10 @@ name: jazzy
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [opened, synchronize, reopened, review_requested, ready_for_review]
+    branches:
+      - main
+  push:
     branches:
       - main
 

--- a/.github/workflows/pixi-build.yaml
+++ b/.github/workflows/pixi-build.yaml
@@ -2,7 +2,10 @@ name: pixi
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [opened, synchronize, reopened, review_requested, ready_for_review]
+    branches:
+      - main
+  push:
     branches:
       - main
   workflow_dispatch:

--- a/as2_hardware_drivers/as2_realsense_interface/CMakeLists.txt
+++ b/as2_hardware_drivers/as2_realsense_interface/CMakeLists.txt
@@ -26,6 +26,7 @@ set(PROJECT_DEPENDENCIES
   sensor_msgs
   nav_msgs
   geometry_msgs
+  fastcdr
   realsense2
   tf2
   tf2_ros
@@ -51,10 +52,21 @@ add_library(${PROJECT_NAME} STATIC ${SOURCE_CPP_FILES})
 ament_target_dependencies(${PROJECT_NAME} ${PROJECT_DEPENDENCIES})
 target_link_libraries(${PROJECT_NAME} ${realsense2_LIBRARY})
 
+# librealsense 2.58.x embeds and exports Fast-CDR symbols when built with DDS.
+# Load ROS's Fast-CDR first on Linux so the default Fast DDS RMW does not bind
+# to librealsense's private, ABI-incompatible copy during rclcpp::Node startup.
+function(as2_target_link_realsense TARGET_NAME)
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(
+      ${TARGET_NAME} "-Wl,--no-as-needed" "$<TARGET_FILE:fastcdr>" "-Wl,--as-needed")
+  endif()
+  target_link_libraries(${TARGET_NAME} ${PROJECT_NAME})
+endfunction()
+
 # Create the node executable
 add_executable(${PROJECT_NAME}_node src/as2_realsense_interface_node.cpp)
 ament_target_dependencies(${PROJECT_NAME}_node ${PROJECT_DEPENDENCIES})
-target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME})
+as2_target_link_realsense(${PROJECT_NAME}_node)
 
 # Install the headers
 install(

--- a/as2_hardware_drivers/as2_realsense_interface/include/as2_realsense_interface/as2_realsense_interface.hpp
+++ b/as2_hardware_drivers/as2_realsense_interface/include/as2_realsense_interface/as2_realsense_interface.hpp
@@ -83,13 +83,13 @@ public:
 private:
   std::string realsense_name_;
 
-  bool verbose_;
-  bool device_not_found_;
-  bool imu_available_;
-  bool depth_available_;
-  bool color_available_;
-  bool fisheye_available_;
-  bool pose_available_;
+  bool verbose_{false};
+  bool device_not_found_{false};
+  bool imu_available_{false};
+  bool depth_available_{false};
+  bool color_available_{false};
+  bool fisheye_available_{false};
+  bool pose_available_{false};
 
   // Sensor comm
   std::string serial_;

--- a/as2_hardware_drivers/as2_realsense_interface/package.xml
+++ b/as2_hardware_drivers/as2_realsense_interface/package.xml
@@ -19,6 +19,7 @@
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_srvs </depend>
+  <depend>fastcdr</depend>
   <depend>librealsense2</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/as2_hardware_drivers/as2_realsense_interface/tests/CMakeLists.txt
+++ b/as2_hardware_drivers/as2_realsense_interface/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(TEST_SOURCE)
 
     add_executable(${PROJECT_NAME}_${TEST_NAME} ${TEST_FILE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_NAME})
+    as2_target_link_realsense(${PROJECT_NAME}_${TEST_NAME})
   endforeach()
 endif()
 
@@ -23,7 +23,8 @@ if(GTEST_SOURCE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main)
+    as2_target_link_realsense(${PROJECT_NAME}_${TEST_NAME})
   endforeach()
 endif()
 
@@ -37,6 +38,7 @@ if(BENCHMARK_SOURCE)
     get_filename_component(BENCHMARK_NAME ${BENCHMARK_FILE} NAME_WE)
 
     add_executable(${PROJECT_NAME}_${BENCHMARK_NAME} ${BENCHMARK_FILE})
-    target_link_libraries(${PROJECT_NAME}_${BENCHMARK_NAME} ${PROJECT_NAME} benchmark::benchmark)
+    target_link_libraries(${PROJECT_NAME}_${BENCHMARK_NAME} benchmark::benchmark)
+    as2_target_link_realsense(${PROJECT_NAME}_${BENCHMARK_NAME})
   endforeach()
 endif()

--- a/as2_hardware_drivers/as2_realsense_interface/tests/as2_realsense_interface_gtest.cpp
+++ b/as2_hardware_drivers/as2_realsense_interface/tests/as2_realsense_interface_gtest.cpp
@@ -68,8 +68,8 @@ std::shared_ptr<real_sense_interface::RealsenseInterface> get_node(
 }
 
 TEST(PlatformGazeboGTest, Constructor) {
-  EXPECT_NO_THROW(get_node());
   auto node = get_node();
+  ASSERT_NE(node, nullptr);
 
   // Spin the node
   rclcpp::executors::MultiThreadedExecutor executor;

--- a/as2_simulation_assets/as2_gazebo_assets/scripts/jinja_gen.py
+++ b/as2_simulation_assets/as2_gazebo_assets/scripts/jinja_gen.py
@@ -93,7 +93,7 @@ def get_sensors(sensors_array: list[str]) -> dict[str, str]:
                         'drone_model_name': drone_model_name,
                         'gimbaled': str2bool(gimbaled)})
 
-        if model=="gimbal_position" or model=="gimbal_speed":
+        if model in ('gimbal_position', 'gimbal_speed'):
             joint_limits_yaw, joint_limits_pitch, joint_limits_roll, sensors_array = \
                 sensors_array[:4], sensors_array[4:8], sensors_array[8:12], sensors_array[12:]
             sensors[-1].update({

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/drone.py
@@ -46,7 +46,7 @@ from as2_gazebo_assets.bridges import bridges as gz_bridges
 from as2_gazebo_assets.bridges import custom_bridges as gz_custom_bridges
 from as2_gazebo_assets.bridges.bridge import Bridge
 from as2_gazebo_assets.models.entity import Entity
-from as2_gazebo_assets.models.payload import Payload, GimbalTypeEnum
+from as2_gazebo_assets.models.payload import GimbalTypeEnum, Payload
 from launch_ros.actions import Node
 
 try:
@@ -259,9 +259,13 @@ class Drone(Entity):
             if isinstance(pld.model_type, GimbalTypeEnum):
                 payload += f'{pld.joint_limits_yaw["effort"]} {pld.joint_limits_yaw["velocity"]} '
                 payload += f'{pld.joint_limits_yaw["upper"]} {pld.joint_limits_yaw["lower"]} '
-                payload += f'{pld.joint_limits_pitch["effort"]} {pld.joint_limits_pitch["velocity"]} '
+                payload += (
+                    f'{pld.joint_limits_pitch["effort"]} '
+                    f'{pld.joint_limits_pitch["velocity"]} ')
                 payload += f'{pld.joint_limits_pitch["upper"]} {pld.joint_limits_pitch["lower"]} '
-                payload += f'{pld.joint_limits_roll["effort"]} {pld.joint_limits_roll["velocity"]} '
+                payload += (
+                    f'{pld.joint_limits_roll["effort"]} '
+                    f'{pld.joint_limits_roll["velocity"]} ')
                 payload += f'{pld.joint_limits_roll["upper"]} {pld.joint_limits_roll["lower"]} '
 
         if isinstance(self.model_type, DroneTypeEnum):

--- a/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
+++ b/as2_simulation_assets/as2_gazebo_assets/src/as2_gazebo_assets/models/payload.py
@@ -430,24 +430,24 @@ class Payload(Entity):  # noqa: F811
     gimbaled: bool = False
     gimbal_name: str = 'None'
     joint_limits_yaw = {
-        "effort": float('inf'),
-        "velocity": float('inf'),
-        "upper": float('inf'),
-        "lower": float('-inf')
+        'effort': float('inf'),
+        'velocity': float('inf'),
+        'upper': float('inf'),
+        'lower': float('-inf')
     }
     joint_limits_pitch = {
-        "effort": float('inf'),
-        "velocity": float('inf'),
-        "upper": float('inf'),
-        "lower": float('-inf')
+        'effort': float('inf'),
+        'velocity': float('inf'),
+        'upper': float('inf'),
+        'lower': float('-inf')
     }
     joint_limits_roll = {
-        "effort": float('inf'),
-        "velocity": float('inf'),
-        "upper": float('inf'),
-        "lower": float('-inf')
+        'effort': float('inf'),
+        'velocity': float('inf'),
+        'upper': float('inf'),
+        'lower': float('-inf')
     }
-    
+
     @validator('payload', always=True)
     def set_gimbaled_default(cls, v, values):
         if 'model_type' in values and isinstance(values['model_type'], GimbalTypeEnum):


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo, Multirotor Simulator |

---

## Description of contribution in a few bullet points

- Fix the 20 `flake8` violations in `as2_gazebo_assets` introduced by #932.
- Prevent the Jazzy RealSense node and constructor test from crashing with `librealsense 2.58.1`. That binary exports a private Fast-CDR implementation which otherwise takes precedence over ROS Fast-CDR when the default Fast DDS RMW is loaded.
- Initialize the RealSense availability flags and avoid constructing the node twice in its constructor test.
- Run Humble, Jazzy, and Pixi workflows when a PR is opened, updated, reopened, marked ready, or receives a review request.
- Run the same workflows after changes land on `main`, so regressions cannot remain undetected until the scheduled coverage workflow.

## Documentation Updates

No user-facing documentation changes are required.

## Future Work

- Remove the explicit Fast-CDR load-order workaround once the ROS Jazzy `librealsense` package stops exporting its private Fast-CDR symbols.
- Consider adding branch-protection rules that require the Humble and Jazzy jobs on the current PR head.

## Root Cause

The workflow triggers only covered `review_requested` and `ready_for_review`. PR #932 therefore merged without an Actions run, and its lint errors first appeared in the scheduled workflow the following day. PR updates and pushes to `main` were also not covered.

The additional Jazzy failure was caused by the dependency update from `librealsense 2.57.7` to `2.58.1`, not by the changes in #969.

## Validation

- Humble clean build: 30 packages built successfully.
- Humble tests: 1985 tests, 0 errors, 0 failures, 335 skipped.
- Jazzy clean coverage build: 30 packages built successfully.
- Jazzy tests with `librealsense 2.58.1` and the default Fast DDS RMW: 1985 tests, 0 errors, 0 failures, 337 skipped.
