### PR TITLE
[as2_behaviors_object_perception] Address post-merge review comments

### DIFF
--- a/as2_behaviors/as2_behaviors_object_perception/CMakeLists.txt
+++ b/as2_behaviors/as2_behaviors_object_perception/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_DEPENDENCIES
   as2_behavior
   sensor_msgs
   geometry_msgs
+  cv_bridge
   OpenCV
   tf2
   as2_usb_camera_interface

--- a/as2_behaviors/as2_behaviors_object_perception/config/config.yaml
+++ b/as2_behaviors/as2_behaviors_object_perception/config/config.yaml
@@ -7,7 +7,8 @@
     camera_info_topic: "sensor_measurements/camera/camera_info" # Camera calibration topic. Empty disables it
     enable_rectification: false # Undistort the image before feeding it to the pipeline
     rectified_camera_info_topic: "" # Republish the rectified intrinsics for downstream pose estimation. Empty disables it
-
+    threshold: 0.0 # Minimum confidence threshold for detections. Detections below this threshold are ignored
+    target_classes: [] # List of target classes to detect. Empty means all classes are accepted
     pipeline:
       stages: ["detector"] # Stages to run, in order
       detector:

--- a/as2_behaviors/as2_behaviors_object_perception/config/config.yaml
+++ b/as2_behaviors/as2_behaviors_object_perception/config/config.yaml
@@ -1,19 +1,18 @@
 /**:
   ros__parameters:
-    persistent: true
-    run_frequency: 30.0
-    camera_image_topic: "sensor_measurements/camera/image_raw"
-    camera_info_topic: "sensor_measurements/camera/camera_info"
-    enable_rectification: false
-    use_embedded_camera: true
-    use_sim_time: False
+    persistent: true # Keep the behavior running after a cycle without detections
+    run_frequency: 30.0 # Pipeline execution rate (Hz)
+    camera_image_topic: "sensor_measurements/camera/image_raw" # Input image topic. Subscribes to CompressedImage if it ends in /compressed, to Image otherwise
+    camera_info_topic: "sensor_measurements/camera/camera_info" # Camera calibration topic. Empty disables it
+    enable_rectification: false # Undistort the image before feeding it to the pipeline
+    rectified_camera_info_topic: "" # Republish the rectified intrinsics for downstream pose estimation. Empty disables it
 
     pipeline:
-      stages: ["detector"]
+      stages: ["detector"] # Stages to run, in order
       detector:
-        plugin: "aruco"
-        input_source: "image"
-        publish_output: true
-        output_topic: "detections_data"
-        enable_debug: true
-        debug_poses_topic: "debug/detection_poses"
+        plugin: "aruco" # Detection plugin to load
+        input_source: "image" # Stage input: image | internal | external
+        publish_output: true # Publish the stage detections
+        output_topic: "detections_data" # Topic for the stage detections
+        enable_debug: true # Publish debug data (poses and plugin-specific topics)
+        debug_poses_topic: "debug/detection_poses" # Topic for the detected poses (PoseArray)

--- a/as2_behaviors/as2_behaviors_object_perception/config/config.yaml
+++ b/as2_behaviors/as2_behaviors_object_perception/config/config.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     persistent: true # Keep the behavior running after a cycle without detections
     run_frequency: 30.0 # Pipeline execution rate (Hz)
+    use_embedded_camera: false # Open the camera device from the behavior itself. If false, images come from a topic
     camera_image_topic: "sensor_measurements/camera/image_raw" # Input image topic. Subscribes to CompressedImage if it ends in /compressed, to Image otherwise
     camera_info_topic: "sensor_measurements/camera/camera_info" # Camera calibration topic. Empty disables it
     enable_rectification: false # Undistort the image before feeding it to the pipeline

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
@@ -121,6 +121,7 @@ private:
     rclcpp::Subscription<as2_msgs::msg::ObjectPerceptionArray>::SharedPtr input_sub;
     as2_msgs::msg::ObjectPerceptionArray external_input;
     bool has_external_input{false};
+    bool logged_first_detection{false};
     as2_behavior::ExecutionStatus last_status{as2_behavior::ExecutionStatus::SUCCESS};
   };
 

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
@@ -52,6 +52,7 @@
 #include "as2_behaviors_object_perception/detection_plugin_base.hpp"
 #include "as2_behaviors_object_perception/common/img_preprocessing.hpp"
 #include "sensor_msgs/msg/compressed_image.hpp"
+#include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "geometry_msgs/msg/pose_array.hpp"
 
@@ -75,6 +76,12 @@ public:
    * @param image_msg  Incoming compressed camera image.
    */
   void image_callback(const sensor_msgs::msg::CompressedImage::SharedPtr image_msg);
+
+  /**
+   * @brief Converts (and optionally rectifies) a raw image and feeds it to the pipeline.
+   * @param image_msg  Incoming raw camera image.
+   */
+  void raw_image_callback(const sensor_msgs::msg::Image::SharedPtr image_msg);
 
   /**
    * @brief Forwards the camera calibration to the preprocessor and the plugins.
@@ -136,6 +143,7 @@ private:
   as2_behaviors_object_perception::ImagePreprocessor preprocessor_;
 
   rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr image_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr raw_image_sub_;
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_sub_;
 
   // Republishes the (rectified) camera info actually used by the pipeline, so

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
@@ -126,7 +126,6 @@ private:
 
   void loadPipeline();
   PipelineStage loadStage(const std::string & stage_name);
-  void loadSinglePluginPipeline();
   PipelineStage * findStage(const std::string & stage_name);
   void publishStageOutput(const PipelineStage & stage);
   void external_input_callback(
@@ -160,7 +159,6 @@ private:
   bool rectified_info_propagated_{false};
   std::unique_ptr<usb_camera_interface::UsbCameraInterface> camera_driver_;
   bool persistent_;
-  std::string plugin_name_;
   as2_msgs::msg::ObjectPerceptionArray latest_pipeline_output_;
 
   // Diagnostics: let the user tell "no images" from "images but no detections".

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
@@ -58,7 +58,8 @@
 namespace as2_behaviors_object_perception
 {
 
-class PerceptionBehavior : public as2_behavior::BehaviorServer<as2_msgs::action::DetectObjects>
+class ObjectPerceptionBehavior
+  : public as2_behavior::BehaviorServer<as2_msgs::action::DetectObjects>
 {
 public:
   /**
@@ -66,8 +67,8 @@ public:
    *        sets up the image/camera subscriptions.
    * @param options  Node options.
    */
