### PR TITLE
[aerostack2] Add missing docstrings in header files

### DIFF
--- a/as2_aerial_platforms/as2_platform_gazebo/include/as2_platform_gazebo/as2_platform_gazebo.hpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/include/as2_platform_gazebo/as2_platform_gazebo.hpp
@@ -61,18 +61,69 @@ namespace gazebo_platform
 class GazeboPlatform : public as2::AerialPlatform
 {
 public:
+  /**
+   * @brief Construct the Gazebo platform, creating the bridge publishers.
+   *
+   * @param options Node options.
+   */
   explicit GazeboPlatform(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  /**
+   * @brief Destroy the Gazebo Platform object.
+   */
   ~GazeboPlatform() {}
 
 public:
+  /**
+   * @brief Create the sensor interfaces the platform publishes.
+   */
   void configureSensors() {}
+  /**
+   * @brief Send the current actuator commands to the vehicle.
+   *
+   * @return true if the command was sent.
+   */
   bool ownSendCommand() override;
+  /**
+   * @brief Arm or disarm the vehicle.
+   *
+   * @param state True to arm, false to disarm.
+   * @return true if the vehicle accepted the request.
+   */
   bool ownSetArmingState(bool state) override;
+  /**
+   * @brief Enter or leave offboard control.
+   *
+   * @param offboard True to take control, false to release it.
+   * @return true if the vehicle accepted the request.
+   */
   bool ownSetOffboardControl(bool offboard) override;
+  /**
+   * @brief Accept a control mode requested through the platform interface.
+   *
+   * @param msg Requested control mode.
+   * @return true if the platform accepts the mode.
+   */
   bool ownSetPlatformControlMode(const as2_msgs::msg::ControlMode & msg) override;
+  /**
+   * @brief Stop the motors immediately, without landing.
+   */
   void ownKillSwitch() override;
+  /**
+   * @brief Hold the vehicle in place with a zero setpoint.
+   */
   void ownStopPlatform() override;
+  /**
+   * @brief Take off with the platform own takeoff routine.
+   *
+   * @return true if the takeoff finished successfully.
+   */
   bool ownTakeoff() override;
+  /**
+   * @brief Land with the platform own landing routine.
+   *
+   * @return true if the landing finished successfully.
+   */
   bool ownLand() override;
 
   // Publishers
@@ -98,8 +149,24 @@ private:
   std::shared_ptr<as2::tf::TfHandler> tf_handler_;
 
 private:
+  /**
+   * @brief Send a zero twist to the simulator, so the vehicle stops moving.
+   */
   void resetCommandTwistMsg();
+  /**
+   * @brief Store the vehicle twist, used by the takeoff and land routines to
+   * track the current height and vertical speed.
+   *
+   * @param _twist_msg Received twist, in the platform body frame.
+   */
   void state_callback(const geometry_msgs::msg::TwistStamped::SharedPtr _twist_msg);
+  /**
+   * @brief Reset the platform to its initial state, for the simulation to be
+   * restarted without relaunching the stack.
+   *
+   * @param request Unused.
+   * @param response Always successful.
+   */
   void reset_callback(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
     std_srvs::srv::Trigger::Response::SharedPtr response);

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_interface.hpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_interface.hpp
@@ -61,9 +61,18 @@ class As2MultirotorSimulatorInterface
   using Kinematics = multirotor::state::internal::Kinematics<double>;
 
 public:
+  /**
+   * @brief Construct the simulator interface, reading the TF frame names and
+   * the use_odom_for_control flag from the node parameters.
+   *
+   * @param node_ptr Platform node the parameters are read from.
+   */
   explicit As2MultirotorSimulatorInterface(
     as2::Node * node_ptr);
 
+  /**
+   * @brief Destroy the As2 Multirotor Simulator Interface object.
+   */
   ~As2MultirotorSimulatorInterface() {}
 
 private:
@@ -142,12 +151,30 @@ public:
     geometry_msgs::msg::TwistStamped & ground_truth_twist,
     const builtin_interfaces::msg::Time & current_time);
 
+  /**
+   * @brief Convert a pose command to the frame the simulator is controlled in.
+   *
+   * @param pose_command Pose command, converted in place.
+   * @return true if the command is expressed in the frame of the simulator.
+   */
   bool processCommand(
     geometry_msgs::msg::PoseStamped & pose_command);
 
+  /**
+   * @brief Convert a twist command to the frame the simulator is controlled in.
+   *
+   * @param twist_command Twist command, converted in place.
+   * @return true if the command is expressed in the frame of the simulator.
+   */
   bool processCommand(
     geometry_msgs::msg::TwistStamped & twist_command);
 
+  /**
+   * @brief Convert a trajectory command to the frame the simulator is controlled in.
+   *
+   * @param trajectory_command Trajectory command, taken by value.
+   * @return true if the command is expressed in the frame of the simulator.
+   */
   bool processCommand(as2_msgs::msg::TrajectorySetpoints trajectory_command);
 };  // class As2MultirotorSimulatorInterface
 }  // namespace as2_platform_multirotor_simulator

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_platform_multirotor_simulator.hpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_platform_multirotor_simulator.hpp
@@ -86,20 +86,84 @@ class MultirotorSimulatorPlatform : public as2::AerialPlatform
   using Kinematics = multirotor::state::internal::Kinematics<double>;
 
 public:
