### PR TITLE
[as2_behavior_tree] general improvements

### DIFF
--- a/as2_behavior_tree/CMakeLists.txt
+++ b/as2_behavior_tree/CMakeLists.txt
@@ -52,6 +52,7 @@ set(PLUGINS_CPP_FILES
   plugins/action/get_origin.cpp
   plugins/action/gps_to_cartesian.cpp
   plugins/action/go_to_gps_action.cpp
+  plugins/action/follow_reference_action.cpp
   plugins/condition/is_flying_condition.cpp
   plugins/decorator/wait_for_event.cpp
   plugins/decorator/wait_for_alert.cpp

--- a/as2_behavior_tree/CMakeLists.txt
+++ b/as2_behavior_tree/CMakeLists.txt
@@ -66,6 +66,15 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME})
 add_library(${PROJECT_NAME} ${PLUGINS_CPP_FILES})
 ament_target_dependencies(${PROJECT_NAME} ${PROJECT_DEPENDENCIES})
 
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_export_include_directories(include)
+ament_export_targets(export_${PROJECT_NAME})
+ament_export_dependencies(${PROJECT_DEPENDENCIES})
+
 # Install the headers
 install(
   DIRECTORY include/

--- a/as2_behavior_tree/include/as2_behavior_tree/action/follow_path.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/action/follow_path.hpp
@@ -62,25 +62,31 @@ public:
 
   void on_tick()
   {
+    getInput("frame_id", frame_id_);
     getInput("path", path_);
     getInput("speed", max_speed_);
     getInput("yaw_mode", yaw_mode_);
+    goal_.header.frame_id = frame_id_;
     goal_.path = path_;  // TODO(pariaspe): improve with port_specialization
     goal_.max_speed = max_speed_;
-    goal_.yaw.mode = as2_msgs::msg::YawMode::KEEP_YAW;
+    goal_.yaw.mode = yaw_mode_;
   }
 
   static BT::PortsList providedPorts()
   {
-    return providedBasicPorts(
-      {BT::InputPort<std::vector<as2_msgs::msg::PoseWithID>>("path"),
-        BT::InputPort<double>("speed"), BT::OutputPort<int>("yaw_mode")});
+    return providedBasicPorts({
+      BT::InputPort<std::string>("frame_id"),
+      BT::InputPort<std::vector<as2_msgs::msg::PoseWithID>>("path"),
+      BT::InputPort<double>("speed"), 
+      BT::InputPort<int>("yaw_mode")
+    });
   }
 
   void on_wait_for_result(
     std::shared_ptr<const as2_msgs::action::FollowPath::Feedback> feedback) {}
 
 private:
+  std::string frame_id_;
   std::vector<as2_msgs::msg::PoseWithID> path_;
   double max_speed_;
   int yaw_mode_;

--- a/as2_behavior_tree/include/as2_behavior_tree/action/follow_path.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/action/follow_path.hpp
@@ -74,12 +74,13 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return providedBasicPorts({
-      BT::InputPort<std::string>("frame_id"),
-      BT::InputPort<std::vector<as2_msgs::msg::PoseWithID>>("path"),
-      BT::InputPort<double>("speed"), 
-      BT::InputPort<int>("yaw_mode")
-    });
+    return providedBasicPorts(
+      {
+        BT::InputPort<std::string>("frame_id"),
+        BT::InputPort<std::vector<as2_msgs::msg::PoseWithID>>("path"),
+        BT::InputPort<double>("speed"),
+        BT::InputPort<int>("yaw_mode")
+      });
   }
 
   void on_wait_for_result(

--- a/as2_behavior_tree/include/as2_behavior_tree/action/follow_reference_action.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/action/follow_reference_action.hpp
@@ -1,0 +1,82 @@
+// Copyright 2024 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file follow_reference.hpp
+ *
+ */
+
+#ifndef AS2_BEHAVIOR_TREE__ACTION__FOLLOW_reference_HPP_
+#define AS2_BEHAVIOR_TREE__ACTION__FOLLOW_reference_HPP_
+
+#include <string>
+#include <memory>
+#include <vector>
+
+#include "as2_behavior_tree/bt_action_node.hpp"
+
+#include "as2_core/names/actions.hpp"
+#include "as2_msgs/action/follow_reference.hpp"
+#include "as2_msgs/msg/pose_with_id.hpp"
+#include "as2_msgs/msg/yaw_mode.hpp"
+
+namespace as2_behavior_tree
+{
+class FollowReferenceAction
+  : public as2_behavior_tree::BtActionNode<as2_msgs::action::FollowReference>
+{
+public:
+  FollowReferenceAction(
+    const std::string & xml_tag_name,
+    const BT::NodeConfiguration & conf);
+
+  void on_tick() override;
+
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts({
+      BT::InputPort<std::string>("frame_id"),
+      BT::InputPort<geometry_msgs::msg::Point>("reference"),
+      BT::InputPort<double>("max_speed_x"),
+      BT::InputPort<double>("max_speed_y"),
+      BT::InputPort<double>("max_speed_z"),
+      BT::InputPort<int>("yaw_mode"),
+      BT::InputPort<double>("yaw_angle")
+    });
+  }
+
+  void on_wait_for_result(
+    std::shared_ptr<const as2_msgs::action::FollowReference::Feedback> feedback);
+
+private:
+
+};
+
+}  // namespace as2_behavior_tree
+
+#endif  // AS2_BEHAVIOR_TREE__ACTION__FOLLOW_reference_HPP_

