### PR TITLE
Find packages in workspace, not in aerostack2 repository

### DIFF
--- a/as2_cli/bash_utils/as2_list.bash
+++ b/as2_cli/bash_utils/as2_list.bash
@@ -3,8 +3,18 @@
 export package_list=();
 export verbose=0;
 
+# Search the whole workspace src/ so packages living outside aerostack2 are
+# listed too. Falls back to aerostack2 alone if the layout is not a colcon ws.
+function packages_search_root(){
+    if [ -d "$AEROSTACK2_WORKSPACE/src" ]; then
+        echo "$AEROSTACK2_WORKSPACE/src"
+    else
+        echo "$AEROSTACK2_PATH"
+    fi
+}
+
 function list_packages(){
-    packages_with_xml=$(find $AEROSTACK2_PATH -name "package.xml"| sed -e 's/\/package.xml//g' | sort -u)
+    packages_with_xml=$(find $(packages_search_root) -name "package.xml"| sed -e 's/\/package.xml//g' | sort -u)
     for package in $packages_with_xml; do
         if [ -f $package/package.xml ]; then
                 if grep -q "ament" $package/package.xml; then


### PR DESCRIPTION
> Replaces #979, which GitHub marked as merged when its commits were pushed to `main` from a local merge. That push was reverted (`main` is back at `af9b2610`) and a merged PR cannot be reopened, so this is a fresh PR from the same head branch at the same commit. Original description below, unchanged.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | -|
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* `as2 list` now discovers packages across the whole colcon workspace (`$AEROSTACK2_WORKSPACE/src`) instead of only the `aerostack2` repository (`$AEROSTACK2_PATH`).
* As a consequence, `as2 cd <pkg>`, `as2 clean <pkg>` and the bash autocompletion for both work with any package in the workspace, not just AS2 ones — they all resolve names through `as2 list`.
* Added a `packages_search_root()` helper in `as2_cli/bash_utils/as2_list.bash` that falls back to `$AEROSTACK2_PATH` when `$AEROSTACK2_WORKSPACE/src` does not exist, so non-colcon layouts keep the previous behaviour.
* Search is scoped to `src/` on purpose: searching `$AEROSTACK2_WORKSPACE` directly would also match the `package.xml` copies under `build/` and `install/`.