-  explicit PerceptionBehavior(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
-  ~PerceptionBehavior() {}
+  explicit ObjectPerceptionBehavior(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  ~ObjectPerceptionBehavior() {}
 
   /**
    * @brief Decompresses (and optionally rectifies) the image and feeds it to the pipeline.

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/as2_behaviors_object_perception.hpp
@@ -162,6 +162,9 @@ private:
   bool persistent_;
   std::string plugin_name_;
   as2_msgs::msg::ObjectPerceptionArray latest_pipeline_output_;
+
+  // Diagnostics: let the user tell "no images" from "images but no detections".
+  bool images_received_{false};
 };
 
 }  // namespace as2_behaviors_object_perception

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/common/common.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/common/common.hpp
@@ -73,6 +73,20 @@ inline std::string getNamespacedTopic(const std::string & node_namespace, const 
   return topic.front() == '/' ? node_namespace + topic : node_namespace + "/" + topic;
 }
 
+/**
+ * @brief Tells whether a topic carries CompressedImage, from its name.
+ *        Follows the image_transport convention: a "/compressed" suffix means
+ *        compressed transport, anything else means raw sensor_msgs/Image.
+ * @param topic  Topic name.
+ * @return true if the topic is a compressed image topic.
+ */
+inline bool isCompressedTopic(const std::string & topic)
+{
+  const std::string suffix = "/compressed";
+  return topic.size() >= suffix.size() &&
+         topic.compare(topic.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
 template<typename T>
 std::string paramToString(const T & value)
 {

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/detection_plugin_base.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/detection_plugin_base.hpp
@@ -55,7 +55,7 @@ namespace detection_plugin_base
  * @brief Abstract base class for object detection plugins.
  *
  * Plugins receive pre-processed images (cv::Mat) from the central
- * PerceptionBehavior and output detections via latest_detections_.
+ * ObjectPerceptionBehavior and output detections via latest_detections_.
  * Image preprocessing (decompression, rectification) is handled by
  * the behavior server, not by individual plugins.
  */
@@ -155,7 +155,7 @@ public:
 
   /**
    * @brief Returns the latest detection results.
-   * @return Detections produced by the last cycle. Read by PerceptionBehavior.
+   * @return Detections produced by the last cycle. Read by ObjectPerceptionBehavior.
    */
   as2_msgs::msg::ObjectPerceptionArray getDetections() const
   {return latest_detections_;}

--- a/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_auto_launch.py
+++ b/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_auto_launch.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Universidad Politécnica de Madrid
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch file for the detect behavior, activating it right after startup."""
+
+__authors__ = 'Guillermo GP-Lenza'
+__copyright__ = 'Copyright (c) 2025 Universidad Politécnica de Madrid'
+__license__ = 'BSD-3-Clause'
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from as2_core.launch_plugin_utils import get_available_plugins
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+from launch_ros.actions import Node
+import yaml
+
+
+PACKAGE = 'as2_behaviors_object_perception'
+
+
+def get_config_file() -> str:
+    """Return the default behavior configuration file."""
+    return os.path.join(get_package_share_directory(PACKAGE), 'config', 'config.yaml')
+
+
+def get_pipeline_plugins(config_file: str) -> list:
+    """Return the plugins named by the pipeline stages, in stage order and without repeats."""
+    with open(config_file, 'r', encoding='utf-8') as file:
+        params = yaml.safe_load(file)['/**']['ros__parameters']
+
+    pipeline = params.get('pipeline', {})
+    available_plugins = get_available_plugins(PACKAGE)
+    plugins = []
+    for stage in pipeline.get('stages', []):
+        plugin = pipeline.get(stage, {}).get('plugin')
+        if plugin is None:
+            raise RuntimeError(f"Pipeline stage '{stage}' does not declare a plugin.")
+        if plugin not in available_plugins:
+            raise RuntimeError(
+                f"Pipeline stage '{stage}' requests unknown plugin '{plugin}'. "
+                f'Available plugins: {available_plugins}')
+        if plugin not in plugins:
+            plugins.append(plugin)
+
+    if not plugins:
+        raise RuntimeError(f'No pipeline stages declared in {config_file}.')
+    return plugins
+
+
+def get_node(context, *args, **kwargs) -> list:
+    """Build the behavior node, resolving the plugin configs from the pipeline stages."""
+    package_folder = get_package_share_directory(PACKAGE)
+    config_file = get_config_file()
+
+    # Merges the default config with the user one and with the launch arguments,
+    # and writes the result to a temporary file.
+    merged_config_file = LaunchConfigurationFromConfigFile(
+        'config_file', default_file=config_file).perform(context)
+
+    # Each stage names its plugin, so the plugin default configs come from the
+    # pipeline itself. Plugin parameters live under a per-plugin namespace, so
+    # several of them can coexist, and the behavior config (loaded afterwards)
+    # can override any of them.
+    plugin_config_files = [
+        os.path.join(package_folder, 'plugins', plugin, 'config', 'plugin_default_config.yaml')
+        for plugin in get_pipeline_plugins(merged_config_file)
+    ]
+    parameters = [path for path in plugin_config_files if os.path.isfile(path)]
+    parameters += [
+        {'use_sim_time': LaunchConfiguration('use_sim_time')},
+        merged_config_file,
+    ]
+
+    # In topic mode the camera driver is external: its params and its calibration
+    # reach the behavior through camera_info, so these files are not needed.
+    with open(merged_config_file, 'r', encoding='utf-8') as file:
+        use_embedded_camera = yaml.safe_load(
+            file)['/**']['ros__parameters'].get('use_embedded_camera', False)
+    if use_embedded_camera:
+        parameters += [
+            LaunchConfiguration('camera_interface_file'),
+            LaunchConfiguration('calibration_file'),
+        ]
+
+    return [Node(
+        package=PACKAGE,
+        executable=f'{PACKAGE}_node',
+        namespace=LaunchConfiguration('namespace'),
+        parameters=parameters,
+        output='screen',
+        arguments=['--ros-args', '--log-level',
+                   LaunchConfiguration('log_level')],
+        emulate_tty=True,
+    )]
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Entrypoint."""
+    package_folder = get_package_share_directory(PACKAGE)
+
+    return LaunchDescription([
+        DeclareLaunchArgument('log_level',
+                              description='Logging level',
+                              default_value='info'),
+        DeclareLaunchArgument('use_sim_time',
+                              description='Use simulation clock if true',
+                              default_value='false'),
+        DeclareLaunchArgument('namespace',
+                              description='Drone namespace',
+                              default_value=EnvironmentVariable(
+                                  'AEROSTACK2_SIMULATION_DRONE_ID')),
+        DeclareLaunchArgument('camera_interface_file',
+                              description='Embedded camera driver params',
+                              default_value=os.path.join(
+                                  package_folder, 'config', 'camera_interface.yaml')),
+        DeclareLaunchArgument('calibration_file',
+                              description='Camera calibration (camera_info) file',
+                              default_value=os.path.join(
+                                  package_folder, 'config', 'camera_calibration.yaml')),
+        DeclareLaunchArgument('threshold',
+                              description='Minimum confidence of the detections to report',
+                              default_value='0.0'),
+        DeclareLaunchArgument('target_classes',
+                              description='Classes to look for. Empty means all of them',
+                              default_value='[]'),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=get_config_file(),
+            description='Behavior configuration file'),
+        OpaqueFunction(function=get_node),
+
+        # Send the goal once the node is up, so the pipeline runs without an
+        # external client.
+        ExecuteProcess(
+            cmd=['bash', '-c', [
+                'sleep 5 && ros2 action send_goal /',
+                LaunchConfiguration('namespace'),
+                '/ObjectPerceptionBehavior as2_msgs/action/DetectObjects ',
+                '"{threshold: ', LaunchConfiguration('threshold'),
+                ', target_classes: ', LaunchConfiguration('target_classes'), '}"',
+            ]],
+            output='screen',
+            shell=False
+        ),
+    ])

--- a/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_auto_launch.py
+++ b/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_auto_launch.py
@@ -26,9 +26,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Launch file for the detect behavior, activating it right after startup."""
+"""Launch file for the object perception behavior with auto-launch."""
 
-__authors__ = 'Guillermo GP-Lenza'
+__authors__ = 'Alba López del Águila'
 __copyright__ = 'Copyright (c) 2025 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
 
@@ -48,69 +48,97 @@ import yaml
 PACKAGE = 'as2_behaviors_object_perception'
 
 
-def get_config_file() -> str:
-    """Return the default behavior configuration file."""
-    return os.path.join(get_package_share_directory(PACKAGE), 'config', 'config.yaml')
+def _extract_ros_parameters(data: dict) -> dict:
+    """Extract ros__parameters from YAML config, handling both /** and node-specific structures."""
+    result = {}
+
+    if data is None:
+        return result
+
+    if '/**' in data:
+        global_params = data['/**']
+        if isinstance(global_params, dict):
+            if 'ros__parameters' in global_params:
+                result.update(global_params['ros__parameters'])
+            for key, value in global_params.items():
+                if key != 'ros__parameters' and isinstance(value, dict):
+                    node_ros_params = value.get('ros__parameters', {})
+                    if node_ros_params:
+                        result.update(node_ros_params)
+
+    for key, value in data.items():
+        if key != '/**' and isinstance(value, dict):
+            node_ros_params = value.get('ros__parameters', {})
+            if node_ros_params:
+                result.update(node_ros_params)
+
+    return result if result else {}
 
 
-def get_pipeline_plugins(config_file: str) -> list:
-    """Return the plugins named by the pipeline stages, in stage order and without repeats."""
-    with open(config_file, 'r', encoding='utf-8') as file:
-        params = yaml.safe_load(file)['/**']['ros__parameters']
+def get_default_config_file() -> str:
+    """Return the default configuration file path."""
+    return os.path.join(
+        get_package_share_directory(PACKAGE),
+        'config',
+        'config.yaml'
+    )
 
-    pipeline = params.get('pipeline', {})
+
+def extract_pipeline_plugins(ros_params: dict) -> list:
+    """Extract pipeline plugin names from ROS parameters."""
+    pipeline = ros_params.get('pipeline', {})
+    stages = pipeline.get('stages', [])
     available_plugins = get_available_plugins(PACKAGE)
+
     plugins = []
-    for stage in pipeline.get('stages', []):
+    for stage in stages:
         plugin = pipeline.get(stage, {}).get('plugin')
-        if plugin is None:
+        if not plugin:
             raise RuntimeError(f"Pipeline stage '{stage}' does not declare a plugin.")
         if plugin not in available_plugins:
             raise RuntimeError(
                 f"Pipeline stage '{stage}' requests unknown plugin '{plugin}'. "
-                f'Available plugins: {available_plugins}')
+                f'Available: {available_plugins}')
         if plugin not in plugins:
             plugins.append(plugin)
 
     if not plugins:
-        raise RuntimeError(f'No pipeline stages declared in {config_file}.')
+        raise RuntimeError('No pipeline stages declared in configuration.')
     return plugins
 
 
 def get_node(context, *args, **kwargs) -> list:
-    """Build the behavior node, resolving the plugin configs from the pipeline stages."""
+    """Build the behavior node with plugin configurations."""
     package_folder = get_package_share_directory(PACKAGE)
-    config_file = get_config_file()
+    default_config = get_default_config_file()
 
-    # Merges the default config with the user one and with the launch arguments,
-    # and writes the result to a temporary file.
     merged_config_file = LaunchConfigurationFromConfigFile(
-        'config_file', default_file=config_file).perform(context)
+        'config_file',
+        default_file=default_config
+    ).perform(context)
 
-    # Each stage names its plugin, so the plugin default configs come from the
-    # pipeline itself. Plugin parameters live under a per-plugin namespace, so
-    # several of them can coexist, and the behavior config (loaded afterwards)
-    # can override any of them.
+    with open(merged_config_file, 'r', encoding='utf-8') as f:
+        config_data = yaml.safe_load(f) or {}
+
+    ros_params = _extract_ros_parameters(config_data)
+    plugins = extract_pipeline_plugins(ros_params)
+
     plugin_config_files = [
         os.path.join(package_folder, 'plugins', plugin, 'config', 'plugin_default_config.yaml')
-        for plugin in get_pipeline_plugins(merged_config_file)
+        for plugin in plugins
     ]
     parameters = [path for path in plugin_config_files if os.path.isfile(path)]
-    parameters += [
+
+    parameters.extend([
         {'use_sim_time': LaunchConfiguration('use_sim_time')},
         merged_config_file,
-    ]
+    ])
 
-    # In topic mode the camera driver is external: its params and its calibration
-    # reach the behavior through camera_info, so these files are not needed.
-    with open(merged_config_file, 'r', encoding='utf-8') as file:
-        use_embedded_camera = yaml.safe_load(
-            file)['/**']['ros__parameters'].get('use_embedded_camera', False)
-    if use_embedded_camera:
-        parameters += [
+    if ros_params.get('use_embedded_camera', False):
+        parameters.extend([
             LaunchConfiguration('camera_interface_file'),
             LaunchConfiguration('calibration_file'),
-        ]
+        ])
 
     return [Node(
         package=PACKAGE,
@@ -118,8 +146,7 @@ def get_node(context, *args, **kwargs) -> list:
         namespace=LaunchConfiguration('namespace'),
         parameters=parameters,
         output='screen',
-        arguments=['--ros-args', '--log-level',
-                   LaunchConfiguration('log_level')],
+        arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
         emulate_tty=True,
     )]
 
@@ -127,6 +154,7 @@ def get_node(context, *args, **kwargs) -> list:
 def generate_launch_description() -> LaunchDescription:
     """Entrypoint."""
     package_folder = get_package_share_directory(PACKAGE)
+    default_config = get_default_config_file()
 
     return LaunchDescription([
         DeclareLaunchArgument('log_level',
@@ -140,21 +168,16 @@ def generate_launch_description() -> LaunchDescription:
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID')),
         DeclareLaunchArgument('camera_interface_file',
-                              description='Embedded camera driver params',
+                              description='Embedded camera driver configuration',
                               default_value=os.path.join(
                                   package_folder, 'config', 'camera_interface.yaml')),
         DeclareLaunchArgument('calibration_file',
-                              description='Camera calibration (camera_info) file',
+                              description='Camera calibration parameters',
                               default_value=os.path.join(
                                   package_folder, 'config', 'camera_calibration.yaml')),
-        DeclareLaunchArgument('threshold',
-                              description='Minimum confidence of the detections to report',
-                              default_value='0.0'),
-        DeclareLaunchArgument('target_classes',
-                              description='Classes to look for. Empty means all of them',
-                              default_value='[]'),
         DeclareLaunchArgumentsFromConfigFile(
-            name='config_file', source_file=get_config_file(),
+            name='config_file',
+            source_file=default_config,
             description='Behavior configuration file'),
         OpaqueFunction(function=get_node),
 

--- a/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
@@ -124,7 +124,7 @@ def generate_launch_description() -> LaunchDescription:
                               default_value=os.path.join(
                                   package_folder, 'config/camera_calibration.yaml')),
         OpaqueFunction(function=get_node),
-        # TESTING ONLY, remove before opening the PR: fires the goal on start.
+
         ExecuteProcess(
             cmd=['bash', '-c', [
                 'sleep 5 && ros2 action send_goal /',

--- a/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
@@ -26,9 +26,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Launch file for the detect behavior."""
+"""Launch file for the object perception behavior."""
 
-__authors__ = 'Guillermo GP-Lenza'
+__authors__ = 'Alba López del Águila'
 __copyright__ = 'Copyright (c) 2025 Universidad Politécnica de Madrid'
 __license__ = 'BSD-3-Clause'
 
@@ -48,69 +48,97 @@ import yaml
 PACKAGE = 'as2_behaviors_object_perception'
 
 
-def get_config_file() -> str:
-    """Return the default behavior configuration file."""
-    return os.path.join(get_package_share_directory(PACKAGE), 'config', 'config.yaml')
+def _extract_ros_parameters(data: dict) -> dict:
+    """Extract ros__parameters from YAML config, handling both /** and node-specific structures."""
+    result = {}
+
+    if data is None:
+        return result
+
+    if '/**' in data:
+        global_params = data['/**']
+        if isinstance(global_params, dict):
+            if 'ros__parameters' in global_params:
+                result.update(global_params['ros__parameters'])
+            for key, value in global_params.items():
+                if key != 'ros__parameters' and isinstance(value, dict):
+                    node_ros_params = value.get('ros__parameters', {})
+                    if node_ros_params:
+                        result.update(node_ros_params)
+
+    for key, value in data.items():
+        if key != '/**' and isinstance(value, dict):
+            node_ros_params = value.get('ros__parameters', {})
+            if node_ros_params:
+                result.update(node_ros_params)
+
+    return result if result else {}
 
 
-def get_pipeline_plugins(config_file: str) -> list:
-    """Return the plugins named by the pipeline stages, in stage order and without repeats."""
-    with open(config_file, 'r', encoding='utf-8') as file:
-        params = yaml.safe_load(file)['/**']['ros__parameters']
+def get_default_config_file() -> str:
+    """Return the default configuration file path."""
+    return os.path.join(
+        get_package_share_directory(PACKAGE),
+        'config',
+        'config.yaml'
+    )
 
-    pipeline = params.get('pipeline', {})
+
+def extract_pipeline_plugins(ros_params: dict) -> list:
+    """Extract pipeline plugin names from ROS parameters."""
+    pipeline = ros_params.get('pipeline', {})
+    stages = pipeline.get('stages', [])
     available_plugins = get_available_plugins(PACKAGE)
+
     plugins = []
-    for stage in pipeline.get('stages', []):
+    for stage in stages:
         plugin = pipeline.get(stage, {}).get('plugin')
-        if plugin is None:
+        if not plugin:
             raise RuntimeError(f"Pipeline stage '{stage}' does not declare a plugin.")
         if plugin not in available_plugins:
             raise RuntimeError(
                 f"Pipeline stage '{stage}' requests unknown plugin '{plugin}'. "
-                f'Available plugins: {available_plugins}')
+                f'Available: {available_plugins}')
         if plugin not in plugins:
             plugins.append(plugin)
 
     if not plugins:
-        raise RuntimeError(f'No pipeline stages declared in {config_file}.')
+        raise RuntimeError('No pipeline stages declared in configuration.')
     return plugins
 
 
 def get_node(context, *args, **kwargs) -> list:
-    """Build the behavior node, resolving the plugin configs from the pipeline stages."""
+    """Build the behavior node with plugin configurations."""
     package_folder = get_package_share_directory(PACKAGE)
-    config_file = get_config_file()
+    default_config = get_default_config_file()
 
-    # Merges the default config with the user one and with the launch arguments,
-    # and writes the result to a temporary file.
     merged_config_file = LaunchConfigurationFromConfigFile(
-        'config_file', default_file=config_file).perform(context)
+        'config_file',
+        default_file=default_config
+    ).perform(context)
 
-    # Each stage names its plugin, so the plugin default configs come from the
-    # pipeline itself. Plugin parameters live under a per-plugin namespace, so
-    # several of them can coexist, and the behavior config (loaded afterwards)
-    # can override any of them.
+    with open(merged_config_file, 'r', encoding='utf-8') as f:
+        config_data = yaml.safe_load(f) or {}
+
+    ros_params = _extract_ros_parameters(config_data)
+    plugins = extract_pipeline_plugins(ros_params)
+
     plugin_config_files = [
         os.path.join(package_folder, 'plugins', plugin, 'config', 'plugin_default_config.yaml')
-        for plugin in get_pipeline_plugins(merged_config_file)
+        for plugin in plugins
     ]
     parameters = [path for path in plugin_config_files if os.path.isfile(path)]
-    parameters += [
+
+    parameters.extend([
         {'use_sim_time': LaunchConfiguration('use_sim_time')},
         merged_config_file,
-    ]
+    ])
 
-    # In topic mode the camera driver is external: its params and its calibration
-    # reach the behavior through camera_info, so these files are not needed.
-    with open(merged_config_file, 'r', encoding='utf-8') as file:
-        use_embedded_camera = yaml.safe_load(
-            file)['/**']['ros__parameters'].get('use_embedded_camera', False)
-    if use_embedded_camera:
-        parameters += [
+    if ros_params.get('use_embedded_camera', False):
+        parameters.extend([
             LaunchConfiguration('camera_interface_file'),
             LaunchConfiguration('calibration_file'),
-        ]
+        ])
 
     return [Node(
         package=PACKAGE,
@@ -118,8 +146,7 @@ def get_node(context, *args, **kwargs) -> list:
         namespace=LaunchConfiguration('namespace'),
         parameters=parameters,
         output='screen',
-        arguments=['--ros-args', '--log-level',
-                   LaunchConfiguration('log_level')],
+        arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
         emulate_tty=True,
     )]
 
@@ -127,6 +154,7 @@ def get_node(context, *args, **kwargs) -> list:
 def generate_launch_description() -> LaunchDescription:
     """Entrypoint."""
     package_folder = get_package_share_directory(PACKAGE)
+    default_config = get_default_config_file()
 
     return LaunchDescription([
         DeclareLaunchArgument('log_level',
@@ -140,15 +168,16 @@ def generate_launch_description() -> LaunchDescription:
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID')),
         DeclareLaunchArgument('camera_interface_file',
-                              description='Embedded camera driver params',
+                              description='Embedded camera driver configuration',
                               default_value=os.path.join(
                                   package_folder, 'config', 'camera_interface.yaml')),
         DeclareLaunchArgument('calibration_file',
-                              description='Camera calibration (camera_info) file',
+                              description='Camera calibration parameters',
                               default_value=os.path.join(
                                   package_folder, 'config', 'camera_calibration.yaml')),
         DeclareLaunchArgumentsFromConfigFile(
-            name='config_file', source_file=get_config_file(),
+            name='config_file',
+            source_file=default_config,
             description='Behavior configuration file'),
         OpaqueFunction(function=get_node),
     ])

--- a/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
@@ -35,46 +35,86 @@ __license__ = 'BSD-3-Clause'
 import os
 
 from ament_index_python.packages import get_package_share_directory
+from as2_core.declare_launch_arguments_from_config_file import DeclareLaunchArgumentsFromConfigFile
+from as2_core.launch_configuration_from_config_file import LaunchConfigurationFromConfigFile
+from as2_core.launch_plugin_utils import get_available_plugins
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
-from launch.conditions import IfCondition
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
 from launch_ros.actions import Node
+import yaml
+
+
+PACKAGE = 'as2_behaviors_object_perception'
+
+
+def get_config_file() -> str:
+    """Return the default behavior configuration file."""
+    return os.path.join(get_package_share_directory(PACKAGE), 'config', 'config.yaml')
+
+
+def get_pipeline_plugins(config_file: str) -> list:
+    """Return the plugins named by the pipeline stages, in stage order and without repeats."""
+    with open(config_file, 'r', encoding='utf-8') as file:
+        params = yaml.safe_load(file)['/**']['ros__parameters']
+
+    pipeline = params.get('pipeline', {})
+    available_plugins = get_available_plugins(PACKAGE)
+    plugins = []
+    for stage in pipeline.get('stages', []):
+        plugin = pipeline.get(stage, {}).get('plugin')
+        if plugin is None:
+            raise RuntimeError(f"Pipeline stage '{stage}' does not declare a plugin.")
+        if plugin not in available_plugins:
+            raise RuntimeError(
+                f"Pipeline stage '{stage}' requests unknown plugin '{plugin}'. "
+                f'Available plugins: {available_plugins}')
+        if plugin not in plugins:
+            plugins.append(plugin)
+
+    if not plugins:
+        raise RuntimeError(f'No pipeline stages declared in {config_file}.')
+    return plugins
 
 
 def get_node(context, *args, **kwargs) -> list:
-    """Build the behavior node, adding the camera driver files only in embedded mode."""
-    package_folder = get_package_share_directory(
-        'as2_behaviors_object_perception')
+    """Build the behavior node, resolving the plugin configs from the pipeline stages."""
+    package_folder = get_package_share_directory(PACKAGE)
+    config_file = get_config_file()
 
-    # Falls back to the plugin's own default config, installed by CMake under
-    # share/<pkg>/plugins/<plugin_name>/config/.
-    plugin_config_file = LaunchConfiguration(
-        'plugin_config_file').perform(context)
-    if not plugin_config_file:
-        plugin_name = LaunchConfiguration('plugin_name').perform(context)
-        plugin_config_file = os.path.join(
-            package_folder, 'plugins', plugin_name, 'config',
-            'plugin_default_config.yaml')
+    # Merges the default config with the user one and with the launch arguments,
+    # and writes the result to a temporary file.
+    merged_config_file = LaunchConfigurationFromConfigFile(
+        'config_file', default_file=config_file).perform(context)
 
-    parameters = [
+    # Each stage names its plugin, so the plugin default configs come from the
+    # pipeline itself. Plugin parameters live under a per-plugin namespace, so
+    # several of them can coexist, and the behavior config (loaded afterwards)
+    # can override any of them.
+    plugin_config_files = [
+        os.path.join(package_folder, 'plugins', plugin, 'config', 'plugin_default_config.yaml')
+        for plugin in get_pipeline_plugins(merged_config_file)
+    ]
+    parameters = [path for path in plugin_config_files if os.path.isfile(path)]
+    parameters += [
         {'use_sim_time': LaunchConfiguration('use_sim_time')},
-        {'use_embedded_camera': LaunchConfiguration('use_embedded_camera')},
-        LaunchConfiguration('config_file'),
-        plugin_config_file,
+        merged_config_file,
     ]
 
     # In topic mode the camera driver is external: its params and its calibration
     # reach the behavior through camera_info, so these files are not needed.
-    if IfCondition(LaunchConfiguration('use_embedded_camera')).evaluate(context):
+    with open(merged_config_file, 'r', encoding='utf-8') as file:
+        use_embedded_camera = yaml.safe_load(
+            file)['/**']['ros__parameters'].get('use_embedded_camera', False)
+    if use_embedded_camera:
         parameters += [
             LaunchConfiguration('camera_interface_file'),
             LaunchConfiguration('calibration_file'),
         ]
 
     return [Node(
-        package='as2_behaviors_object_perception',
-        executable='as2_behaviors_object_perception_node',
+        package=PACKAGE,
+        executable=f'{PACKAGE}_node',
         namespace=LaunchConfiguration('namespace'),
         parameters=parameters,
         output='screen',
@@ -86,8 +126,7 @@ def get_node(context, *args, **kwargs) -> list:
 
 def generate_launch_description() -> LaunchDescription:
     """Entrypoint."""
-    package_folder = get_package_share_directory(
-        'as2_behaviors_object_perception')
+    package_folder = get_package_share_directory(PACKAGE)
 
     return LaunchDescription([
         DeclareLaunchArgument('log_level',
@@ -100,39 +139,16 @@ def generate_launch_description() -> LaunchDescription:
                               description='Drone namespace',
                               default_value=EnvironmentVariable(
                                   'AEROSTACK2_SIMULATION_DRONE_ID')),
-        DeclareLaunchArgument('config_file',
-                              description='Behavior configuration file',
-                              default_value=os.path.join(package_folder,
-                                                         'config/config.yaml')),
-        DeclareLaunchArgument('plugin_name',
-                              description='Detection plugin to load',
-                              default_value='aruco'),
-        DeclareLaunchArgument('plugin_config_file',
-                              description='Detection plugin configuration file. '
-                                          'If empty, the default one is used',
-                              default_value=''),
-        DeclareLaunchArgument('use_embedded_camera',
-                              description='Open the camera device from the behavior itself. '
-                                          'If false, images come from a topic',
-                              default_value='false'),
         DeclareLaunchArgument('camera_interface_file',
                               description='Embedded camera driver params',
                               default_value=os.path.join(
-                                  package_folder, 'config/camera_interface.yaml')),
+                                  package_folder, 'config', 'camera_interface.yaml')),
         DeclareLaunchArgument('calibration_file',
                               description='Camera calibration (camera_info) file',
                               default_value=os.path.join(
-                                  package_folder, 'config/camera_calibration.yaml')),
+                                  package_folder, 'config', 'camera_calibration.yaml')),
+        DeclareLaunchArgumentsFromConfigFile(
+            name='config_file', source_file=get_config_file(),
+            description='Behavior configuration file'),
         OpaqueFunction(function=get_node),
-
-        ExecuteProcess(
-            cmd=['bash', '-c', [
-                'sleep 5 && ros2 action send_goal /',
-                LaunchConfiguration('namespace'),
-                '/ObjectPerceptionBehavior as2_msgs/action/DetectObjects ',
-                '"{threshold: 0.0, target_classes: []}"',
-            ]],
-            output='screen',
-            shell=False
-        )
     ])

--- a/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
@@ -36,28 +36,56 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition, UnlessCondition
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.conditions import IfCondition
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
 from launch_ros.actions import Node
+
+
+def get_node(context, *args, **kwargs) -> list:
+    """Build the behavior node, adding the camera driver files only in embedded mode."""
+    package_folder = get_package_share_directory(
+        'as2_behaviors_object_perception')
+
+    # Falls back to the plugin's own default config, installed by CMake under
+    # share/<pkg>/plugins/<plugin_name>/config/.
+    plugin_config_file = LaunchConfiguration('plugin_config_file').perform(context)
+    if not plugin_config_file:
+        plugin_name = LaunchConfiguration('plugin_name').perform(context)
+        plugin_config_file = os.path.join(
+            package_folder, 'plugins', plugin_name, 'config',
+            'plugin_default_config.yaml')
+
+    parameters = [
+        {'use_sim_time': LaunchConfiguration('use_sim_time')},
+        {'use_embedded_camera': LaunchConfiguration('use_embedded_camera')},
+        LaunchConfiguration('config_file'),
+        plugin_config_file,
+    ]
+
+    # In topic mode the camera driver is external: its params and its calibration
+    # reach the behavior through camera_info, so these files are not needed.
+    if IfCondition(LaunchConfiguration('use_embedded_camera')).evaluate(context):
+        parameters += [
+            LaunchConfiguration('camera_interface_file'),
+            LaunchConfiguration('calibration_file'),
+        ]
+
+    return [Node(
+        package='as2_behaviors_object_perception',
+        executable='as2_behaviors_object_perception_node',
+        namespace=LaunchConfiguration('namespace'),
+        parameters=parameters,
+        output='screen',
+        arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+        emulate_tty=True,
+    )]
 
 
 def generate_launch_description() -> LaunchDescription:
     """Entrypoint."""
     package_folder = get_package_share_directory(
         'as2_behaviors_object_perception')
-    behavior_config_file = os.path.join(package_folder,
-                                        'config/config.yaml')
-
-    common_node_args = {
-        'package': 'as2_behaviors_object_perception',
-        'executable': 'as2_behaviors_object_perception_node',
-        'namespace': LaunchConfiguration('namespace'),
-        'output': 'screen',
-        'arguments': ['--ros-args', '--log-level',
-                      LaunchConfiguration('log_level')],
-        'emulate_tty': True,
-    }
 
     return LaunchDescription([
         DeclareLaunchArgument('log_level',
@@ -72,41 +100,26 @@ def generate_launch_description() -> LaunchDescription:
                                   'AEROSTACK2_SIMULATION_DRONE_ID')),
         DeclareLaunchArgument('config_file',
                               description='Behavior configuration file',
-                              default_value=behavior_config_file),
+                              default_value=os.path.join(package_folder,
+                                                         'config/config.yaml')),
         DeclareLaunchArgument('plugin_name',
-                              description='Detection plugin configuration file'),
+                              description='Detection plugin to load',
+                              default_value='aruco'),
+        DeclareLaunchArgument('plugin_config_file',
+                              description='Detection plugin configuration file. '
+                                          'If empty, the default one is used',
+                              default_value=''),
         DeclareLaunchArgument('use_embedded_camera',
-                              description='Use the embedded camera driver. '
-                                          'If false, images come from a topic'),
+                              description='Open the camera device from the behavior itself. '
+                                          'If false, images come from a topic',
+                              default_value='false'),
         DeclareLaunchArgument('camera_interface_file',
                               description='Embedded camera driver params',
-                              condition=IfCondition(
-                                  LaunchConfiguration('use_embedded_camera'))),
+                              default_value=os.path.join(
+                                  package_folder, 'config/camera_interface.yaml')),
         DeclareLaunchArgument('calibration_file',
                               description='Camera calibration (camera_info) file',
-                              condition=IfCondition(
-                                  LaunchConfiguration('use_embedded_camera'))),
-        # Topic mode: camera_info comes via topic, no camera files needed.
-        Node(
-            condition=UnlessCondition(
-                LaunchConfiguration('use_embedded_camera')),
-            parameters=[
-                {'use_sim_time': LaunchConfiguration('use_sim_time')},
-                LaunchConfiguration('config_file'),
-                LaunchConfiguration('plugin_name'),
-            ],
-            **common_node_args,
-        ),
-        # Embedded mode: driver params + calibration file are required.
-        Node(
-            condition=IfCondition(LaunchConfiguration('use_embedded_camera')),
-            parameters=[
-                {'use_sim_time': LaunchConfiguration('use_sim_time')},
-                LaunchConfiguration('config_file'),
-                LaunchConfiguration('plugin_name'),
-                LaunchConfiguration('camera_interface_file'),
-                LaunchConfiguration('calibration_file'),
-            ],
-            **common_node_args,
-        ),
+                              default_value=os.path.join(
+                                  package_folder, 'config/camera_calibration.yaml')),
+        OpaqueFunction(function=get_node),
     ])

--- a/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
+++ b/as2_behaviors/as2_behaviors_object_perception/launch/detect_behavior_launch.py
@@ -36,7 +36,7 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
 from launch.conditions import IfCondition
 from launch.substitutions import EnvironmentVariable, LaunchConfiguration
 from launch_ros.actions import Node
@@ -49,7 +49,8 @@ def get_node(context, *args, **kwargs) -> list:
 
     # Falls back to the plugin's own default config, installed by CMake under
     # share/<pkg>/plugins/<plugin_name>/config/.
-    plugin_config_file = LaunchConfiguration('plugin_config_file').perform(context)
+    plugin_config_file = LaunchConfiguration(
+        'plugin_config_file').perform(context)
     if not plugin_config_file:
         plugin_name = LaunchConfiguration('plugin_name').perform(context)
         plugin_config_file = os.path.join(
@@ -77,7 +78,8 @@ def get_node(context, *args, **kwargs) -> list:
         namespace=LaunchConfiguration('namespace'),
         parameters=parameters,
         output='screen',
-        arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+        arguments=['--ros-args', '--log-level',
+                   LaunchConfiguration('log_level')],
         emulate_tty=True,
     )]
 
@@ -122,4 +124,15 @@ def generate_launch_description() -> LaunchDescription:
                               default_value=os.path.join(
                                   package_folder, 'config/camera_calibration.yaml')),
         OpaqueFunction(function=get_node),
+        # TESTING ONLY, remove before opening the PR: fires the goal on start.
+        ExecuteProcess(
+            cmd=['bash', '-c', [
+                'sleep 5 && ros2 action send_goal /',
+                LaunchConfiguration('namespace'),
+                '/ObjectPerceptionBehavior as2_msgs/action/DetectObjects ',
+                '"{threshold: 0.0, target_classes: []}"',
+            ]],
+            output='screen',
+            shell=False
+        )
     ])

--- a/as2_behaviors/as2_behaviors_object_perception/package.xml
+++ b/as2_behaviors/as2_behaviors_object_perception/package.xml
@@ -21,6 +21,7 @@
   <depend>as2_usb_camera_interface</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>cv_bridge</depend>
   <depend>visualization_msgs</depend>
   <depend>tf2</depend>
 

--- a/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/include/aruco/aruco.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/include/aruco/aruco.hpp
@@ -31,7 +31,7 @@
  *  \brief      ArUco marker detection + pose estimation plugin header.
  *
  *  Detects ArUco markers in the pre-processed (BGR) image provided by
- *  PerceptionBehavior and emits one ObjectPerception per marker, with the four
+ *  ObjectPerceptionBehavior and emits one ObjectPerception per marker, with the four
  *  corners as keypoints, an axis-aligned bounding box, and (when camera
  *  intrinsics are available) the marker pose in the camera frame.
  *
@@ -122,7 +122,7 @@ public:
 
   /**
    * @brief Stores the latest pre-processed frame for the next detection cycle.
-   * @param image   Pre-processed (BGR) image from PerceptionBehavior.
+   * @param image   Pre-processed (BGR) image from ObjectPerceptionBehavior.
    * @param header  Timestamp and frame of the image.
    */
   void image_callback(const cv::Mat & image, const std_msgs::msg::Header & header) override;

--- a/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/include/aruco/aruco.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/include/aruco/aruco.hpp
@@ -148,9 +148,17 @@ private:
 
   bool isTargetClass(int marker_id) const;
 
+  /**
+   * @brief Builds a human-readable description of the active id filter, meant
+   *        for the activation log: an empty target_classes means no filtering.
+   * @return Sentence describing which markers will be reported.
+   */
+  std::string describeTargetClasses() const;
+
   double marker_size_{0.1};
   bool estimate_pose_{true};
   bool enable_rectification_{false};
+  std::string tag_dict_name_;
 
 #if AS2_ARUCO_HAS_DETECTOR_CLASS
   cv::aruco::ArucoDetector detector_;

--- a/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/src/aruco.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/src/aruco.cpp
@@ -31,7 +31,7 @@
  *
  * ArUco marker detection + pose estimation plugin.
  *
- * Receives the pre-processed (BGR) frame from PerceptionBehavior and emits one
+ * Receives the pre-processed (BGR) frame from ObjectPerceptionBehavior and emits one
  * ObjectPerception per detected marker: the four corners are reported as
  * keypoints, an axis-aligned bounding box is computed from them, and — when the
  * camera intrinsics are known — the marker's 6-DoF pose in the camera frame is

--- a/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/src/aruco.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/src/aruco.cpp
@@ -93,6 +93,7 @@ void Plugin::ownInit()
 {
   const std::string dict_id =
     node_ptr_->declare_parameter<std::string>("aruco.tag_dict", "6x6_250");
+  tag_dict_name_ = dict_id;
   marker_size_ =
     node_ptr_->declare_parameter<double>("aruco.marker_size", 0.1);
   estimate_pose_ =
@@ -147,10 +148,30 @@ void Plugin::ownInit()
 }
 
 
+std::string Plugin::describeTargetClasses() const
+{
+  std::lock_guard<std::mutex> lock(target_classes_mutex_);
+  if (target_classes_.empty()) {
+    return "no id filter set, so every " + tag_dict_name_ + " marker found will be reported";
+  }
+
+  std::string ids;
+  for (const auto & target : target_classes_) {
+    if (!ids.empty()) {
+      ids += ", ";
+    }
+    ids += target;
+  }
+  return "reporting only marker ids [" + ids + "], any other " + tag_dict_name_ +
+         " marker will be ignored";
+}
+
 bool Plugin::own_activate(as2_msgs::action::DetectObjects::Goal & goal)
 {
   if (goal.threshold < 0.0f || goal.threshold > 1.0f) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Threshold must be in [0, 1]");
+    RCLCPP_ERROR(
+      node_ptr_->get_logger(),
+      "Cannot start: threshold is %.2f but must be between 0 and 1", goal.threshold);
     return false;
   }
 
@@ -165,23 +186,24 @@ bool Plugin::own_activate(as2_msgs::action::DetectObjects::Goal & goal)
   }
 
   RCLCPP_INFO(
-    node_ptr_->get_logger(),
-    "aruco activated. target markers: %s",
-    target_classes_.empty() ? "all" : std::to_string(target_classes_.size()).c_str());
+    node_ptr_->get_logger(), "aruco detection started: %s", describeTargetClasses().c_str());
   return true;
 }
 
 bool Plugin::own_modify(as2_msgs::action::DetectObjects::Goal & goal)
 {
   if (goal.threshold < 0.0f || goal.threshold > 1.0f) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Threshold must be in [0, 1]");
+    RCLCPP_ERROR(
+      node_ptr_->get_logger(),
+      "Cannot update: threshold is %.2f but must be between 0 and 1", goal.threshold);
     return false;
   }
   {
     std::lock_guard<std::mutex> lock(target_classes_mutex_);
     target_classes_ = goal.target_classes;
   }
-  RCLCPP_INFO(node_ptr_->get_logger(), "aruco modified");
+  RCLCPP_INFO(
+    node_ptr_->get_logger(), "aruco filter updated: %s", describeTargetClasses().c_str());
   return true;
 }
 

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
@@ -167,8 +167,8 @@ void ObjectPerceptionBehavior::loadPipeline()
     "pipeline.stages", std::vector<std::string>{});
 
   if (stage_names.empty()) {
-    loadSinglePluginPipeline();
-    return;
+    RCLCPP_FATAL(this->get_logger(), "Launch argument <pipeline.stages> is empty");
+    throw std::runtime_error("Perception pipeline has no stages");
   }
 
   pipeline_stages_.clear();