--- a/as2_behavior_tree/include/as2_behavior_tree/action/follow_reference_action.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/action/follow_reference_action.hpp
@@ -31,8 +31,8 @@
  *
  */
 
-#ifndef AS2_BEHAVIOR_TREE__ACTION__FOLLOW_reference_HPP_
-#define AS2_BEHAVIOR_TREE__ACTION__FOLLOW_reference_HPP_
+#ifndef AS2_BEHAVIOR_TREE__ACTION__FOLLOW_REFERENCE_ACTION_HPP_
+#define AS2_BEHAVIOR_TREE__ACTION__FOLLOW_REFERENCE_ACTION_HPP_
 
 #include <string>
 #include <memory>
@@ -59,24 +59,24 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return providedBasicPorts({
-      BT::InputPort<std::string>("frame_id"),
-      BT::InputPort<geometry_msgs::msg::Point>("reference"),
-      BT::InputPort<double>("max_speed_x"),
-      BT::InputPort<double>("max_speed_y"),
-      BT::InputPort<double>("max_speed_z"),
-      BT::InputPort<int>("yaw_mode"),
-      BT::InputPort<double>("yaw_angle")
-    });
+    return providedBasicPorts(
+      {
+        BT::InputPort<std::string>("frame_id"),
+        BT::InputPort<geometry_msgs::msg::Point>("reference"),
+        BT::InputPort<double>("max_speed_x"),
+        BT::InputPort<double>("max_speed_y"),
+        BT::InputPort<double>("max_speed_z"),
+        BT::InputPort<int>("yaw_mode"),
+        BT::InputPort<double>("yaw_angle")
+      });
   }
 
   void on_wait_for_result(
     std::shared_ptr<const as2_msgs::action::FollowReference::Feedback> feedback);
 
 private:
-
 };
 
 }  // namespace as2_behavior_tree
 
-#endif  // AS2_BEHAVIOR_TREE__ACTION__FOLLOW_reference_HPP_
+#endif  // AS2_BEHAVIOR_TREE__ACTION__FOLLOW_REFERENCE_ACTION_HPP_

--- a/as2_behavior_tree/include/as2_behavior_tree/action/go_to_action.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/action/go_to_action.hpp
@@ -66,10 +66,13 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return providedBasicPorts(
-      {BT::InputPort<double>("max_speed"), BT::InputPort<double>("yaw_angle"),
-        BT::InputPort<geometry_msgs::msg::PointStamped>("pose"),
-        BT::InputPort<int>("yaw_mode")});
+    return providedBasicPorts({
+      BT::InputPort<geometry_msgs::msg::PointStamped>("pose"),
+      BT::InputPort<std::string>("frame_id", "earth", "frame id for the goal"),
+      BT::InputPort<double>("max_speed"), 
+      BT::InputPort<int>("yaw_mode"),
+      BT::InputPort<double>("yaw_angle"),
+    });
   }
 };
 

--- a/as2_behavior_tree/include/as2_behavior_tree/action/go_to_action.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/action/go_to_action.hpp
@@ -66,13 +66,14 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return providedBasicPorts({
-      BT::InputPort<geometry_msgs::msg::PointStamped>("pose"),
-      BT::InputPort<std::string>("frame_id", "earth", "frame id for the goal"),
-      BT::InputPort<double>("max_speed"), 
-      BT::InputPort<int>("yaw_mode"),
-      BT::InputPort<double>("yaw_angle"),
-    });
+    return providedBasicPorts(
+      {
+        BT::InputPort<geometry_msgs::msg::PointStamped>("pose"),
+        BT::InputPort<std::string>("frame_id", "earth", "frame id for the goal"),
+        BT::InputPort<double>("max_speed"),
+        BT::InputPort<int>("yaw_mode"),
+        BT::InputPort<double>("yaw_angle"),
+      });
   }
 };
 