+  /**
+   * @brief Construct the platform, set the simulator up and start its timers.
+   *
+   * @param options Node options.
+   */
   explicit MultirotorSimulatorPlatform(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  /**
+   * @brief Destroy the Multirotor Simulator Platform object.
+   */
   ~MultirotorSimulatorPlatform();
 
 public:
+  /**
+   * @brief Create the sensor interfaces the platform publishes.
+   */
   void configureSensors() override;
+
+  /**
+   * @brief Arm or disarm the simulated vehicle.
+   *
+   * @param state True to arm, false to disarm.
+   * @return true if the request was applied.
+   */
   bool ownSetArmingState(bool state) override;
+
+  /**
+   * @brief Enter or leave offboard control.
+   *
+   * @param offboard True to take control, false to release it.
+   * @return true if the request was applied.
+   */
   bool ownSetOffboardControl(bool offboard) override;
+
+  /**
+   * @brief Set the control mode of the simulator controller.
+   *
+   * @param msg Requested control mode.
+   * @return true if the simulator supports the mode.
+   */
   bool ownSetPlatformControlMode(const as2_msgs::msg::ControlMode & msg) override;
+
+  /**
+   * @brief Feed the current actuator commands to the simulator, as its reference.
+   *
+   * @return true if the reference was applied.
+   */
   bool ownSendCommand() override;
+
+  /**
+   * @brief Hold the vehicle in place with a zero reference.
+   */
   void ownStopPlatform() override;
+
+  /**
+   * @brief Stop the motors immediately, without landing.
+   */
   void ownKillSwitch() override;
+
+  /**
+   * @brief Take off with the platform own takeoff routine.
+   *
+   * @return true if the takeoff finished successfully.
+   */
   bool ownTakeoff() override;
+
+  /**
+   * @brief Land with the platform own landing routine.
+   *
+   * @return true if the landing finished successfully.
+   */
   bool ownLand() override;
 
+  /**
+   * @brief Store a gimbal reference, applied by the simulator on its next step.
+   *
+   * @param msg Gimbal control reference.
+   */
   void gimbalControlCallback(const as2_msgs::msg::GimbalControl::SharedPtr msg);
 
 private:

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/common/common.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/common/common.hpp
@@ -60,6 +60,13 @@
 namespace as2_behaviors_object_perception
 {
 
+/**
+ * @brief Prepend the node namespace to a topic name.
+ *
+ * @param node_namespace Namespace of the node.
+ * @param topic Topic name. Empty or private ("~...") names are left as they are.
+ * @return Namespaced topic name.
+ */
 inline std::string getNamespacedTopic(const std::string & node_namespace, const std::string & topic)
 {
   if (topic.empty() || topic.front() == '~') {
@@ -87,6 +94,13 @@ inline bool isCompressedTopic(const std::string & topic)
          topic.compare(topic.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
+/**
+ * @brief Format a scalar parameter value for logging.
+ *
+ * @tparam T Parameter type, anything streamable.
+ * @param value Value to format.
+ * @return Value as text.
+ */
 template<typename T>
 std::string paramToString(const T & value)
 {
@@ -96,6 +110,13 @@ std::string paramToString(const T & value)
 }
 
 // Specialization for std::vector
+/**
+ * @brief Format a vector parameter value for logging, as "[a, b, c]".
+ *
+ * @tparam T Element type, anything streamable.
+ * @param vec Vector to format.
+ * @return Vector as text.
+ */
 template<typename T>
 std::string paramToString(const std::vector<T> & vec)
 {
@@ -138,6 +159,11 @@ template<typename T>
 class MutexQueue
 {
 public:
+  /**
+   * @brief Construct the queue with a maximum size.
+   *
+   * @param max_size Maximum number of elements held.
+   */
   explicit MutexQueue(size_t max_size = 10)
   : max_size_(max_size) {}
 
@@ -155,6 +181,14 @@ public:
   }
 
   // Push with drop policy if full
+  /**
+   * @brief Push an element into the queue.
+   *
+   * @param item Element to push.
+   * @param drop_if_full When the queue is full, true drops the oldest element
+   *                     to make room, false rejects the new one.
+   * @return true if the element was stored.
+   */
   bool push(const T & item, bool drop_if_full = true)
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -170,6 +204,12 @@ public:
   }
 
   // Try to pop (non-blocking)
+  /**
+   * @brief Take the oldest element, without blocking.
+   *
+   * @param item Output. Element taken, untouched when the queue is empty.
+   * @return true if an element was taken.
+   */
   bool tryPop(T & item)
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -182,6 +222,11 @@ public:
   }
 
   // Get current size
+  /**
+   * @brief Get the number of elements currently held.
+   *
+   * @return Number of elements.
+   */
   size_t size() const
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -189,6 +234,11 @@ public:
   }
 
   // Check if empty
+  /**
+   * @brief Get whether the queue holds no elements.
+   *
+   * @return true if the queue is empty.
+   */
   bool empty() const
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -210,6 +260,15 @@ class TimerProcessor
 public:
   using ProcessFunction = std::function<OutputType(const InputType &)>;
 
+  /**
+   * @brief Construct the processor and start its timer.
+   *
+   * @param node_ptr Node owning the timer.
+   * @param param_base_name Prefix of the parameters that configure the stage.
+   * @param process_func Function applied to every input element.
+   * @param input_queue Queue the elements are taken from.
+   * @param output_queue Queue the results are pushed to.
+   */
   TimerProcessor(
     as2::Node * node_ptr,
     const std::string & param_base_name,
@@ -242,7 +301,17 @@ public:
       callback_group_);
   }
 
+  /**
+   * @brief Enable or disable the processing timer.
+   *
+   * @param enabled True to process, false to idle.
+   */
   void setEnabled(bool enabled) {enabled_ = enabled;}
+  /**
+   * @brief Get whether the processing timer is enabled.
+   *
+   * @return true if the stage is processing.
+   */
   bool isEnabled() const {return enabled_;}
 
 private:
@@ -254,6 +323,9 @@ private:
   rclcpp::CallbackGroup::SharedPtr callback_group_;
   std::atomic<bool> enabled_;
 
+  /**
+   * @brief Take one element from the input queue, process it and push the result.
+   */
   void timerCallback()
   {
     if (!enabled_.load() || !rclcpp::ok()) {

--- a/as2_core/include/as2_core/aerial_platform.hpp
+++ b/as2_core/include/as2_core/aerial_platform.hpp
@@ -78,6 +78,10 @@ namespace as2
 class AerialPlatform : public as2::Node
 {
 private:
+  /**
+   * @brief Declare the platform parameters, create the command interfaces and
+   * start the command and info timers. Called by both constructors.
+   */
   void initialize();
   bool sending_commands_ = false;
 
@@ -110,6 +114,9 @@ public:
   AerialPlatform(
     const std::string & ns, const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
+  /**
+   * @brief Destroy the Aerial Platform object.
+   */
   ~AerialPlatform() {}
 
   /**
@@ -246,6 +253,11 @@ protected:
   void resetPlatform();
 
 private:
+  /**
+   * @brief Load the control modes the platform supports from a yaml file.
+   *
+   * @param filename Path of the control modes yaml file.
+   */
   void loadControlModes(const std::string & filename);
 
   // Getters
@@ -263,6 +275,12 @@ public:
     return state_machine_.processEvent(event);
   }
 
+  /**
+   * @brief Set the State Machine Event object, by event id.
+   *
+   * @param event Event id to process.
+   * @return true if the event was accepted in the current state.
+   */
   bool handleStateMachineEvent(const int8_t & event) {return state_machine_.processEvent(event);}
 
   /**
@@ -309,6 +327,9 @@ public:
 protected:
   bool has_new_references_ = false;
 
+  /**
+   * @brief Zero the actuator command messages.
+   */
   void resetActuatorCommandMsgs();
 
   // ROS publishers & subscribers
@@ -332,6 +353,11 @@ private:
     platform_info_pub_->publish(platform_info_msg_);
   }
 
+  /**
+   * @brief Handle an alert event, killing or stopping the platform.
+   *
+   * @param msg Alert event message.
+   */
   void alertEventCallback(const as2_msgs::msg::AlertEvent::ConstSharedPtr msg);
 
   // ROS Services & srv callbacks

--- a/as2_core/include/as2_core/node.hpp
+++ b/as2_core/include/as2_core/node.hpp
@@ -75,6 +75,10 @@ namespace as2
 class Node : public AS2_NODE_FATHER_TYPE
 {
 private:
+  /**
+   * @brief Read the node frequency parameter and create the loop rate.
+   * Called by both constructors.
+   */
   void init()
   {
     if (!this->has_parameter("node_frequency")) {
@@ -107,6 +111,12 @@ public:
     init();
   }
 
+  /**
+   * @brief Construct a new Node object, in the default namespace.
+   *
+   * @param name Node name.
+   * @param options Node options.
+   */
   explicit Node(
     const std::string & name,
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
@@ -117,6 +127,19 @@ public:
   }
 
 #if AS2_NODE_FATHER == AS2_LIFECYLCE_NODE
+  /**
+   * @brief Create a lifecycle publisher, already activated.
+   *
+   * The lifecycle node only publishes while it is active, and most aerostack2
+   * nodes publish from construction, so the publisher is activated here.
+   *
+   * @tparam MessageT Message type.
+   * @tparam AllocatorT Allocator type.
+   * @param topic_name Topic to publish on.
+   * @param qos Quality of service of the publisher.
+   * @param options Publisher options.
+   * @return Activated lifecycle publisher.
+   */
   template<typename MessageT, typename AllocatorT = std::allocator<void>>
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<MessageT, AllocatorT>> create_publisher(
     const std::string & topic_name, const rclcpp::QoS & qos,
@@ -134,11 +157,29 @@ public:
 #elif AS2_NODE_FATHER == AS2_RCLCPP_NODE
 
 public:
+  /**
+   * @brief Trigger the configure transition from code, without a lifecycle client.
+   */
   void configure() {this->on_configure(rclcpp_lifecycle::State());}
+  /**
+   * @brief Trigger the activate transition from code, without a lifecycle client.
+   */
   void activate() {this->on_activate(rclcpp_lifecycle::State());}
+  /**
+   * @brief Trigger the deactivate transition from code, without a lifecycle client.
+   */
   void deactivate() {this->on_deactivate(rclcpp_lifecycle::State());}
+  /**
+   * @brief Trigger the cleanup transition from code, without a lifecycle client.
+   */
   void cleanup() {this->on_cleanup(rclcpp_lifecycle::State());}
+  /**
+   * @brief Trigger the shutdown transition from code, without a lifecycle client.
+   */
   void shutdown() {this->on_shutdown(rclcpp_lifecycle::State());}
+  /**
+   * @brief Trigger the error transition from code, without a lifecycle client.
+   */
   void error() {this->on_error(rclcpp_lifecycle::State());}
 #endif
 
@@ -167,6 +208,12 @@ protected:
    */
 
   using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+  /**
+   * @brief Callback for the activate state.
+   *
+   * @return CallbackReturn::SUCCESS
+   */
   virtual CallbackReturn on_activate(const rclcpp_lifecycle::State & = rclcpp_lifecycle::State())
   {
     RCLCPP_DEBUG(this->get_logger(), "node [%s] on_activate", this->get_name());
@@ -272,6 +319,15 @@ public:
    */
   inline double get_loop_frequency() {return loop_frequency_;}
 
+  /**
+   * @brief Propose a loop frequency from code, as a default.
+   *
+   * The node_frequency parameter wins: a frequency set from the launch is kept
+   * and this call is rejected.
+   *
+   * @param frequency Proposed frequency, in Hz. Values <= 0 are ignored.
+   * @return true if the proposed frequency was taken.
+   */
   bool preset_loop_frequency(double frequency)
   {
     if (frequency <= 0) {

--- a/as2_core/include/as2_core/utils/control_mode_utils.hpp
+++ b/as2_core/include/as2_core/utils/control_mode_utils.hpp
@@ -89,28 +89,84 @@ namespace control_mode
 #define UNSET_MODE_MASK 0b00000000
 #define HOVER_MODE_MASK 0b00010000
 
+/**
+ * @brief Encode a control mode into its uint8_t representation.
+ *
+ * @param mode Control mode to encode.
+ * @return Encoded control mode.
+ */
 uint8_t convertAS2ControlModeToUint8t(const as2_msgs::msg::ControlMode & mode);
+
+/**
+ * @brief Decode a control mode from its uint8_t representation.
+ *
+ * @param control_mode_uint8t Encoded control mode.
+ * @return Decoded control mode.
+ */
 as2_msgs::msg::ControlMode convertUint8tToAS2ControlMode(uint8_t control_mode_uint8t);
 
+/**
+ * @brief Get a human readable name of an encoded control mode.
+ *
+ * @param control_mode_uint8t Encoded control mode.
+ * @return Control mode, yaw mode and reference frame, as text.
+ */
 std::string controlModeToString(const uint8_t control_mode_uint8t);
+
+/**
+ * @brief Get a human readable name of a control mode.
+ *
+ * @param mode Control mode.
+ * @return Control mode, yaw mode and reference frame, as text.
+ */
 std::string controlModeToString(const as2_msgs::msg::ControlMode & mode);
 
+/**
+ * @brief Pack a control mode into a uint8_t, without validating its fields.
+ *
+ * @param mode Control mode to pack.
+ * @return Packed control mode.
+ */
 constexpr uint8_t convertToUint8t(const as2_msgs::msg::ControlMode & mode)
 {
   return (mode.control_mode << 4) | (mode.yaw_mode << 2) | mode.reference_frame;
 }
 
+/**
+ * @brief Pack the fields of a control mode into a uint8_t.
+ *
+ * @param control_mode_uint8t Control mode field.
+ * @param yaw_mode_uint8t Yaw mode field.
+ * @param reference_frame_uint8t Reference frame field.
+ * @return Packed control mode.
+ */
 constexpr uint8_t convertToUint8t(
   uint8_t control_mode_uint8t, uint8_t yaw_mode_uint8t, uint8_t reference_frame_uint8t)
 {
   return (control_mode_uint8t << 4) | (yaw_mode_uint8t << 2) | reference_frame_uint8t;
 }
 
+/**
+ * @brief Compare two encoded control modes, under a mask.
+ *
+ * @param mode1 First encoded control mode.
+ * @param mode2 Second encoded control mode.
+ * @param mask Bits taken into account. Defaults to every bit.
+ * @return true if both modes are equal in the masked bits.
+ */
 inline bool compareModes(const uint8_t mode1, const uint8_t mode2, const uint8_t mask = MATCH_ALL)
 {
   return (mode1 & mask) == (mode2 & mask);
 }
 
+/**
+ * @brief Compare two control modes, under a mask.
+ *
+ * @param mode1 First control mode.
+ * @param mode2 Second control mode.
+ * @param mask Bits taken into account. Defaults to every bit.
+ * @return true if both modes are equal in the masked bits.
+ */
 inline bool compareModes(
   const as2_msgs::msg::ControlMode & mode1, const as2_msgs::msg::ControlMode & mode2,
   const uint8_t mask = MATCH_ALL)
@@ -119,27 +175,62 @@ inline bool compareModes(
     convertAS2ControlModeToUint8t(mode1), convertAS2ControlModeToUint8t(mode2), mask);
 }
 
+/**
+ * @brief Get whether an encoded control mode is UNSET.
+ *
+ * @param control_mode_uint8t Encoded control mode.
+ * @return true if the control mode is UNSET, whatever its other fields are.
+ */
 inline bool isUnsetMode(const uint8_t control_mode_uint8t)
 {
   return compareModes(control_mode_uint8t, UNSET_MODE_MASK, MATCH_CONTROL_MODE);
 }
 
+/**
+ * @brief Get whether a control mode is UNSET.
+ *
+ * @param mode Control mode.
+ * @return true if the control mode is UNSET, whatever its other fields are.
+ */
 inline bool isUnsetMode(const as2_msgs::msg::ControlMode & mode)
 {
   return mode.control_mode == as2_msgs::msg::ControlMode::UNSET;
 }
 
+/**
+ * @brief Get whether an encoded control mode is HOVER.
+ *
+ * @param control_mode_uint8t Encoded control mode.
+ * @return true if the control mode is HOVER, whatever its other fields are.
+ */
 inline bool isHoverMode(const uint8_t control_mode_uint8t)
 {
   return compareModes(control_mode_uint8t, HOVER_MODE_MASK, MATCH_CONTROL_MODE);
 }
 
+/**
+ * @brief Get whether a control mode is HOVER.
+ *
+ * @param mode Control mode.
+ * @return true if the control mode is HOVER, whatever its other fields are.
+ */
 inline bool isHoverMode(const as2_msgs::msg::ControlMode & mode)
 {
   return mode.control_mode == as2_msgs::msg::ControlMode::HOVER;
 }
 
+/**
+ * @brief Log a control mode with the node logger, at INFO level.
+ *
+ * @param mode Control mode to log.
+ */
 void printControlMode(const as2_msgs::msg::ControlMode & mode);
+
+/**
+ * @brief Log an encoded control mode with the node logger, at INFO level.
+ *
+ * @param control_mode_uint8t Encoded control mode to log.
+ */
 void printControlMode(uint8_t control_mode_uint8t);
 
 }  // namespace control_mode

--- a/as2_hardware_drivers/as2_usb_camera_interface/include/as2_usb_camera_interface/common.hpp
+++ b/as2_hardware_drivers/as2_usb_camera_interface/include/as2_usb_camera_interface/common.hpp
@@ -51,6 +51,13 @@
 namespace as2_usb_camera_interface
 {
 
+/**
+ * @brief Format a scalar parameter value for logging.
+ *
+ * @tparam T Parameter type, anything streamable.
+ * @param value Value to format.
+ * @return Value as text.
+ */
 template<typename T>
 std::string paramToString(const T & value)
 {
@@ -59,6 +66,13 @@ std::string paramToString(const T & value)
   return oss.str();
 }
 
+/**
+ * @brief Format a vector parameter value for logging, as "[a, b, c]".
+ *
+ * @tparam T Element type, anything streamable.
+ * @param vec Vector to format.
+ * @return Vector as text.
+ */
 template<typename T>
 std::string paramToString(const std::vector<T> & vec)
 {
@@ -113,6 +127,11 @@ template<typename T>
 class MutexQueue
 {
 public:
+  /**
+   * @brief Construct the queue with a maximum size.
+   *
+   * @param max_size Maximum number of elements held.
+   */
   explicit MutexQueue(size_t max_size = 10)
   : max_size_(max_size) {}
 
@@ -130,6 +149,14 @@ public:
   }
 
   // Push with drop policy if full
+  /**
+   * @brief Push an element into the queue.
+   *
+   * @param item Element to push.
+   * @param drop_if_full When the queue is full, true drops the oldest element
+   *                     to make room, false rejects the new one.
+   * @return true if the element was stored.
+   */
   bool push(const T & item, bool drop_if_full = true)
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -145,6 +172,12 @@ public:
   }
 
   // Try to pop (non-blocking)
+  /**
+   * @brief Take the oldest element, without blocking.
+   *
+   * @param item Output. Element taken, untouched when the queue is empty.
+   * @return true if an element was taken.
+   */
   bool tryPop(T & item)
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -157,6 +190,11 @@ public:
   }
 
   // Get current size
+  /**
+   * @brief Get the number of elements currently held.
+   *
+   * @return Number of elements.
+   */
   size_t size() const
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -164,6 +202,11 @@ public:
   }
 
   // Check if empty
+  /**
+   * @brief Get whether the queue holds no elements.
+   *
+   * @return true if the queue is empty.
+   */
   bool empty() const
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -171,6 +214,11 @@ public:
   }
 
   // Set the maximum queue size
+  /**
+   * @brief Change the maximum size of the queue.
+   *
+   * @param max_size New maximum number of elements.
+   */
   void setMaxSize(size_t max_size)
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
@@ -63,10 +63,25 @@ namespace as2_motion_controller_plugin_base
 class ControllerBase
 {
 public:
+  /**
+   * @brief Construct the Controller Base object. The plugin is only usable
+   * after initialize().
+   */
   ControllerBase() = default;
+
+  /**
+   * @brief Destroy the Controller Base object.
+   */
   virtual ~ControllerBase() = default;
 
+  /**
+   * @brief Not copyable: the plugin holds the node it was initialized with.
+   */
   ControllerBase(const ControllerBase &) = delete;
+
+  /**
+   * @brief Not copy assignable, for the same reason.
+   */
   ControllerBase & operator=(const ControllerBase &) = delete;
 
   // API for ControllerHandler / ControllerManager

--- a/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
@@ -102,6 +102,9 @@ public:
     as2::Node * node,
     as2::tf::TfHandler * tf_handler);
 
+  /**
+   * @brief Destroy the Controller Handler object.
+   */
   virtual ~ControllerHandler() {}
 
   /**

--- a/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
@@ -64,24 +64,36 @@ namespace as2_motion_controller_param_utils
 template<typename T>
 T readParam(rclcpp::Node * node, const std::string & name);
 
+/**
+ * @brief readParam specialization for bool.
+ */
 template<>
 inline bool readParam<bool>(rclcpp::Node * node, const std::string & name)
 {
   return node->get_parameter(name).as_bool();
 }
 
+/**
+ * @brief readParam specialization for int64_t.
+ */
 template<>
 inline int64_t readParam<int64_t>(rclcpp::Node * node, const std::string & name)
 {
   return node->get_parameter(name).as_int();
 }
 
+/**
+ * @brief readParam specialization for double.
+ */
 template<>
 inline double readParam<double>(rclcpp::Node * node, const std::string & name)
 {
   return node->get_parameter(name).as_double();
 }
 
+/**
+ * @brief readParam specialization for std::string.
+ */
 template<>
 inline std::string readParam<std::string>(rclcpp::Node * node, const std::string & name)
 {

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -57,7 +57,18 @@ namespace motionReferenceHandlers
 class BasicMotionReferenceHandler
 {
 public:
+  /**
+   * @brief Construct the handler, creating the reference publishers and the
+   * controller info subscription the first time it is instantiated.
+   *
+   * @param as2_ptr Node the references are published from.
+   * @param ns Namespace of the drone. Empty to use the node namespace.
+   */
   explicit BasicMotionReferenceHandler(as2::Node * as2_ptr, const std::string & ns = "");
+
+  /**
+   * @brief Destroy the Basic Motion Reference Handler object.
+   */
   ~BasicMotionReferenceHandler();
 
 protected:
@@ -71,10 +82,39 @@ protected:
 
   as2_msgs::msg::ControlMode desired_control_mode_;
 
+  /**
+   * @brief Send the current thrust reference, settling the control mode first.
+   *
+   * @return true if the reference was published.
+   */
   bool sendThrustCommand();
+
+  /**
+   * @brief Send the current pose reference, settling the control mode first.
+   *
+   * @return true if the reference was published.
+   */
   bool sendPoseCommand();
+
+  /**
+   * @brief Send the current twist reference, settling the control mode first.
+   *
+   * @return true if the reference was published.
+   */
   bool sendTwistCommand();
+
+  /**
+   * @brief Send the current trajectory reference, settling the control mode first.
+   *
+   * @return true if the reference was published.
+   */
   bool sendTrajectoryCommand();
+
+  /**
+   * @brief Request the desired control mode if the current one does not match it.
+   *
+   * @return true if the desired control mode is the active one.
+   */
   bool checkMode();
 
 private:
@@ -89,6 +129,12 @@ private:
   static rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
   static rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;
 
+  /**
+   * @brief Negotiate a control mode with the motion controller.
+   *
+   * @param mode Control mode to request.
+   * @return true if the mode was accepted.
+   */
   bool setMode(const as2_msgs::msg::ControlMode & mode);
 };
 

--- a/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
+++ b/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
@@ -74,7 +74,21 @@ private:
   tf2::Transform odom_to_base_ = tf2::Transform::getIdentity();
 
 public:
+  /**
+   * @brief Construct the State Estimator Base object. The plugin is only
+   * usable after setup().
+   */
   StateEstimatorBase() {}
+
+  /**
+   * @brief Wire the plugin to its node, TF handler and broadcasters, read the
+   * frame parameters and hand control to on_setup().
+   *
+   * @param node Node hosting the plugin.
+   * @param tf_handler TF handler shared with the state estimator node.
+   * @param tf_broadcaster Broadcaster for the dynamic transforms.
+   * @param static_tf_broadcaster Broadcaster for the static transforms.
+   */
   void setup(
     as2::Node * node,
     std::shared_ptr<as2::tf::TfHandler> tf_handler,
@@ -108,7 +122,20 @@ public:
 
     on_setup();
   }
+  /**
+   * @brief Set the plugin up, once its node and broadcasters are available.
+   */
   virtual void on_setup() = 0;
+
+  /**
+   * @brief Get the earth to map transform of this estimator.
+   *
+   * The default implementation warns and returns the identity, so a plugin
+   * that does not localize against a map still produces a valid TF tree.
+   *
+   * @param transform Output. Earth to map transform.
+   * @return true if the transform is valid.
+   */
   virtual bool get_earth_to_map_transform(geometry_msgs::msg::TransformStamped & transform)
   {
     RCLCPP_WARN(
@@ -125,6 +152,11 @@ protected:
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
 
+  /**
+   * @brief Cache the earth to map transform when the given one is that link.
+   *
+   * @param transform Transform about to be published.
+   */
   void check_standard_transform(const geometry_msgs::msg::TransformStamped & transform)
   {
     if (transform.header.frame_id == get_earth_frame() &&
@@ -140,32 +172,92 @@ protected:
     }
   }
 
+  /**
+   * @brief Broadcast a dynamic transform.
+   *
+   * @param transform Transform to broadcast.
+   */
   inline void publish_transform(const geometry_msgs::msg::TransformStamped & transform)
   {
     tf_broadcaster_->sendTransform(transform);
   }
+  /**
+   * @brief Broadcast a static transform.
+   *
+   * @param transform Transform to broadcast.
+   */
   inline void publish_static_transform(const geometry_msgs::msg::TransformStamped & transform)
   {
     static_tf_broadcaster_->sendTransform(transform);
   }
 
+  /**
+   * @brief Publish the estimated twist of the vehicle.
+   *
+   * @param twist Twist to publish.
+   */
   inline void publish_twist(const geometry_msgs::msg::TwistStamped & twist)
   {
     twist_pub_->publish(twist);
   }
+  /**
+   * @brief Publish the estimated pose of the vehicle.
+   *
+   * @param pose Pose to publish.
+   */
   inline void publish_pose(const geometry_msgs::msg::PoseStamped & pose)
   {
     pose_pub_->publish(pose);
   }
 
+  /**
+   * @brief Global earth frame id, shared by every robot.
+   *
+   * @return Frame id.
+   */
   inline const std::string & get_earth_frame() const {return earth_frame_id_;}
+  /**
+   * @brief Namespaced map frame id of the robot.
+   *
+   * @return Frame id.
+   */
   inline const std::string & get_map_frame() const {return map_frame_id_;}
+  /**
+   * @brief Namespaced odom frame id of the robot.
+   *
+   * @return Frame id.
+   */
   inline const std::string & get_odom_frame() const {return odom_frame_id_;}
+  /**
+   * @brief Namespaced base_link frame id of the robot.
+   *
+   * @return Frame id.
+   */
   inline const std::string & get_base_frame() const {return base_frame_id_;}
 
+  /**
+   * @brief Override the earth frame id, for a plugin with its own convention.
+   *
+   * @param frame Frame id to use.
+   */
   inline void set_earth_frame(const std::string & frame) {earth_frame_id_ = frame;}
+  /**
+   * @brief Override the map frame id, for a plugin with its own convention.
+   *
+   * @param frame Frame id to use.
+   */
   inline void set_map_frame(const std::string & frame) {map_frame_id_ = frame;}
+  /**
+   * @brief Override the odom frame id, for a plugin with its own convention.
+   *
+   * @param frame Frame id to use.
+   */
   inline void set_odom_frame(const std::string & frame) {odom_frame_id_ = frame;}
+  /**
+   * @brief Override the base_link frame id, for a plugin with its own convention.
+   *
+   * @param frame Frame id to use.
+   */
   inline void set_base_frame(const std::string & frame) {base_frame_id_ = frame;}
 
   tf2::Transform odom_to_baselink;
@@ -176,6 +268,12 @@ protected:
   bool static_transforms_published_ = false;
   rclcpp::TimerBase::SharedPtr static_transforms_timer_;
 
+  /**
+   * @brief Get the earth to map transform as a tf2::Transform.
+   *
+   * @param earth_to_map Output. Earth to map transform.
+   * @return true if the transform is valid.
+   */
   bool get_earth_to_map_transform(tf2::Transform & earth_to_map)
   {
     geometry_msgs::msg::TransformStamped transform;
@@ -186,6 +284,15 @@ protected:
     return false;
   }
 
+  /**
+   * @brief Express a pose known in earth as the odom to base_link transform.
+   *
+   * @param earth_to_baselink Pose of the vehicle in earth.
+   * @param odom_to_baselink Output. Same pose, relative to odom.
+   * @param earth_to_map Earth to map transform.
+   * @param map_to_odom Map to odom transform. Defaults to the identity.
+   * @return true always, the conversion cannot fail.
+   */
   bool convert_earth_to_baselink_2_odom_to_baselink_transform(
     const tf2::Transform & earth_to_baselink,
     tf2::Transform & odom_to_baselink,
@@ -196,6 +303,15 @@ protected:
     return true;
   }
 
+  /**
+   * @brief Express a pose known in odom as the earth to base_link transform.
+   *
+   * @param odom_to_baselink Pose of the vehicle in odom.
+   * @param earth_to_baselink Output. Same pose, relative to earth.
+   * @param earth_to_map Earth to map transform.
+   * @param map_to_odom Map to odom transform. Defaults to the identity.
+   * @return true always, the conversion cannot fail.
+   */
   bool convert_odom_to_baselink_2_earth_to_baselink_transform(
     const tf2::Transform & odom_to_baselink,
     tf2::Transform & earth_to_baselink,

--- a/as2_user_interfaces/as2_alphanumeric_viewer/include/as2_alphanumeric_viewer/alphanumeric_viewer.hpp
+++ b/as2_user_interfaces/as2_alphanumeric_viewer/include/as2_alphanumeric_viewer/alphanumeric_viewer.hpp
@@ -68,36 +68,135 @@
 class AlphanumericViewer : public as2::Node
 {
 public:
+  /**
+   * @brief Construct the viewer node and subscribe to the topics it shows.
+   */
   AlphanumericViewer();
 
+  /**
+   * @brief Refresh the active window: read the pressed key, switch window if it
+   * is an arrow key, and repaint the values.
+   */
   void run();
+  /**
+   * @brief Initialize ncurses and paint the static layout of the first window.
+   */
   void setupNode();
+  /**
+   * @brief Paint the static layout of the summary window.
+   */
   void printSummaryMenu();
+  /**
+   * @brief Paint the static layout of the sensor window.
+   */
   void printSensorMenu();
+  /**
+   * @brief Paint the static layout of the navigation window.
+   */
   void printNavigationMenu();
+  /**
+   * @brief Paint the static layout of the platform window.
+   */
   void printPlatformMenu();
+  /**
+   * @brief Print a double with the common format, in the current cursor position.
+   *
+   * @param var Value to print.
+   * @param aux True when the value has been received, false to print it dimmed.
+   */
   void printStream(double var, bool aux);
+  /**
+   * @brief Print a float with three decimals, in the current cursor position.
+   *
+   * @param var Value to print.
+   * @param aux True when the value has been received, false to print it dimmed.
+   */
   void printStream3(float var, bool aux);
+  /**
+   * @brief Print a float with the common format, in the current cursor position.
+   *
+   * @param var Value to print.
+   * @param aux True when the value has been received, false to print it dimmed.
+   */
   void printStream(float var, bool aux);
+  /**
+   * @brief Paint the values of the summary window.
+   */
   void printSummaryValues();
+  /**
+   * @brief Paint the values of the navigation window.
+   */
   void printNavigationValues();
+  /**
+   * @brief Paint the values of the sensor window.
+   */
   void printSensorValues();
+  /**
+   * @brief Paint the values of the platform window.
+   */
   void printPlatformValues();
+  /**
+   * @brief Paint the battery percentage, in the current cursor position.
+   */
   void printBattery();
+  /**
+   * @brief Paint the state machine state of the platform.
+   */
   void printQuadrotorState();
+  /**
+   * @brief Paint the yaw mode the controller takes as input.
+   */
   void printControlModeInYaw();
+  /**
+   * @brief Paint the control mode the controller takes as input.
+   */
   void printControlModeInControl();
+  /**
+   * @brief Paint the reference frame the controller takes as input.
+   */
   void printControlModeInFrame();
+  /**
+   * @brief Paint the yaw mode the platform is in.
+   */
   void printControlModeOutYaw();
+  /**
+   * @brief Paint the control mode the platform is in.
+   */
   void printControlModeOutControl();
+  /**
+   * @brief Paint the reference frame the platform is in.
+   */
   void printControlModeOutFrame();
+  /**
+   * @brief Paint the connected, armed and offboard flags of the platform.
+   *
+   * @param line First line the flags are painted in.
+   */
   void printPlatformStatus(int line);
+  /**
+   * @brief Mark every value as not received, so the next repaint dims them.
+   */
   void clearValues();
 
   using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
+  /**
+   * @brief Lifecycle configure transition. Sets the node up and starts ncurses.
+   *
+   * @return CallbackReturn::SUCCESS
+   */
   CallbackReturn on_configure(const rclcpp_lifecycle::State &) override;
+  /**
+   * @brief Lifecycle deactivate transition. Ends the ncurses session.
+   *
+   * @return CallbackReturn::SUCCESS
+   */
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State &) override;
+  /**
+   * @brief Lifecycle shutdown transition. Ends the ncurses session.
+   *
+   * @return CallbackReturn::SUCCESS
+   */
   CallbackReturn on_shutdown(const rclcpp_lifecycle::State &) override;
 
 private:
@@ -165,17 +264,77 @@ private:
 
   int window = 0;
 
+  /**
+   * @brief Store the self localization pose.
+   *
+   * @param _msg Received message.
+   */
   void poseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr _msg);
+  /**
+   * @brief Store the self localization twist.
+   *
+   * @param _msg Received message.
+   */
   void twistCallback(const geometry_msgs::msg::TwistStamped::SharedPtr _msg);
+  /**
+   * @brief Store the battery state.
+   *
+   * @param _msg Received message.
+   */
   void batteryCallback(const sensor_msgs::msg::BatteryState::SharedPtr _msg);
+  /**
+   * @brief Store the IMU measurement.
+   *
+   * @param _msg Received message.
+   */
   void imuCallback(const sensor_msgs::msg::Imu::SharedPtr _msg);
+  /**
+   * @brief Store the platform info and its control mode.
+   *
+   * @param _msg Received message.
+   */
   void platformCallback(const as2_msgs::msg::PlatformInfo::SharedPtr _msg);
+  /**
+   * @brief Store the pose actuator command sent to the platform.
+   *
+   * @param _msg Received message.
+   */
   void actuatorPoseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr _msg);
+  /**
+   * @brief Store the thrust actuator command sent to the platform.
+   *
+   * @param _msg Received message.
+   */
   void actuatorThrustCallback(const as2_msgs::msg::Thrust::SharedPtr _msg);
+  /**
+   * @brief Store the twist actuator command sent to the platform.
+   *
+   * @param _msg Received message.
+   */
   void actuatorSpeedCallback(const geometry_msgs::msg::TwistStamped::SharedPtr _msg);
+  /**
+   * @brief Store the controller info and its input control mode.
+   *
+   * @param _msg Received message.
+   */
   void controllerCallback(const as2_msgs::msg::ControllerInfo::SharedPtr _msg);
+  /**
+   * @brief Store the pose motion reference.
+   *
+   * @param _msg Received message.
+   */
   void poseReferenceCallback(const geometry_msgs::msg::PoseStamped::SharedPtr _msg);
+  /**
+   * @brief Store the twist motion reference.
+   *
+   * @param _msg Received message.
+   */
   void speedReferenceCallback(const geometry_msgs::msg::TwistStamped::SharedPtr _msg);
+  /**
+   * @brief Store the GPS fix.
+   *
+   * @param _msg Received message.
+   */
   void gpsCallback(const sensor_msgs::msg::NavSatFix::SharedPtr _msg);
   // void trajectoryReferenceCallback (const as2_msgs::msg::TrajectoryWaypoints::SharedPtr _msg);
 };


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo, Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Adds doxygen docstrings to every public method that was missing one across 14 headers of 9 packages. **Documentation only: no declaration, signature or behaviour changes.**
* Packages touched: `as2_core`, `as2_motion_controller`, `as2_motion_reference_handlers`, `as2_state_estimator`, `as2_platform_gazebo`, `as2_platform_multirotor_simulator`, `as2_alphanumeric_viewer`, `as2_usb_camera_interface`, `as2_behaviors_object_perception`.