@@ -176,29 +176,6 @@ void ObjectPerceptionBehavior::loadPipeline()
   for (const auto & stage_name : stage_names) {
     pipeline_stages_.push_back(loadStage(stage_name));
   }
-}
-
-void ObjectPerceptionBehavior::loadSinglePluginPipeline()
-{
-  try {
-    plugin_name_ = this->declare_parameter<std::string>("plugin_name");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <plugin_name> not defined or malformed: %s", e.what());
-    throw;
-  }
-
-  PipelineStage stage;
-  stage.name = plugin_name_;
-  stage.plugin_name = plugin_name_;
-  stage.input_source = "image";
-
-  const std::string full_plugin_name = stage.plugin_name + "::Plugin";
-  stage.plugin = detection_loader_.createSharedInstance(full_plugin_name);
-  stage.plugin->initialize(this);
-  pipeline_stages_.push_back(stage);
-
-  RCLCPP_INFO(this->get_logger(), "Loaded perception plugin: %s", plugin_name_.c_str());
 }
 
 ObjectPerceptionBehavior::PipelineStage ObjectPerceptionBehavior::loadStage(

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
@@ -41,6 +41,8 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <sensor_msgs/image_encodings.hpp>
+#include "as2_core/custom/cv_bridge.hpp"
 #include "as2_behaviors_object_perception/common/common.hpp"
 
 namespace as2_behaviors_object_perception
@@ -120,10 +122,23 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
     camera_driver_ = std::make_unique<usb_camera_interface::UsbCameraInterface>(this);
     initializeCameraInfo();
   } else {
-    image_sub_ = this->create_subscription<sensor_msgs::msg::CompressedImage>(
-      camera_image_topic_,
-      as2_names::topics::sensor_measurements::qos,
-      std::bind(&ObjectPerceptionBehavior::image_callback, this, std::placeholders::_1));
+    // The transport is picked from the topic name, as image_transport does: a
+    // "/compressed" suffix means CompressedImage, anything else raw Image.
+    if (isCompressedTopic(camera_image_topic_)) {
+      image_sub_ = this->create_subscription<sensor_msgs::msg::CompressedImage>(
+        camera_image_topic_,
+        as2_names::topics::sensor_measurements::qos,
+        std::bind(&ObjectPerceptionBehavior::image_callback, this, std::placeholders::_1));
+    } else {
+      raw_image_sub_ = this->create_subscription<sensor_msgs::msg::Image>(
+        camera_image_topic_,
+        as2_names::topics::sensor_measurements::qos,
+        std::bind(&ObjectPerceptionBehavior::raw_image_callback, this, std::placeholders::_1));
+    }
+    RCLCPP_INFO(
+      this->get_logger(), "Subscribed to image topic '%s' (%s)",
+      camera_image_topic_.c_str(),
+      isCompressedTopic(camera_image_topic_) ? "CompressedImage" : "Image");
 
     if (!camera_info_topic_.empty()) {
       cam_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
@@ -490,6 +505,27 @@ void ObjectPerceptionBehavior::image_callback(
 {
   cv::Mat frame;
   if (!preprocessor_.preprocessCompressedImage(*image_msg, frame)) {
+    return;
+  }
+  handleImageFrame(frame, image_msg->header);
+}
+
+void ObjectPerceptionBehavior::raw_image_callback(
+  const sensor_msgs::msg::Image::SharedPtr image_msg)
+{
+  cv_bridge::CvImageConstPtr cv_image;
+  try {
+    cv_image = cv_bridge::toCvShare(image_msg, sensor_msgs::image_encodings::BGR8);
+  } catch (const cv_bridge::Exception & e) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Could not convert image from '%s' to BGR8: %s",
+      image_msg->encoding.c_str(), e.what());
+    return;
+  }
+
+  cv::Mat frame;
+  if (!preprocessor_.preprocessImage(cv_image->image, frame)) {
     return;
   }
   handleImageFrame(frame, image_msg->header);

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
@@ -116,6 +116,9 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
     // Latched: published once, late subscribers still get it.
     rectified_cam_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>(
       rectified_camera_info_topic_, rclcpp::QoS(1).transient_local());
+    RCLCPP_INFO(
+      this->get_logger(), "Publishing rectified camera info on '%s'",
+      rectified_camera_info_topic_.c_str());
   }
 
   loadPipeline();
@@ -147,6 +150,9 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
         camera_info_topic_,
         as2_names::topics::sensor_measurements::qos,
         std::bind(&ObjectPerceptionBehavior::camera_info_callback, this, std::placeholders::_1));
