### PR TITLE
[CI] Work around behaviortree_cpp 4.9.1 multiarch install path in Docker images

### DIFF
--- a/docker/humble/Dockerfile
+++ b/docker/humble/Dockerfile
@@ -43,6 +43,15 @@ RUN rosdep update
 RUN rosdep fix-permissions
 RUN rosdep install --from-paths src --ignore-src -r -y
 
+# Workaround for behaviortree_cpp 4.9.1: its deb installs the library under
+# lib/<multiarch>/, where ament_export_libraries and the LD_LIBRARY_PATH
+# environment hook cannot find it, so find_package(behaviortree_cpp) fails.
+# Fixed upstream in 4.10.0, not yet released for humble.
+# See https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1175
+# No-op once the humble deb ships >= 4.10.0; delete it then.
+RUN find /opt/ros/$ROS_DISTRO/lib -path '*-linux-gnu/libbehaviortree_cpp.so' \
+        -exec ln -sf {} /opt/ros/$ROS_DISTRO/lib/ \;
+
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc

--- a/docker/humble_vnc/dockerfile
+++ b/docker/humble_vnc/dockerfile
@@ -15,6 +15,15 @@ WORKDIR $HOME/ros2/aerostack2_ws
 RUN . /opt/ros/humble/setup.bash && rosdep update
 RUN . /opt/ros/humble/setup.bash && rosdep install -y -r -q --from-paths src --ignore-src --rosdistro humble
 
+# Workaround for behaviortree_cpp 4.9.1: its deb installs the library under
+# lib/<multiarch>/, where ament_export_libraries and the LD_LIBRARY_PATH
+# environment hook cannot find it, so find_package(behaviortree_cpp) fails.
+# Fixed upstream in 4.10.0, not yet released for humble.
+# See https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1175
+# No-op once the humble deb ships >= 4.10.0; delete it then.
+RUN sudo find /opt/ros/humble/lib -path '*-linux-gnu/libbehaviortree_cpp.so' \
+        -exec ln -sf {} /opt/ros/humble/lib/ \;
+
 RUN . /opt/ros/humble/setup.bash && colcon build --symlink-install --parallel-workers 6
 
 ENV AEROSTACK2_PATH=$HOME/ros2/aerostack2_ws/src/aerostack2


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

Follow-up to #982, which missed the Docker images. The `docker_release` workflow has been
failing on `main` with the same `behaviortree_cpp` error that #982 fixed for the build and
coverage jobs:
[run 31427253200](https://github.com/aerostack2/aerostack2/actions/runs/31427253200/job/93581779054).

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | follow-up to #982 (upstream: [BehaviorTree.CPP#1175](https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1175)) |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - (image build only, no runtime code touched) |

---

## What happened

`ros-humble-behaviortree-cpp` 4.9.1 installs its shared library under
`lib/x86_64-linux-gnu/`, while the same package still advertises it through
`ament_export_libraries`, whose lookup only searches `<prefix>/lib` with
`NO_DEFAULT_PATH`. `find_package(behaviortree_cpp REQUIRED)` therefore aborts with a
`FATAL_ERROR` and `as2_behavior_tree` never configures. Full analysis in #982.

#982 patched the two GitHub Actions jobs that build the workspace, but the Docker images
run their own `rosdep install` + `colcon build` inside the image, so they were left
broken:

```
#28 210.6 CMake Error at .../ament_cmake_export_libraries-extras.cmake:48 (message):
#28 210.6   Package 'behaviortree_cpp' exports the library 'behaviortree_cpp' which
#28 210.6   couldn't be found
#28 210.6 Failed   <<< as2_behavior_tree [1.29s, exited with code 1]
ERROR: failed to build: ... colcon build ... exit code: 1
```

---

## Description of contribution in a few bullet points

* `docker/humble/Dockerfile`: symlink the library where ament looks for it, between
  `rosdep install` and `colcon build`. This is the image built by both `docker_release` and
  `docker_nightly`.
* `docker/humble_vnc/dockerfile`: same, this image does its own `rosdep install` +
  `colcon build` from a different base and hits exactly the same failure. Not built in CI,
  but broken for anyone building it.
* `docker/humble_gzharmonic/dockerfile` needs no change: it is `FROM
  aerostack2/nightly-humble:latest`, so it inherits the symlink from the base image.
* `docker/galactic/Dockerfile` left alone: Galactic is EOL and does not use this package.
* Same `find ... -exec ln` form as #982: with no match it does nothing and exits 0, so the
  workaround disables itself when the fixed deb lands instead of breaking the build.

Verified inside `osrf/ros:humble-desktop` with the broken deb installed, running the exact
command added to the Dockerfile:

```
--- before the symlink ---
exit=1
  couldn't be found
--- after ---
exit=0
-- FOUND: /opt/ros/humble/lib/libament_index_cpp.so;/opt/ros/humble/lib/libbehaviortree_cpp.so
```

I also audited every remaining place that builds the workspace (`build-humble.yaml` both
jobs, `build-jazzy.yaml`, `codecov_test.yaml`, all four Dockerfiles) to make sure nothing
else is left. `build-platforms` does not build `as2_behavior_tree` and is green; jazzy still
resolves 4.9.0.

## Description of documentation updates required from your changes

None.

---

## Future work that may be required in bullet points

* **Delete this workaround** together with the one from #982 once the humble deb ships
  >= 4.10.0. All blocks carry that condition in a comment.
* The real fix is a bloom release of 4.10.0 for humble; `rosdistro` still declares 4.9.1.
* `rosdistro` also declares 4.9.1 for jazzy, so `build-jazzy.yaml` will need the same
  treatment when that deb is built and synced.