--- a/as2_behavior_tree/include/as2_behavior_tree/bt_action_node.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/bt_action_node.hpp
@@ -324,7 +324,7 @@ public:
       }
     }
 
-    setStatus(BT::NodeStatus::IDLE);
+    resetStatus();
   }
 
 protected:

--- a/as2_behavior_tree/include/as2_behavior_tree/bt_action_node.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/bt_action_node.hpp
@@ -25,6 +25,7 @@
 #include "behaviortree_cpp/action_node.h"
 #include "behaviortree_cpp/bt_factory.h"
 #include "rclcpp_action/rclcpp_action.hpp"
+#include "as2_behavior_tree/port_specialization.hpp"
 
 namespace as2_behavior_tree
 {

--- a/as2_behavior_tree/include/as2_behavior_tree/bt_service_node.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/bt_service_node.hpp
@@ -130,7 +130,7 @@ public:
   void halt() override
   {
     request_sent_ = false;
-    setStatus(BT::NodeStatus::IDLE);
+    resetStatus();
   }
 
   /**

--- a/as2_behavior_tree/include/as2_behavior_tree/condition/is_flying_condition.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/condition/is_flying_condition.hpp
@@ -61,20 +61,20 @@ public:
 
   BT::NodeStatus tick() override;
 
-  static BT::PortsList providedPorts() {return {};}
+  static BT::PortsList providedPorts();
 
 private:
-  void stateCallback(as2_msgs::msg::PlatformInfo::SharedPtr msg)
-  {
-    is_flying_ = msg->status.state == as2_msgs::msg::PlatformStatus::FLYING;
-  }
+  void state_callback(as2_msgs::msg::PlatformInfo::SharedPtr msg);
+  void wait_for_message();
 
-private:
   rclcpp::Node::SharedPtr node_;
   rclcpp::CallbackGroup::SharedPtr callback_group_;
   rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
   rclcpp::Subscription<as2_msgs::msg::PlatformInfo>::SharedPtr state_sub_;
+  std::string topic_name_;
   bool is_flying_ = false;
+  bool msg_arrived_ = false;
+  std::chrono::milliseconds wait_for_timeout_{1000};
 };
 
 }  // namespace as2_behavior_tree

--- a/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
@@ -66,6 +66,22 @@ inline geometry_msgs::msg::Pose convertFromString(BT::StringView str)
 }
 
 template<>
+inline geometry_msgs::msg::Point convertFromString(BT::StringView str)
+{
+  // We expect real numbers separated by semicolons
+  auto parts = splitString(str, ';');
+  if (parts.size() != 3) {
+    throw RuntimeError("invalid input)");
+  } else {
+    geometry_msgs::msg::Point output;
+    output.x = convertFromString<double>(parts[0]);
+    output.y = convertFromString<double>(parts[1]);
+    output.z = convertFromString<double>(parts[2]);
+    return output;
+  }
+}
+
+template<>
 inline geometry_msgs::msg::PointStamped convertFromString(BT::StringView str)
 {
   // We expect real numbers separated by semicolons

--- a/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
@@ -38,6 +38,7 @@
 #define AS2_BEHAVIOR_TREE__PORT_SPECIALIZATION_HPP_
 
 #include <vector>
+#include <chrono>
 #include "behaviortree_cpp/bt_factory.h"
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "geometry_msgs/msg/pose.hpp"
@@ -110,6 +111,13 @@ convertFromString(BT::StringView str)
     output.emplace_back(mypose_2);
     return output;
   }
+}
+
+template<>
+inline std::chrono::milliseconds convertFromString(BT::StringView str)
+{
+    int ms = convertFromString<int>(str);
+    return std::chrono::milliseconds(ms);
 }
 
 }  // end namespace BT

--- a/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
@@ -82,35 +82,45 @@ inline geometry_msgs::msg::PointStamped convertFromString(BT::StringView str)
   }
 }
 
-// TODO(pariaspe): generalize
 template<>
 inline std::vector<as2_msgs::msg::PoseWithID>
 convertFromString(BT::StringView str)
 {
-  // We expect real numbers separated by semicolons
+  std::vector<as2_msgs::msg::PoseWithID> output;
+
+  // Split poses by '|'
   auto points = splitString(str, '|');
-  auto parts = splitString(points[0], ';');
-  if (parts.size() != 3) {
-    throw RuntimeError("invalid input)");
-  } else {
-    std::vector<as2_msgs::msg::PoseWithID> output;
-    as2_msgs::msg::PoseWithID mypose;
-    mypose.id = "0";
-    mypose.pose.position.x = convertFromString<double>(parts[0]);
-    mypose.pose.position.y = convertFromString<double>(parts[1]);
-    mypose.pose.position.z = convertFromString<double>(parts[2]);
 
-    auto parts_2 = splitString(points[1], ';');
-    as2_msgs::msg::PoseWithID mypose_2;
-    mypose_2.id = "1";
-    mypose_2.pose.position.x = convertFromString<double>(parts_2[0]);
-    mypose_2.pose.position.y = convertFromString<double>(parts_2[1]);
-    mypose_2.pose.position.z = convertFromString<double>(parts_2[2]);
-
-    output.emplace_back(mypose);
-    output.emplace_back(mypose_2);
-    return output;
+  if (points.empty()) {
+    throw RuntimeError("Empty input for poses");
   }
+
+  output.reserve(points.size());
+
+  for (size_t i = 0; i < points.size(); ++i)
+  {
+    auto parts = splitString(points[i], ';');
+
+    if (parts.size() != 3) {
+      throw RuntimeError("Invalid pose format: expected x;y;z");
+    }
+
+    as2_msgs::msg::PoseWithID pose;
+    pose.id = std::to_string(i);
+
+    pose.pose.position.x = convertFromString<double>(parts[0]);
+    pose.pose.position.y = convertFromString<double>(parts[1]);
+    pose.pose.position.z = convertFromString<double>(parts[2]);
+
+    pose.pose.orientation.x = 0.0;
+    pose.pose.orientation.y = 0.0;
+    pose.pose.orientation.z = 0.0;
+    pose.pose.orientation.w = 1.0;
+
+    output.emplace_back(std::move(pose));
+  }
+
+  return output;
 }
 
 template<>

--- a/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
+++ b/as2_behavior_tree/include/as2_behavior_tree/port_specialization.hpp
@@ -39,6 +39,7 @@
 
 #include <vector>
 #include <chrono>
+#include <utility>
 #include "behaviortree_cpp/bt_factory.h"
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "geometry_msgs/msg/pose.hpp"
@@ -113,8 +114,7 @@ convertFromString(BT::StringView str)
 
   output.reserve(points.size());
 
-  for (size_t i = 0; i < points.size(); ++i)
-  {
+  for (size_t i = 0; i < points.size(); ++i) {
     auto parts = splitString(points[i], ';');
 
     if (parts.size() != 3) {
@@ -142,8 +142,8 @@ convertFromString(BT::StringView str)
 template<>
 inline std::chrono::milliseconds convertFromString(BT::StringView str)
 {
-    int ms = convertFromString<int>(str);
-    return std::chrono::milliseconds(ms);
+  int ms = convertFromString<int>(str);
+  return std::chrono::milliseconds(ms);
 }
 
 }  // end namespace BT

--- a/as2_behavior_tree/plugins/action/follow_reference_action.cpp
+++ b/as2_behavior_tree/plugins/action/follow_reference_action.cpp
@@ -1,0 +1,63 @@
+// Copyright 2024 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file follow_reference_action.hpp
+ *
+ * Follow Reference implementation as behavior tree node
+ *
+ */
+
+#include "as2_behavior_tree/action/follow_reference_action.hpp"
+
+namespace as2_behavior_tree
+{
+FollowReferenceAction::FollowReferenceAction(
+  const std::string & xml_tag_name,
+  const BT::NodeConfiguration & conf):
+    as2_behavior_tree::BtActionNode<as2_msgs::action::FollowReference>(
+      xml_tag_name, as2_names::actions::behaviors::followreference, conf) 
+{}
+
+void FollowReferenceAction::on_tick()
+{
+    getInput("frame_id", goal_.target_pose.header.frame_id);
+    geometry_msgs::msg::Point target;
+    getInput("reference",  target);
+    goal_.target_pose.point = target;
+    getInput("max_speed_x", goal_.max_speed_x);
+    getInput("max_speed_y", goal_.max_speed_y);
+    getInput("max_speed_z", goal_.max_speed_z);
+    getInput("yaw_mode", goal_.yaw.mode);
+    getInput("yaw_angle", goal_.yaw.angle);
+}
+
+void FollowReferenceAction::on_wait_for_result(
+  std::shared_ptr<const as2_msgs::action::FollowReference::Feedback> feedback) {}
+
+}  // namespace as2_behavior_tree

--- a/as2_behavior_tree/plugins/action/follow_reference_action.cpp
+++ b/as2_behavior_tree/plugins/action/follow_reference_action.cpp
@@ -39,22 +39,22 @@ namespace as2_behavior_tree
 {
 FollowReferenceAction::FollowReferenceAction(
   const std::string & xml_tag_name,
-  const BT::NodeConfiguration & conf):
-    as2_behavior_tree::BtActionNode<as2_msgs::action::FollowReference>(
-      xml_tag_name, as2_names::actions::behaviors::followreference, conf) 
+  const BT::NodeConfiguration & conf)
+: as2_behavior_tree::BtActionNode<as2_msgs::action::FollowReference>(
+    xml_tag_name, as2_names::actions::behaviors::followreference, conf)
 {}
 
 void FollowReferenceAction::on_tick()
 {
-    getInput("frame_id", goal_.target_pose.header.frame_id);
-    geometry_msgs::msg::Point target;
-    getInput("reference",  target);
-    goal_.target_pose.point = target;
-    getInput("max_speed_x", goal_.max_speed_x);
-    getInput("max_speed_y", goal_.max_speed_y);
-    getInput("max_speed_z", goal_.max_speed_z);
-    getInput("yaw_mode", goal_.yaw.mode);
-    getInput("yaw_angle", goal_.yaw.angle);
+  getInput("frame_id", goal_.target_pose.header.frame_id);
+  geometry_msgs::msg::Point target;
+  getInput("reference", target);
+  goal_.target_pose.point = target;
+  getInput("max_speed_x", goal_.max_speed_x);
+  getInput("max_speed_y", goal_.max_speed_y);
+  getInput("max_speed_z", goal_.max_speed_z);
+  getInput("yaw_mode", goal_.yaw.mode);
+  getInput("yaw_angle", goal_.yaw.angle);
 }
 
 void FollowReferenceAction::on_wait_for_result(

--- a/as2_behavior_tree/plugins/action/go_to_action.cpp
+++ b/as2_behavior_tree/plugins/action/go_to_action.cpp
@@ -55,6 +55,7 @@ void GoToAction::on_tick()
     goal_.yaw.mode);        // TODO(pariaspe): runtime warning, called
                             // BT::convertFromString() for type [unsigned char]
   getInput<geometry_msgs::msg::PointStamped>("pose", goal_.target_pose);
+  getInput<std::string>("frame_id", goal_.target_pose.header.frame_id);
 }
 
 void GoToAction::on_wait_for_result(

--- a/as2_behavior_tree/plugins/condition/is_flying_condition.cpp
+++ b/as2_behavior_tree/plugins/condition/is_flying_condition.cpp
@@ -43,7 +43,7 @@ namespace as2_behavior_tree
 IsFlyingCondition::IsFlyingCondition(
   const std::string & xml_tag_name,
   const BT::NodeConfiguration & conf)
-: BT::ConditionNode(xml_tag_name, conf)
+: BT::ConditionNode(xml_tag_name, conf), topic_name_(as2_names::topics::platform::info)
 {
   node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
   callback_group_ = node_->create_callback_group(
@@ -52,12 +52,26 @@ IsFlyingCondition::IsFlyingCondition(
     callback_group_,
     node_->get_node_base_interface());
 
+  std::string remapped_topic_name;
+  if (getInput("topic_name", remapped_topic_name)) {
+    topic_name_ = remapped_topic_name;
+  }
+
   rclcpp::SubscriptionOptions sub_option;
   sub_option.callback_group = callback_group_;
   state_sub_ = node_->create_subscription<as2_msgs::msg::PlatformInfo>(
-    as2_names::topics::platform::info, as2_names::topics::platform::qos,
-    std::bind(&IsFlyingCondition::stateCallback, this, std::placeholders::_1),
+    topic_name_, as2_names::topics::platform::qos,
+    std::bind(&IsFlyingCondition::state_callback, this, std::placeholders::_1),
     sub_option);
+
+  wait_for_message();
+}
+
+
+BT::PortsList IsFlyingCondition::providedPorts() {
+  return {
+      BT::InputPort<std::string>("topic_name", "Platform info topic name")
+    };
 }
 
 BT::NodeStatus IsFlyingCondition::tick()
@@ -67,6 +81,48 @@ BT::NodeStatus IsFlyingCondition::tick()
     return BT::NodeStatus::SUCCESS;
   }
   return BT::NodeStatus::FAILURE;
+}
+
+void IsFlyingCondition::state_callback(as2_msgs::msg::PlatformInfo::SharedPtr msg)
+{
+  msg_arrived_ = true;
+  is_flying_ = msg->status.state == as2_msgs::msg::PlatformStatus::FLYING;
+}
+
+void IsFlyingCondition::wait_for_message()
+{
+  RCLCPP_INFO(node_->get_logger(),
+              "Waiting for message on topic %s...",
+              topic_name_.c_str());
+
+  rclcpp::Rate rate(100);
+  auto start = node_->now();
+
+  rclcpp::Duration timeout(wait_for_timeout_);
+  while (rclcpp::ok())
+  {
+    callback_group_executor_.spin_some();
+
+    if (msg_arrived_)
+    {
+      RCLCPP_INFO(node_->get_logger(), "... message received");
+      return;
+    }
+
+    if (wait_for_timeout_.count() > 0 &&
+        (node_->now() - start) > timeout)
+    {
+      RCLCPP_ERROR(node_->get_logger(),
+                   "\"%s\" topic not available after waiting for %ld ms",
+                   topic_name_.c_str(),
+                   wait_for_timeout_.count());
+
+      throw std::runtime_error(
+        "Topic " + topic_name_ + " not available");
+    }
+
+    rate.sleep();
+  }
 }
 
 }  // namespace as2_behavior_tree