+      RCLCPP_INFO(
+        this->get_logger(), "Subscribed to camera info topic '%s'",
+        camera_info_topic_.c_str());
     } else {
       RCLCPP_WARN(
         this->get_logger(),
@@ -200,10 +206,17 @@ ObjectPerceptionBehavior::PipelineStage ObjectPerceptionBehavior::loadStage(
   stage.plugin = detection_loader_.createSharedInstance(full_plugin_name);
   stage.plugin->initialize(this);
 
+  RCLCPP_INFO(
+    this->get_logger(), "Loaded pipeline stage '%s' with plugin '%s'",
+    stage.name.c_str(), stage.plugin_name.c_str());
+
   if (stage.publish_output && !stage.output_topic.empty()) {
     stage.output_pub =
       this->create_publisher<as2_msgs::msg::ObjectPerceptionArray>(
       stage.output_topic, as2_names::topics::sensor_measurements::qos);
+    RCLCPP_INFO(
+      this->get_logger(), "Stage '%s' publishes detections on '%s'",
+      stage.name.c_str(), stage.output_topic.c_str());
   }
 
   // Debug: publishes the valid 3D poses as a PoseArray for visualization (e.g. RViz).
@@ -211,6 +224,9 @@ ObjectPerceptionBehavior::PipelineStage ObjectPerceptionBehavior::loadStage(
     stage.debug_poses_pub =
       this->create_publisher<geometry_msgs::msg::PoseArray>(
       stage.debug_poses_topic, as2_names::topics::sensor_measurements::qos);
+    RCLCPP_INFO(
+      this->get_logger(), "Stage '%s' publishes debug poses on '%s'",
+      stage.name.c_str(), stage.debug_poses_topic.c_str());
   }
 
   if (stage.input_source == "external") {
@@ -226,11 +242,11 @@ ObjectPerceptionBehavior::PipelineStage ObjectPerceptionBehavior::loadStage(
       [this, stage_name](const as2_msgs::msg::ObjectPerceptionArray::SharedPtr msg) {
         external_input_callback(stage_name, msg);
       });
+    RCLCPP_INFO(
+      this->get_logger(), "Stage '%s' takes its input from '%s'",
+      stage.name.c_str(), stage.input_topic.c_str());
   }
 
-  RCLCPP_INFO(
-    this->get_logger(), "Loaded pipeline stage '%s' with plugin '%s'",
-    stage.name.c_str(), stage.plugin_name.c_str());
   return stage;
 }
 
@@ -290,7 +306,7 @@ void ObjectPerceptionBehavior::handleImageFrame(
 
   if (!images_received_) {
     RCLCPP_INFO(
-      this->get_logger(), "Receiving images (%dx%d)", frame.cols, frame.rows);
+      this->get_logger(), "First image received (%dx%d)", frame.cols, frame.rows);
     images_received_ = true;
   }
 
@@ -367,6 +383,8 @@ bool ObjectPerceptionBehavior::on_activate(
         this->get_logger(), "Failed to activate pipeline stage '%s'", stage.name.c_str());
       return false;
     }
+    // "First" is relative to the goal: each new goal reports its first detection.
+    stage.logged_first_detection = false;
   }
   RCLCPP_INFO(
     this->get_logger(),
@@ -470,18 +488,15 @@ as2_behavior::ExecutionStatus ObjectPerceptionBehavior::on_run(
     has_previous_output = true;
     if (stage.plugin->hasNewDetections()) {
       publishStageOutput(stage);
-      std::string classes;
-      for (const auto & perception : previous_output.perceptions) {
-        if (!classes.empty()) {
-          classes += ", ";
-        }
-        classes += perception.hypothesis.hypothesis.class_id;
+      // Only the first one: enough to tell the stage works, and the topics were
+      // already logged at startup. A per-stage flag instead of RCLCPP_INFO_ONCE,
+      // which would fire for a single stage of the pipeline.
+      if (!stage.logged_first_detection) {
+        stage.logged_first_detection = true;
+        RCLCPP_INFO(
+          this->get_logger(), "Stage '%s' first detection: %zu object(s)",
+          stage.name.c_str(), previous_output.perceptions.size());
       }
-      RCLCPP_INFO_THROTTLE(
-        this->get_logger(), *this->get_clock(), 2000,
-        "Stage '%s' detected %zu object(s) [%s], published on '%s'",
-        stage.name.c_str(), previous_output.perceptions.size(), classes.c_str(),
-        stage.output_topic.empty() ? "(publishing disabled)" : stage.output_topic.c_str());
     }
 
     if (stage.last_status == as2_behavior::ExecutionStatus::FAILURE ||

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
@@ -104,16 +104,17 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
     this->declare_parameter<bool>("enable_rectification", false);
   preprocessor_.setRectificationEnabled(enable_rectification);
 
-  // Republish the camera info actually used by the pipeline (rectified K when
-  // rectification is on) on a latched topic, for downstream PnP/pose estimation.
+  // Rectification changes the effective intrinsics, so downstream PnP/pose
+  // estimation needs the new K. Only makes sense when rectifying, and it is
+  // opt-in: an empty topic (the default) disables it.
   const auto rectified_camera_info_topic_param =
-    this->declare_parameter<std::string>(
-    "rectified_camera_info_topic", "sensor_measurements/camera/rectified/camera_info");
-  if (!rectified_camera_info_topic_param.empty()) {
+    this->declare_parameter<std::string>("rectified_camera_info_topic", "");
+  if (enable_rectification && !rectified_camera_info_topic_param.empty()) {
     rectified_camera_info_topic_ = as2_behaviors_object_perception::getNamespacedTopic(
       ns, rectified_camera_info_topic_param);
+    // Latched: published once, late subscribers still get it.
     rectified_cam_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>(
-      rectified_camera_info_topic_, as2_names::topics::sensor_measurements::qos);
+      rectified_camera_info_topic_, rclcpp::QoS(1).transient_local());
   }
 
   loadPipeline();
@@ -152,7 +153,10 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
     }
   }
 
-  RCLCPP_DEBUG(this->get_logger(), "ObjectPerceptionBehavior ready.");
+  RCLCPP_INFO(
+    this->get_logger(),
+    "ObjectPerceptionBehavior ready, waiting for a DetectObjects goal. "
+    "The pipeline does not run until the behavior is activated.");
 }
 
 void ObjectPerceptionBehavior::loadPipeline()
@@ -306,23 +310,27 @@ void ObjectPerceptionBehavior::handleImageFrame(
     return;
   }
 
+  if (!images_received_) {
+    RCLCPP_INFO(
+      this->get_logger(), "Receiving images (%dx%d)", frame.cols, frame.rows);
+    images_received_ = true;
+  }
+
   // When the stream is rectified, the effective intrinsics change (a new K is
   // estimated, distortion is zeroed). Keypoints produced by the detector are in
   // rectified pixel coordinates, so downstream stages doing PnP need the
   // rectified K, not the raw camera_info. Forward it once it is available.
-  if (preprocessor_.rectificationReady()) {
+  if (preprocessor_.rectificationReady() && !rectified_info_propagated_) {
     const auto rectified_info = preprocessor_.getCameraInfo();
-    if (!rectified_info_propagated_) {
-      for (auto & stage : pipeline_stages_) {
-        stage.plugin->camera_info_callback(rectified_info);
-      }
-      rectified_info_propagated_ = true;
-      RCLCPP_INFO(this->get_logger(), "Propagated rectified camera info to pipeline stages");
+    for (auto & stage : pipeline_stages_) {
+      stage.plugin->camera_info_callback(rectified_info);
     }
-    // Republished every frame so late subscribers (external pose estimation) get it.
+    // The publisher is latched, so a single publish also reaches late subscribers.
     if (rectified_cam_info_pub_) {
       rectified_cam_info_pub_->publish(rectified_info);
     }
+    rectified_info_propagated_ = true;
+    RCLCPP_INFO(this->get_logger(), "Propagated rectified camera info to pipeline stages");
   }
 
   for (auto & stage : pipeline_stages_) {
@@ -433,6 +441,14 @@ as2_behavior::ExecutionStatus ObjectPerceptionBehavior::on_run(
     drainCameraQueue();
   }
 
+  if (!images_received_) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Behavior active but no image received yet%s%s",
+      use_embedded_camera ? " from the embedded camera" : " on topic ",
+      use_embedded_camera ? "" : camera_image_topic_.c_str());
+  }
+
   as2_msgs::msg::ObjectPerceptionArray previous_output;
   bool has_previous_output = false;
 
@@ -463,6 +479,10 @@ as2_behavior::ExecutionStatus ObjectPerceptionBehavior::on_run(
     has_previous_output = true;
     if (stage.plugin->hasNewDetections()) {
       publishStageOutput(stage);
+      RCLCPP_INFO_THROTTLE(
+        this->get_logger(), *this->get_clock(), 2000,
+        "Stage '%s': %zu detection(s)", stage.name.c_str(),
+        previous_output.perceptions.size());
     }
 
     if (stage.last_status == as2_behavior::ExecutionStatus::FAILURE ||
@@ -538,6 +558,9 @@ void ObjectPerceptionBehavior::camera_info_callback(
   for (auto & stage : pipeline_stages_) {
     stage.plugin->camera_info_callback(*cam_info_msg);
   }
+  // New calibration invalidates the rectification maps, so the rectified
+  // intrinsics have to be recomputed and propagated again.
+  rectified_info_propagated_ = false;
 }
 
 }  // namespace as2_behaviors_object_perception

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
@@ -46,9 +46,9 @@
 namespace as2_behaviors_object_perception
 {
 
-PerceptionBehavior::PerceptionBehavior(const rclcpp::NodeOptions & options)
+ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & options)
 : as2_behavior::BehaviorServer<as2_msgs::action::DetectObjects>(
-    "PerceptionBehavior", options),
+    "ObjectPerceptionBehavior", options),
   detection_loader_(
     "as2_behaviors_object_perception",
     "detection_plugin_base::DetectionBase"),
@@ -123,13 +123,13 @@ PerceptionBehavior::PerceptionBehavior(const rclcpp::NodeOptions & options)
     image_sub_ = this->create_subscription<sensor_msgs::msg::CompressedImage>(
       camera_image_topic_,
       as2_names::topics::sensor_measurements::qos,
-      std::bind(&PerceptionBehavior::image_callback, this, std::placeholders::_1));
+      std::bind(&ObjectPerceptionBehavior::image_callback, this, std::placeholders::_1));
 
     if (!camera_info_topic_.empty()) {
       cam_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
         camera_info_topic_,
         as2_names::topics::sensor_measurements::qos,
-        std::bind(&PerceptionBehavior::camera_info_callback, this, std::placeholders::_1));
+        std::bind(&ObjectPerceptionBehavior::camera_info_callback, this, std::placeholders::_1));
     } else {
       RCLCPP_WARN(
         this->get_logger(),
@@ -137,10 +137,10 @@ PerceptionBehavior::PerceptionBehavior(const rclcpp::NodeOptions & options)
     }
   }
 
