### PR TITLE
[CI] Work around behaviortree_cpp 4.9.1 multiarch install path

### DIFF
--- a/.github/workflows/build-humble.yaml
+++ b/.github/workflows/build-humble.yaml
@@ -16,7 +16,16 @@ jobs:
       image: osrf/ros:humble-desktop
     steps:
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions python3-empy
+        run: |
+          sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions python3-empy ros-humble-behaviortree-cpp
+          # Workaround for behaviortree_cpp 4.9.1: its deb installs the library under
+          # lib/<multiarch>/, where ament_export_libraries and the LD_LIBRARY_PATH
+          # environment hook cannot find it, so find_package(behaviortree_cpp) fails.
+          # Fixed upstream in 4.10.0, not yet released for humble.
+          # See https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1175
+          # No-op once the humble deb ships >= 4.10.0; delete it then.
+          sudo find /opt/ros/humble/lib -path '*-linux-gnu/libbehaviortree_cpp.so' \
+            -exec ln -sf {} /opt/ros/humble/lib/ \;
       - name: Setup ros
         uses: ros-tooling/setup-ros@v0.7
         with:

--- a/.github/workflows/codecov_test.yaml
+++ b/.github/workflows/codecov_test.yaml
@@ -16,7 +16,16 @@ jobs:
       fail-fast: false
     steps:
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions
+        run: |
+          sudo apt-get update && sudo apt-get install -y lcov python3-vcstool python3-colcon-lcov-result python3-colcon-coveragepy-result python3-rosdep python3-pip python3-colcon-common-extensions ros-humble-behaviortree-cpp
+          # Workaround for behaviortree_cpp 4.9.1: its deb installs the library under
+          # lib/<multiarch>/, where ament_export_libraries and the LD_LIBRARY_PATH
+          # environment hook cannot find it, so find_package(behaviortree_cpp) fails.
+          # Fixed upstream in 4.10.0, not yet released for humble.
+          # See https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1175
+          # No-op once the humble deb ships >= 4.10.0; delete it then.
+          sudo find /opt/ros/humble/lib -path '*-linux-gnu/libbehaviortree_cpp.so' \
+            -exec ln -sf {} /opt/ros/humble/lib/ \;
       # - name: Setup ros
       #   uses: ros-tooling/setup-ros@v0.3
       #   with:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

`main` has been red since 2026-08-07 for a reason that is not in this repository: the
`ros-humble-behaviortree-cpp` Debian package regressed. This PR is a temporary workaround
in CI, with its removal condition written next to it.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - (upstream: [BehaviorTree.CPP#1175](https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1175)) |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - (CI only, no runtime code touched) |

---

## What happened

`ros-humble-behaviortree-cpp` 4.9.1 installs its shared library in a multiarch
subdirectory, while the same package still advertises it through the legacy ament
mechanism, which only ever looks in `<prefix>/lib`:

```
4.9.0:  /opt/ros/humble/lib/libbehaviortree_cpp.so
4.9.1:  /opt/ros/humble/lib/x86_64-linux-gnu/libbehaviortree_cpp.so
```

```cmake
# /opt/ros/humble/share/behaviortree_cpp/cmake/ament_cmake_export_libraries-extras.cmake
set(_exported_libraries "behaviortree_cpp")          # bare name, no path
find_library(_lib NAMES "${_library}"
  PATHS "${behaviortree_cpp_DIR}/../../../lib"       # /opt/ros/humble/lib only
  NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
if(NOT _lib)
  message(FATAL_ERROR "Package 'behaviortree_cpp' exports the library 'behaviortree_cpp' which couldn't be found")
```

So `find_package(behaviortree_cpp REQUIRED)` in `as2_behavior_tree/CMakeLists.txt:33`
aborts during configuration. `as2_behavior_tree` fails and `as2_behavior`,
`as2_alphanumeric_viewer` and `as2_gazebo_assets` are aborted with it, leaving 20 packages
unprocessed.

The package contradicts itself: `behaviortree_cppTargetsExport-none.cmake` does declare the
correct multiarch path. Only the two legacy ament paths are stale — the
`ament_export_libraries` lookup above and `environment/library_path.dsv`, which prepends
just `<prefix>/lib` to `LD_LIBRARY_PATH`. That second one means the library would not be
found at runtime either, not only at build time.

Root cause upstream is [#1152](https://github.com/BehaviorTree/BehaviorTree.CPP/pull/1152),
which replaced `set(BTCPP_LIB_DESTINATION lib)` with `GNUInstallDirs`; on Debian-family
systems `CMAKE_INSTALL_LIBDIR` resolves to `lib/<multiarch-triplet>`.

## Why it surfaced now

Nothing in `main` changed. Commit `af9b2610` passed on 2026-07-28 and fails today,
unmodified. What changed is the apt index:

| Date | Event |
| --- | --- |
| 2026-07-06 | 4.9.1 tagged, regression included |
| 2026-07-22 | Fixed upstream in [#1176](https://github.com/BehaviorTree/BehaviorTree.CPP/pull/1176) |
| 2026-07-24 03:11 | Build farm builds the humble deb **from 4.9.1**, without the fix |
| 2026-07-24 06:56 | 4.10.0 tagged, with the fix — four hours too late |
| **2026-08-07 19:55** | `packages.ros.org` index regenerated; 4.9.1 becomes installable |

The nightly `codecov_test` job shows the flip precisely, all three runs on the same commit
`af9b2610`: 2026-08-07 07:07 green (4.9.0), 2026-08-08 07:55 red (4.9.1), 2026-08-09 red.

---

## Description of contribution in a few bullet points

* `build-humble.yaml` (job `build`) and `codecov_test.yaml`: install
  `ros-humble-behaviortree-cpp` explicitly in the *Install deps* step and symlink the
  library into `/opt/ros/humble/lib`, where ament looks for it.
* The package has to be pre-installed there because `action-ros-ci` runs `rosdep` and
  `colcon build` in a single step, leaving no point in between to place the symlink.
  `rosdep` then finds it already installed and does nothing.
* `find ... -exec ln` rather than a plain `ln`: with no match it does nothing and exits 0,
  so the workaround disables itself when the fixed deb lands instead of turning CI red on
  its own. It also covers arm64 without a second path.
* One symlink covers both failure modes: `/opt/ros/humble/lib` is both where CMake looks at
  configure time and what the environment hook puts on `LD_LIBRARY_PATH` at runtime.
* Not touched: `build-platforms` (does not build `as2_behavior_tree`, currently green) and
  `build-jazzy.yaml` (jazzy still resolves 4.9.0).

## Description of documentation updates required from your changes

None. No runtime code, package or configuration is modified.

Worth knowing for users, though: anyone running `apt upgrade` on Humble right now gets the
same broken package and cannot build `as2_behavior_tree` locally. This PR only fixes CI.
The same one-line symlink works as a local workaround.

---

## Future work that may be required in bullet points

* **Delete this workaround** once the humble deb ships >= 4.10.0. Both blocks carry that
  condition in a comment.
* **The real fix is a release, not a patch.** 4.10.0 already contains it, but `rosdistro`
  still declares 4.9.1 for humble and no 4.10.0 release tag exists in the release
  repository for any distro. Someone has to ask upstream to bloom-release it.
* **Jazzy will break too.** `rosdistro` already declares 4.9.1 for jazzy; the deb has not
  been built and synced yet. When it is, the same change is needed in `build-jazzy.yaml`,
  substituting `humble` for `jazzy`.
* Both jobs resolve dependencies fresh from `packages.ros.org` on every run, so `main` can
  go red without a single commit, as happened here. A pinned container or a lockfile would
  make builds reproducible.