--- a/as2_behavior_tree/plugins/condition/is_flying_condition.cpp
+++ b/as2_behavior_tree/plugins/condition/is_flying_condition.cpp
@@ -68,10 +68,11 @@ IsFlyingCondition::IsFlyingCondition(
 }
 
 
-BT::PortsList IsFlyingCondition::providedPorts() {
+BT::PortsList IsFlyingCondition::providedPorts()
+{
   return {
-      BT::InputPort<std::string>("topic_name", "Platform info topic name")
-    };
+    BT::InputPort<std::string>("topic_name", "Platform info topic name")
+  };
 }
 
 BT::NodeStatus IsFlyingCondition::tick()
@@ -91,34 +92,34 @@ void IsFlyingCondition::state_callback(as2_msgs::msg::PlatformInfo::SharedPtr ms
 
 void IsFlyingCondition::wait_for_message()
 {
-  RCLCPP_INFO(node_->get_logger(),
-              "Waiting for message on topic %s...",
-              topic_name_.c_str());
+  RCLCPP_INFO(
+    node_->get_logger(),
+    "Waiting for message on topic %s...",
+    topic_name_.c_str());
 
   rclcpp::Rate rate(100);
   auto start = node_->now();
 
   rclcpp::Duration timeout(wait_for_timeout_);
-  while (rclcpp::ok())
-  {
+  while (rclcpp::ok()) {
     callback_group_executor_.spin_some();
 
-    if (msg_arrived_)
-    {
+    if (msg_arrived_) {
       RCLCPP_INFO(node_->get_logger(), "... message received");
       return;
     }
 
     if (wait_for_timeout_.count() > 0 &&
-        (node_->now() - start) > timeout)
+      (node_->now() - start) > timeout)
     {
-      RCLCPP_ERROR(node_->get_logger(),
-                   "\"%s\" topic not available after waiting for %ld ms",
-                   topic_name_.c_str(),
-                   wait_for_timeout_.count());
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "\"%s\" topic not available after waiting for %ld ms",
+        topic_name_.c_str(),
+        wait_for_timeout_.count());
 
       throw std::runtime_error(
-        "Topic " + topic_name_ + " not available");
+              "Topic " + topic_name_ + " not available");
     }
 
     rate.sleep();


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

This splits PR #961 with changes only affecting `as2_behavior_tree` package. Changes are:
* CMake: easier include as2_behavior_tree package
* Fix: bt_cpp library now resetStatus() instead of setting directly the node to IDLE
* Fix: port with type chrono::millisecond impossible to parse
* Fix: follow_path bt_action ports list. Added frame_id and speed. Solved error on yaw_mode
* Feat: wait for topic in the flying conditions and topic_name port
* Feat: Solved parsing with multiple poses in follow_path bt_action
* Feat: added follow_reference bt_action
* Feat: go_to bt_action ports list. Added frame_id, max_speed and yaw_angle


Changes made by @torydebra 