-  RCLCPP_DEBUG(this->get_logger(), "PerceptionBehavior ready.");
+  RCLCPP_DEBUG(this->get_logger(), "ObjectPerceptionBehavior ready.");
 }
 
-void PerceptionBehavior::loadPipeline()
+void ObjectPerceptionBehavior::loadPipeline()
 {
   const auto stage_names =
     this->declare_parameter<std::vector<std::string>>(
@@ -158,7 +158,7 @@ void PerceptionBehavior::loadPipeline()
   }
 }
 
-void PerceptionBehavior::loadSinglePluginPipeline()
+void ObjectPerceptionBehavior::loadSinglePluginPipeline()
 {
   try {
     plugin_name_ = this->declare_parameter<std::string>("plugin_name");
@@ -181,7 +181,8 @@ void PerceptionBehavior::loadSinglePluginPipeline()
   RCLCPP_INFO(this->get_logger(), "Loaded perception plugin: %s", plugin_name_.c_str());
 }
 
-PerceptionBehavior::PipelineStage PerceptionBehavior::loadStage(const std::string & stage_name)
+ObjectPerceptionBehavior::PipelineStage ObjectPerceptionBehavior::loadStage(
+  const std::string & stage_name)
 {
   const std::string prefix = "pipeline." + stage_name + ".";
   PipelineStage stage;
@@ -236,7 +237,8 @@ PerceptionBehavior::PipelineStage PerceptionBehavior::loadStage(const std::strin
   return stage;
 }
 
-PerceptionBehavior::PipelineStage * PerceptionBehavior::findStage(const std::string & stage_name)
+ObjectPerceptionBehavior::PipelineStage * ObjectPerceptionBehavior::findStage(
+  const std::string & stage_name)
 {
   for (auto & stage : pipeline_stages_) {
     if (stage.name == stage_name) {
@@ -246,7 +248,7 @@ PerceptionBehavior::PipelineStage * PerceptionBehavior::findStage(const std::str
   return nullptr;
 }
 
-void PerceptionBehavior::publishStageOutput(const PipelineStage & stage)
+void ObjectPerceptionBehavior::publishStageOutput(const PipelineStage & stage)
 {
   const auto detections = stage.plugin->getDetections();
 
@@ -269,7 +271,7 @@ void PerceptionBehavior::publishStageOutput(const PipelineStage & stage)
   }
 }
 
-void PerceptionBehavior::external_input_callback(
+void ObjectPerceptionBehavior::external_input_callback(
   const std::string & stage_name,
   const as2_msgs::msg::ObjectPerceptionArray::SharedPtr msg)
 {
@@ -281,7 +283,7 @@ void PerceptionBehavior::external_input_callback(
   stage->has_external_input = true;
 }
 
-void PerceptionBehavior::handleImageFrame(
+void ObjectPerceptionBehavior::handleImageFrame(
   const cv::Mat & frame, const std_msgs::msg::Header & header)
 {
   if (pipeline_stages_.empty()) {
@@ -315,7 +317,7 @@ void PerceptionBehavior::handleImageFrame(
   }
 }
 
-void PerceptionBehavior::initializeCameraInfo()
+void ObjectPerceptionBehavior::initializeCameraInfo()
 {
   if (!camera_driver_ || camera_info_initialized_) {
     return;
@@ -329,7 +331,7 @@ void PerceptionBehavior::initializeCameraInfo()
   camera_info_initialized_ = true;
 }
 
-void PerceptionBehavior::drainCameraQueue()
+void ObjectPerceptionBehavior::drainCameraQueue()
 {
   if (!camera_driver_) {
     return;
@@ -355,7 +357,7 @@ void PerceptionBehavior::drainCameraQueue()
   }
 }
 
-bool PerceptionBehavior::on_activate(
+bool ObjectPerceptionBehavior::on_activate(
   std::shared_ptr<const as2_msgs::action::DetectObjects::Goal> goal)
 {
   for (auto & stage : pipeline_stages_) {
@@ -365,11 +367,11 @@ bool PerceptionBehavior::on_activate(
       return false;
     }
   }
-  RCLCPP_INFO(this->get_logger(), "PerceptionBehavior activated");
+  RCLCPP_INFO(this->get_logger(), "ObjectPerceptionBehavior activated");
   return true;
 }
 
-bool PerceptionBehavior::on_modify(
+bool ObjectPerceptionBehavior::on_modify(
   std::shared_ptr<const as2_msgs::action::DetectObjects::Goal> goal)
 {
   for (auto & stage : pipeline_stages_) {
@@ -380,7 +382,7 @@ bool PerceptionBehavior::on_modify(
   return true;
 }
 
-bool PerceptionBehavior::on_deactivate(const std::shared_ptr<std::string> & message)
+bool ObjectPerceptionBehavior::on_deactivate(const std::shared_ptr<std::string> & message)
 {
   bool success = true;
   for (auto & stage : pipeline_stages_) {
@@ -389,7 +391,7 @@ bool PerceptionBehavior::on_deactivate(const std::shared_ptr<std::string> & mess
   return success;
 }
 
-bool PerceptionBehavior::on_pause(const std::shared_ptr<std::string> & message)
+bool ObjectPerceptionBehavior::on_pause(const std::shared_ptr<std::string> & message)
 {
   bool success = true;
   for (auto & stage : pipeline_stages_) {
@@ -398,7 +400,7 @@ bool PerceptionBehavior::on_pause(const std::shared_ptr<std::string> & message)
   return success;
 }
 
-bool PerceptionBehavior::on_resume(const std::shared_ptr<std::string> & message)
+bool ObjectPerceptionBehavior::on_resume(const std::shared_ptr<std::string> & message)
 {
   bool success = true;
   for (auto & stage : pipeline_stages_) {
@@ -407,7 +409,7 @@ bool PerceptionBehavior::on_resume(const std::shared_ptr<std::string> & message)
   return success;
 }
 
-as2_behavior::ExecutionStatus PerceptionBehavior::on_run(
+as2_behavior::ExecutionStatus ObjectPerceptionBehavior::on_run(
   const std::shared_ptr<const as2_msgs::action::DetectObjects::Goal> & /*goal*/,
   std::shared_ptr<as2_msgs::action::DetectObjects::Feedback> & feedback_msg,
   std::shared_ptr<as2_msgs::action::DetectObjects::Result> & result_msg)
@@ -476,14 +478,14 @@ as2_behavior::ExecutionStatus PerceptionBehavior::on_run(
          as2_behavior::ExecutionStatus::SUCCESS;
 }
 
-void PerceptionBehavior::on_execution_end(const as2_behavior::ExecutionStatus & state)
+void ObjectPerceptionBehavior::on_execution_end(const as2_behavior::ExecutionStatus & state)
 {
   for (auto & stage : pipeline_stages_) {
     stage.plugin->on_execution_end(state);
   }
 }
 
-void PerceptionBehavior::image_callback(
+void ObjectPerceptionBehavior::image_callback(
   const sensor_msgs::msg::CompressedImage::SharedPtr image_msg)
 {
   cv::Mat frame;
@@ -493,7 +495,7 @@ void PerceptionBehavior::image_callback(
   handleImageFrame(frame, image_msg->header);
 }
 
-void PerceptionBehavior::camera_info_callback(
+void ObjectPerceptionBehavior::camera_info_callback(
   const sensor_msgs::msg::CameraInfo::SharedPtr cam_info_msg)
 {
   preprocessor_.updateCameraInfo(*cam_info_msg);

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
@@ -63,7 +63,8 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
     if (use_embedded_camera) {
       RCLCPP_INFO(
         this->get_logger(),
-        "camera_image_topic is empty, using embedded camera driver (as2_usb_camera_interface)");
+        "Images will be captured directly from the camera device by this node "
+        "(use_embedded_camera is true), not read from a topic");
     } else {
       const auto camera_image_topic_param =
         this->declare_parameter<std::string>("camera_image_topic");
@@ -390,7 +391,10 @@ bool ObjectPerceptionBehavior::on_activate(
       return false;
     }
   }
-  RCLCPP_INFO(this->get_logger(), "ObjectPerceptionBehavior activated");
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Detection started. Results are published on the output topic of each stage; "
+    "the action feedback carries the detections of the last stage");
   return true;
 }
 
@@ -442,11 +446,21 @@ as2_behavior::ExecutionStatus ObjectPerceptionBehavior::on_run(
   }
 
   if (!images_received_) {
-    RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 5000,
-      "Behavior active but no image received yet%s%s",
-      use_embedded_camera ? " from the embedded camera" : " on topic ",
-      use_embedded_camera ? "" : camera_image_topic_.c_str());
+    if (use_embedded_camera) {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000,
+        "Detection is active but the camera device has not delivered any image yet. "
+        "Check that the device in camera_interface_file exists and is not in use");
+    } else {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000,
+        "Detection is active but no image has arrived on '%s' yet. Check that the topic "
+        "is being published and that its type is %s",
+        camera_image_topic_.c_str(),
+        isCompressedTopic(camera_image_topic_) ?
+        "sensor_msgs/CompressedImage (the topic name ends in /compressed)" :
+        "sensor_msgs/Image (add a /compressed suffix to the topic name for CompressedImage)");
+    }
   }
 
   as2_msgs::msg::ObjectPerceptionArray previous_output;
@@ -479,10 +493,18 @@ as2_behavior::ExecutionStatus ObjectPerceptionBehavior::on_run(
     has_previous_output = true;
     if (stage.plugin->hasNewDetections()) {
       publishStageOutput(stage);
+      std::string classes;
+      for (const auto & perception : previous_output.perceptions) {
+        if (!classes.empty()) {
+          classes += ", ";
+        }
+        classes += perception.hypothesis.hypothesis.class_id;
+      }
       RCLCPP_INFO_THROTTLE(
         this->get_logger(), *this->get_clock(), 2000,
-        "Stage '%s': %zu detection(s)", stage.name.c_str(),
-        previous_output.perceptions.size());
+        "Stage '%s' detected %zu object(s) [%s], published on '%s'",
+        stage.name.c_str(), previous_output.perceptions.size(), classes.c_str(),
+        stage.output_topic.empty() ? "(publishing disabled)" : stage.output_topic.c_str());
     }
 
     if (stage.last_status == as2_behavior::ExecutionStatus::FAILURE ||

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception_node.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception_node.cpp
@@ -41,7 +41,7 @@
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  auto nodeptr = std::make_shared<as2_behaviors_object_perception::PerceptionBehavior>();
+  auto nodeptr = std::make_shared<as2_behaviors_object_perception::ObjectPerceptionBehavior>();
   RCLCPP_INFO(nodeptr->get_logger(), "Node created succesfully");
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(nodeptr);


### PR DESCRIPTION
Follow-up to #910, addressing the review comments that arrived after it was merged.

### Launcher and config
- The launcher had two `Node()` actions behind opposite conditions. Now it is a single node built in an `OpaqueFunction`, the pattern already used by `gripper_behavior_launch.py`: the embedded camera files are only appended to `parameters` when they are needed.
- `use_embedded_camera` defaults to `false`. The normal case is an external camera driver publishing on a topic, so it should not have to be set by hand. Every other argument has a default too, so the behavior launches with no arguments.
- `plugin_name` is now the plugin name (`aruco`), not a path. It used to be the path to the plugin YAML despite its name. The config file is derived from it, and `plugin_config_file` overrides it.
- `config.yaml` documents every parameter with `param: value # description`, as the other config files do.
- Dropped `use_embedded_camera` and `use_sim_time` from `config.yaml`. Both are launch arguments, and `use_sim_time` is one in every other behavior.

### Naming
- `PerceptionBehavior` is now `ObjectPerceptionBehavior`, matching the package. Since `BehaviorServer` uses the constructor string as both the node name and the action name, the action is now `/<ns>/ObjectPerceptionBehavior`, consistent with `TakeoffBehavior` and `GoToBehavior`.

### Image input
- The node only subscribed to `CompressedImage`, but the default topic is `sensor_measurements/camera/image_raw`, which is `sensor_msgs/Image` everywhere else in aerostack2 (the Gazebo bridge included). Nothing ever connected in that configuration.
- The transport is now chosen from the topic name, as `image_transport` does: a `/compressed` suffix means `CompressedImage`, anything else raw `Image`. Adds a `cv_bridge` dependency, included through `as2_core/custom/cv_bridge.hpp` so Humble and Jazzy both build.

### Rectified camera info
- The publisher was created unconditionally, because the parameter had a non-empty default, and republished on every frame. It is now created only when `enable_rectification` is on and the topic is set, is latched, and publishes once.
- A new `camera_info` resets `rectified_info_propagated_`. New calibration invalidates the rectification maps, so the rectified intrinsics have to be recomputed and propagated again.

### Logs
Aimed at someone who does not know how the behavior works:
- Says which topic and message type it subscribed to, and that it is waiting for a goal before the pipeline runs.
- On activation, states what will be reported rather than echoing the goal: an empty `target_classes` means no filter, so it says so instead of printing `all`. With a filter it lists the ids.
- Detections report what was found and where it is published.
- If no image arrives, the warning says what to check and which message type the topic must carry.
- Fixed a log claiming `camera_image_topic is empty` when selecting the embedded camera; that stopped being the condition when `use_embedded_camera` was introduced.

