### PR TITLE
[as2_core] Centralize ROS 2 parameter reading in as2::Node::getParameter

### DIFF
--- a/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
+++ b/as2_aerial_platforms/as2_platform_gazebo/src/as2_platform_gazebo.cpp
@@ -41,24 +41,19 @@ namespace gazebo_platform
 GazeboPlatform::GazeboPlatform(const rclcpp::NodeOptions & options)
 : as2::AerialPlatform(options)
 {
-  this->declare_parameter<std::string>("cmd_vel_topic");
-  std::string cmd_vel_topic_param = this->get_parameter("cmd_vel_topic").as_string();
+  std::string cmd_vel_topic_param = this->getParameter<std::string>("cmd_vel_topic");
 
-  this->declare_parameter<std::string>("acro_topic");
-  std::string acro_topic_param = this->get_parameter("acro_topic").as_string();
+  std::string acro_topic_param = this->getParameter<std::string>("acro_topic");
 
-  this->declare_parameter<std::string>("arm_topic");
-  std::string arm_topic_param = this->get_parameter("arm_topic").as_string();
+  std::string arm_topic_param = this->getParameter<std::string>("arm_topic");
 
   // Use takeoff and land with platform for debugging purposes
-  this->declare_parameter<bool>("enable_takeoff_platform");
-  enable_takeoff_ = this->get_parameter("enable_takeoff_platform").as_bool();
+  enable_takeoff_ = this->getParameter<bool>("enable_takeoff_platform");
   if (enable_takeoff_) {
     RCLCPP_INFO(this->get_logger(), "Enabled takeoff platform");
   }
 
-  this->declare_parameter<bool>("enable_land_platform");
-  enable_land_ = this->get_parameter("enable_land_platform").as_bool();
+  enable_land_ = this->getParameter<bool>("enable_land_platform");
   if (enable_land_) {
     RCLCPP_INFO(this->get_logger(), "Enabled land platform");
   }

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_interface.hpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_interface.hpp
@@ -90,44 +90,6 @@ private:
 
 public:
   /**
-    * @brief Get parameter from the parameter server
-    *
-    * @param param_name Name of the parameter
-    * @param param_value Value of the parameter
-    * @param use_default Use default value if parameter is not found
-   */
-  template<typename T>
-  inline void getParam(const std::string & param_name, T & param_value, bool use_default = false)
-  {
-    try {
-      // Declare parameter if not declared
-      if (!node_ptr_->has_parameter(param_name)) {
-        if (use_default) {
-          node_ptr_->declare_parameter<T>(param_name, param_value);
-        } else {
-          node_ptr_->declare_parameter<T>(param_name);
-        }
-      }
-
-      if constexpr (std::is_same<T, std::vector<double>>::value) {
-        param_value = node_ptr_->get_parameter(param_name).as_double_array();
-      } else if constexpr (std::is_same<T, double>::value) {
-        param_value = node_ptr_->get_parameter(param_name).as_double();
-      } else if constexpr (std::is_same<T, std::string>::value) {
-        param_value = node_ptr_->get_parameter(param_name).as_string();
-      } else if constexpr (std::is_same<T, bool>::value) {
-        param_value = node_ptr_->get_parameter(param_name).as_bool();
-      } else {
-        RCLCPP_WARN(node_ptr_->get_logger(), "Parameter type %s not expected", typeid(T).name());
-        param_value = node_ptr_->get_parameter<T>(param_name, param_value);
-      }
-    } catch (const std::exception & e) {
-      RCLCPP_ERROR(
-        node_ptr_->get_logger(), "Error getting parameter %s: %s", param_name.c_str(), e.what());
-    }
-  }
-
-  /**
    * @brief Convert simulator data to odometry message
    *
    * @param kinematics Kinematics data

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_platform_multirotor_simulator.hpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/include/as2_platform_multirotor_simulator/as2_platform_multirotor_simulator.hpp
@@ -220,44 +220,6 @@ private:
   inline void readParams(PlatformParams & platform_params);
 
   /**
-   * @brief Get parameter from the parameter server
-   *
-   * @param param_name Name of the parameter
-   * @param param_value Value of the parameter
-   * @param use_default Use default value if parameter is not found
-  */
-  template<typename T>
-  inline void getParam(const std::string & param_name, T & param_value, bool use_default = false)
-  {
-    try {
-      // Declare parameter if not declared
-      if (!this->has_parameter(param_name)) {
-        if (use_default) {
-          this->declare_parameter<T>(param_name, param_value);
-        } else {
-          this->declare_parameter<T>(param_name);
-        }
-      }
-
-      if constexpr (std::is_same<T, std::vector<double>>::value) {
-        param_value = this->get_parameter(param_name).as_double_array();
-      } else if constexpr (std::is_same<T, double>::value) {
-        param_value = this->get_parameter(param_name).as_double();
-      } else if constexpr (std::is_same<T, std::string>::value) {
-        param_value = this->get_parameter(param_name).as_string();
-      } else if constexpr (std::is_same<T, bool>::value) {
-        param_value = this->get_parameter(param_name).as_bool();
-      } else {
-        RCLCPP_WARN(this->get_logger(), "Parameter type %s not expected", typeid(T).name());
-        param_value = this->get_parameter<T>(param_name, param_value);
-      }
-    } catch (const std::exception & e) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Error getting parameter %s: %s", param_name.c_str(), e.what());
-    }
-  }
-
-  /**
    * @brief Simulator timer callback
   */
   void simulatorTimerCallback();

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_interface.cpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_interface.cpp
@@ -48,24 +48,22 @@ As2MultirotorSimulatorInterface::As2MultirotorSimulatorInterface(
   as2::Node * node_ptr)
 : node_ptr_(node_ptr), tf_handler_(node_ptr)
 {
-  getParam("global_ref_frame", frame_id_earth_);
-  getParam("odom_frame", frame_id_odom_);
-  getParam("base_frame", frame_id_baselink_);
+  frame_id_earth_ = node_ptr_->getParameter<std::string>("global_ref_frame");
+  frame_id_odom_ = node_ptr_->getParameter<std::string>("odom_frame");
+  frame_id_baselink_ = node_ptr_->getParameter<std::string>("base_frame");
   frame_id_odom_ = as2::tf::generateTfName(node_ptr, frame_id_odom_);
   frame_id_baselink_ = as2::tf::generateTfName(node_ptr, frame_id_baselink_);
 
-  getParam("use_odom_for_control", using_odom_for_control_);
-
+  using_odom_for_control_ = node_ptr_->getParameter<bool>("use_odom_for_control");
   // Initial position
-  getParam("vehicle_initial_pose.x", initial_position_.x());
-  getParam("vehicle_initial_pose.y", initial_position_.y());
-  getParam("vehicle_initial_pose.z", initial_position_.z());
-
+  initial_position_.x() = node_ptr_->getParameter<double>("vehicle_initial_pose.x");
+  initial_position_.y() = node_ptr_->getParameter<double>("vehicle_initial_pose.y");
+  initial_position_.z() = node_ptr_->getParameter<double>("vehicle_initial_pose.z");
   // Initial orientation
   double roll, pitch, yaw;
-  getParam("vehicle_initial_pose.yaw", yaw);
-  getParam("vehicle_initial_pose.pitch", pitch);
-  getParam("vehicle_initial_pose.roll", roll);
+  yaw = node_ptr_->getParameter<double>("vehicle_initial_pose.yaw");
+  pitch = node_ptr_->getParameter<double>("vehicle_initial_pose.pitch");
+  roll = node_ptr_->getParameter<double>("vehicle_initial_pose.roll");
   as2::frame::eulerToQuaternion(roll, pitch, yaw, initial_orientation_);
   initial_orientation_ = initial_orientation_.normalized();
 }

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_platform_multirotor_simulator.cpp
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/src/as2_platform_multirotor_simulator.cpp
@@ -99,15 +99,15 @@ MultirotorSimulatorPlatform::~MultirotorSimulatorPlatform()
 
 void MultirotorSimulatorPlatform::configureSensors()
 {
-  getParam("global_ref_frame", frame_id_earth_);
-  getParam("base_frame", frame_id_baselink_);
+  frame_id_earth_ = getParameter<std::string>("global_ref_frame");
+  frame_id_baselink_ = getParameter<std::string>("base_frame");
   frame_id_baselink_ = as2::tf::generateTfName(this, frame_id_baselink_);
 
   // Get gimbal name
   std::string gimbal_name = "gimbal";
   std::string gimbal_base_name = "gimbal_base";
-  getParam("gimbal.frame_id", gimbal_name);
-  getParam("gimbal.base_frame_id", gimbal_base_name);
+  gimbal_name = getParameter<std::string>("gimbal.frame_id");
+  gimbal_base_name = getParameter<std::string>("gimbal.base_frame_id");
 
   RCLCPP_INFO(this->get_logger(), "Ground truth freq: %f", platform_params_.ground_truth_pub_freq);
   RCLCPP_INFO(this->get_logger(), "Odometry freq: %f", platform_params_.odometry_pub_freq);
@@ -134,9 +134,9 @@ void MultirotorSimulatorPlatform::configureSensors()
     std::bind(&MultirotorSimulatorPlatform::gimbalControlCallback, this, std::placeholders::_1));
 
   geometry_msgs::msg::Transform gimbal_transform;
-  getParam("gimbal.base_transform.x", gimbal_transform.translation.x);
-  getParam("gimbal.base_transform.y", gimbal_transform.translation.y);
-  getParam("gimbal.base_transform.z", gimbal_transform.translation.z);
+  gimbal_transform.translation.x = getParameter<double>("gimbal.base_transform.x");
+  gimbal_transform.translation.y = getParameter<double>("gimbal.base_transform.y");
+  gimbal_transform.translation.z = getParameter<double>("gimbal.base_transform.z");
   sensor_gimbal_ptr_->setGimbalBaseTransform(gimbal_transform);
 }
 
@@ -484,68 +484,53 @@ void MultirotorSimulatorPlatform::gimbalControlCallback(
 
 Eigen::Vector3d MultirotorSimulatorPlatform::readVectorParams(const std::string & param_name)
 {
-  Eigen::Vector3d default_value = Eigen::Vector3d::Zero();  // Default value
-
-  try {
-    std::vector<double> vec;
-    this->getParam(param_name, vec);
-
-    if (vec.size() != 3) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Parameter '%s' is not a vector of size 3.", param_name.c_str());
-      // Print vector
-      RCLCPP_ERROR(this->get_logger(), "Vector: ");
-      for (auto & v : vec) {
-        RCLCPP_ERROR(this->get_logger(), "%f", v);
-      }
-      return default_value;
-    }
-
-    return Eigen::Vector3d(vec[0], vec[1], vec[2]);
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(
-      this->get_logger(), "Error getting parameter %s: %s", param_name.c_str(), e.what());
-    return default_value;
+  const std::vector<double> vec = getParameter<std::vector<double>>(param_name);
+  if (vec.size() != 3) {
+    RCLCPP_FATAL(
+      this->get_logger(), "Parameter '%s' has %zu elements, expected 3",
+      param_name.c_str(), vec.size());
+    throw rclcpp::exceptions::InvalidParameterValueException(
+            "Parameter '" + param_name + "' is not a vector of size 3");
   }
+  return Eigen::Vector3d(vec[0], vec[1], vec[2]);
 }
 
 void MultirotorSimulatorPlatform::readParams(PlatformParams & platform_params)
 {
   RCLCPP_INFO(this->get_logger(), "Reading parameters...");
   // Platform Parameters
-  getParam("imu_pub_freq", platform_params.imu_pub_freq);
-  getParam("odometry_pub_freq", platform_params.odometry_pub_freq);
-  getParam("ground_truth_pub_freq", platform_params.ground_truth_pub_freq);
-  getParam("gps_pub_freq", platform_params.gps_pub_freq);
-  getParam("gimbal.pub_freq", platform_params.gimbal_pub_freq);
-
+  platform_params.imu_pub_freq = getParameter<double>("imu_pub_freq");
+  platform_params.odometry_pub_freq = getParameter<double>("odometry_pub_freq");
+  platform_params.ground_truth_pub_freq = getParameter<double>("ground_truth_pub_freq");
+  platform_params.gps_pub_freq = getParameter<double>("gps_pub_freq");
+  platform_params.gimbal_pub_freq = getParameter<double>("gimbal.pub_freq");
   // Get max frequency
   platform_params.state_freq = std::max(
     std::max(platform_params.imu_pub_freq, platform_params.odometry_pub_freq),
     std::max(platform_params.ground_truth_pub_freq, platform_params.gps_pub_freq));
 
   // GPS Origin
-  getParam("gps_origin.latitude", platform_params.latitude);
-  getParam("gps_origin.longitude", platform_params.longitude);
-  getParam("gps_origin.altitude", platform_params.altitude);
+  platform_params.latitude = getParameter<double>("gps_origin.latitude");
+  platform_params.longitude = getParameter<double>("gps_origin.longitude");
+  platform_params.altitude = getParameter<double>("gps_origin.altitude");
 
   // Simulator params
   double floor_height = 0.0;
-  getParam("use_odom_for_control", using_odom_for_control_);
-  getParam("floor_height", floor_height);
-  getParam("simulation.update_freq", platform_params.update_freq);
-  getParam("simulation.control_freq", platform_params.control_freq);
-  getParam("simulation.inertial_odometry_freq", platform_params.inertial_odometry_freq);
-
+  using_odom_for_control_ = getParameter<bool>("use_odom_for_control");
+  floor_height = getParameter<double>("floor_height");
+  platform_params.update_freq = getParameter<double>("simulation.update_freq");
+  platform_params.control_freq = getParameter<double>("simulation.control_freq");
+  platform_params.inertial_odometry_freq =
+    getParameter<double>("simulation.inertial_odometry_freq");
   // Initial pose
   Eigen::Vector3d initial_position;
-  getParam("vehicle_initial_pose.x", initial_position.x());
-  getParam("vehicle_initial_pose.y", initial_position.y());
-  getParam("vehicle_initial_pose.z", initial_position.z());
+  initial_position.x() = getParameter<double>("vehicle_initial_pose.x");
+  initial_position.y() = getParameter<double>("vehicle_initial_pose.y");
+  initial_position.z() = getParameter<double>("vehicle_initial_pose.z");
   double roll, pitch, yaw;
-  getParam("vehicle_initial_pose.yaw", yaw);
-  getParam("vehicle_initial_pose.pitch", pitch);
-  getParam("vehicle_initial_pose.roll", roll);
+  yaw = getParameter<double>("vehicle_initial_pose.yaw");
+  pitch = getParameter<double>("vehicle_initial_pose.pitch");
+  roll = getParameter<double>("vehicle_initial_pose.roll");
   Eigen::Quaterniond initial_orientation;
   as2::frame::eulerToQuaternion(roll, pitch, yaw, initial_orientation);
 
@@ -557,30 +542,30 @@ void MultirotorSimulatorPlatform::readParams(PlatformParams & platform_params)
 
   // Dynamics::Model params
   dp.model_params.gravity = readVectorParams("multirotor.dynamics.model.gravity");
-  getParam("multirotor.dynamics.model.vehicle_mass", dp.model_params.vehicle_mass);
+  dp.model_params.vehicle_mass = getParameter<double>("multirotor.dynamics.model.vehicle_mass");
   dp.model_params.vehicle_inertia =
     readVectorParams("multirotor.dynamics.model.vehicle_inertia").asDiagonal();
-  getParam(
-    "multirotor.dynamics.model.vehicle_drag_coefficient", dp.model_params.vehicle_drag_coefficient);
+  dp.model_params.vehicle_drag_coefficient = getParameter<double>(
+    "multirotor.dynamics.model.vehicle_drag_coefficient");
   dp.model_params.vehicle_aero_moment_coefficient =
     readVectorParams("multirotor.dynamics.model.vehicle_aero_moment_coefficient").asDiagonal();
-  getParam(
-    "multirotor.dynamics.model.force_process_noise_auto_correlation",
-    dp.model_params.moment_process_noise_auto_correlation);
-  getParam(
-    "multirotor.dynamics.model.moment_process_noise_auto_correlation",
-    dp.model_params.moment_process_noise_auto_correlation);
-
+  dp.model_params.moment_process_noise_auto_correlation = getParameter<double>(
+    "multirotor.dynamics.model.force_process_noise_auto_correlation");
+  dp.model_params.moment_process_noise_auto_correlation = getParameter<double>(
+    "multirotor.dynamics.model.moment_process_noise_auto_correlation");
   double thrust_coefficient, torque_coefficient, x_dist, y_dist, min_speed, max_speed,
     time_constant, rotational_inertia;
-  getParam("multirotor.dynamics.model.motors_params.thrust_coefficient", thrust_coefficient);
-  getParam("multirotor.dynamics.model.motors_params.torque_coefficient", torque_coefficient);
-  getParam("multirotor.dynamics.model.motors_params.x_dist", x_dist);
-  getParam("multirotor.dynamics.model.motors_params.y_dist", y_dist);
-  getParam("multirotor.dynamics.model.motors_params.min_speed", min_speed);
-  getParam("multirotor.dynamics.model.motors_params.max_speed", max_speed);
-  getParam("multirotor.dynamics.model.motors_params.time_constant", time_constant);
-  getParam("multirotor.dynamics.model.motors_params.rotational_inertia", rotational_inertia);
+  thrust_coefficient = getParameter<double>(
+    "multirotor.dynamics.model.motors_params.thrust_coefficient");
+  torque_coefficient = getParameter<double>(
+    "multirotor.dynamics.model.motors_params.torque_coefficient");
+  x_dist = getParameter<double>("multirotor.dynamics.model.motors_params.x_dist");
+  y_dist = getParameter<double>("multirotor.dynamics.model.motors_params.y_dist");
+  min_speed = getParameter<double>("multirotor.dynamics.model.motors_params.min_speed");
+  max_speed = getParameter<double>("multirotor.dynamics.model.motors_params.max_speed");
+  time_constant = getParameter<double>("multirotor.dynamics.model.motors_params.time_constant");
+  rotational_inertia = getParameter<double>(
+    "multirotor.dynamics.model.motors_params.rotational_inertia");
   dp.model_params.motors_params = multirotor::model::Model<double, 4>::create_quadrotor_x_config(
     thrust_coefficient, torque_coefficient, x_dist, y_dist, min_speed, max_speed, time_constant,
     rotational_inertia);
@@ -667,17 +652,17 @@ void MultirotorSimulatorPlatform::readParams(PlatformParams & platform_params)
   cp.position_controller_params.pid_params.proportional_saturation_flag = true;
 
   // IMU params
-  getParam("multirotor.imu.gyro_noise_var", simulator_params_.imu_params.gyro_noise_var);
-  getParam("multirotor.imu.accel_noise_var", simulator_params_.imu_params.accel_noise_var);
-  getParam(
-    "multirotor.imu.gyro_bias_noise_autocorr_time",
-    simulator_params_.imu_params.gyro_bias_noise_autocorr_time);
-  getParam(
-    "multirotor.imu.accel_bias_noise_autocorr_time",
-    simulator_params_.imu_params.accel_bias_noise_autocorr_time);
-
+  simulator_params_.imu_params.gyro_noise_var =
+    getParameter<double>("multirotor.imu.gyro_noise_var");
+  simulator_params_.imu_params.accel_noise_var = getParameter<double>(
+    "multirotor.imu.accel_noise_var");
+  simulator_params_.imu_params.gyro_bias_noise_autocorr_time = getParameter<double>(
+    "multirotor.imu.gyro_bias_noise_autocorr_time");
+  simulator_params_.imu_params.accel_bias_noise_autocorr_time = getParameter<double>(
+    "multirotor.imu.accel_bias_noise_autocorr_time");
   // Inertial Odometry params
-  getParam("multirotor.inertial_odometry.alpha", simulator_params_.inertial_odometry_params.alpha);
+  simulator_params_.inertial_odometry_params.alpha = getParameter<double>(
+    "multirotor.inertial_odometry.alpha");
   simulator_params_.inertial_odometry_params.initial_world_orientation = initial_orientation;
 
   simulator_ = Simulator(simulator_params_);

--- a/as2_behaviors/as2_behavior/include/as2_behavior/__impl/behavior_server__impl.hpp
+++ b/as2_behaviors/as2_behavior/include/as2_behavior/__impl/behavior_server__impl.hpp
@@ -50,9 +50,6 @@ BehaviorServer<actionT>::BehaviorServer(
   const rclcpp::NodeOptions & options)
 : as2::Node(name, options), action_name_(name)
 {
-  if (!this->has_parameter("run_frequency")) {
-    this->declare_parameter<float>("run_frequency", 10.0);
-  }
   register_action();
   register_service_servers();
   register_publishers();
@@ -153,8 +150,7 @@ void BehaviorServer<actionT>::register_timers()
 template<typename actionT>
 void BehaviorServer<actionT>::register_run_timer()
 {
-  float run_frequency;
-  this->get_parameter("run_frequency", run_frequency);
+  const float run_frequency = this->getParameter<float>("run_frequency", 10.0);
   run_timer_ = this->create_timer(
     std::chrono::duration<double>(1.0f / run_frequency),
     std::bind(&BehaviorServer::timer_callback, this));

--- a/as2_behaviors/as2_behaviors_motion/follow_path_behavior/src/follow_path_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_motion/follow_path_behavior/src/follow_path_behavior.cpp
@@ -42,46 +42,19 @@ FollowPathBehavior::FollowPathBehavior(const rclcpp::NodeOptions & options)
     as2_names::actions::behaviors::followpath,
     options)
 {
-  try {
-    this->declare_parameter<std::string>("plugin_name");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <plugin_name> not defined or malformed: %s",
-      e.what());
-    this->~FollowPathBehavior();
-  }
-  try {
-    this->declare_parameter<double>("follow_path_speed");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <follow_path_speed> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~FollowPathBehavior();
-  }
-  try {
-    this->declare_parameter<double>("follow_path_threshold");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <follow_path_threshold> not defined or malformed: %s", e.what());
-    this->~FollowPathBehavior();
-  }
-
   loader_ = std::make_shared<pluginlib::ClassLoader<follow_path_base::FollowPathBase>>(
     "as2_behaviors_motion", "follow_path_base::FollowPathBase");
 
   tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
 
   try {
-    std::string plugin_name = this->get_parameter("plugin_name").as_string();
+    std::string plugin_name = this->getParameter<std::string>("plugin_name");
     plugin_name += "::Plugin";
     follow_path_plugin_ = loader_->createSharedInstance(plugin_name);
 
     follow_path_base::follow_path_plugin_params params;
-    params.follow_path_speed = this->get_parameter("follow_path_speed").as_double();
-    params.follow_path_threshold = this->get_parameter("follow_path_threshold").as_double();
+    params.follow_path_speed = this->getParameter<double>("follow_path_speed");
+    params.follow_path_threshold = this->getParameter<double>("follow_path_threshold");
 
     follow_path_plugin_->initialize(this, tf_handler_, params);
 
@@ -163,7 +136,7 @@ bool FollowPathBehavior::process_goal(
 
   new_goal.max_speed = (goal->max_speed != 0.0f) ?
     goal->max_speed :
-    this->get_parameter("follow_path_speed").as_double();
+    this->getParameter<double>("follow_path_speed");
 
   return true;
 }

--- a/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/include/follow_reference_behavior/follow_reference_base.hpp
+++ b/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/include/follow_reference_behavior/follow_reference_base.hpp
@@ -82,11 +82,11 @@ public:
     // nor passes them; we declare on demand here so the base owns the
     // contract with the node. Values come from the launch-loaded config.
     params_.follow_reference_max_speed_x =
-      declareAndGetDouble("follow_reference_max_speed_x");
+      node_ptr_->getParameter<double>("follow_reference_max_speed_x");
     params_.follow_reference_max_speed_y =
-      declareAndGetDouble("follow_reference_max_speed_y");
+      node_ptr_->getParameter<double>("follow_reference_max_speed_y");
     params_.follow_reference_max_speed_z =
-      declareAndGetDouble("follow_reference_max_speed_z");
+      node_ptr_->getParameter<double>("follow_reference_max_speed_z");
 
     hover_motion_handler_ =
       std::make_shared<as2::motionReferenceHandlers::HoverMotion>(node_ptr_);
@@ -202,22 +202,6 @@ public:
   }
 
 private:
-  double declareAndGetDouble(const std::string & param_name)
-  {
-    if (!node_ptr_->has_parameter(param_name)) {
-      try {
-        node_ptr_->declare_parameter<double>(param_name);
-      } catch (const rclcpp::ParameterTypeException & e) {
-        RCLCPP_FATAL(
-          node_ptr_->get_logger(),
-          "Parameter <%s> not defined or malformed: %s",
-          param_name.c_str(), e.what());
-        throw;
-      }
-    }
-    return node_ptr_->get_parameter(param_name).as_double();
-  }
-
   bool processGoal(as2_msgs::action::FollowReference::Goal & _goal)
   {
     if (platform_state_ != as2_msgs::msg::PlatformStatus::FLYING) {

--- a/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/plugins/follow_reference_plugin_trajectory.cpp
+++ b/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/plugins/follow_reference_plugin_trajectory.cpp
@@ -108,9 +108,9 @@ public:
     // published one, and at most at `modify_frequency_` Hz.
     // Defaults: threshold=0 (any change triggers modify), frequency=0 (no
     // rate-limit). Raise them to filter TF noise or cap the modify rate.
-    modify_threshold_ = declareAndGetDouble(
+    modify_threshold_ = node_ptr_->getParameter<double>(
       "follow_reference_plugin_trajectory.modify_threshold", 0.0);
-    modify_frequency_ = declareAndGetDouble(
+    modify_frequency_ = node_ptr_->getParameter<double>(
       "follow_reference_plugin_trajectory.modify_frequency", 0.0);
   }
 
@@ -337,15 +337,6 @@ private:
   double modify_frequency_ = 0.0;
   geometry_msgs::msg::PointStamped last_target_in_earth_;
   rclcpp::Time last_modify_time_;
-
-  double declareAndGetDouble(
-    const std::string & param_name, double default_value)
-  {
-    if (!node_ptr_->has_parameter(param_name)) {
-      node_ptr_->declare_parameter<double>(param_name, default_value);
-    }
-    return node_ptr_->get_parameter(param_name).as_double();
-  }
 
   bool tryConvertTargetToEarth(
     const geometry_msgs::msg::PointStamped & target,

--- a/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/src/follow_reference_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_motion/follow_reference_behavior/src/follow_reference_behavior.cpp
@@ -43,15 +43,6 @@ FollowReferenceBehavior::FollowReferenceBehavior(const rclcpp::NodeOptions & opt
     as2_names::actions::behaviors::followreference,
     options)
 {
-  try {
-    this->declare_parameter<std::string>("plugin_name");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <plugin_name> not defined or malformed: %s", e.what());
-    this->~FollowReferenceBehavior();
-  }
-
   loader_ = std::make_shared<
     pluginlib::ClassLoader<follow_reference_base::FollowReferenceBase>>(
     "as2_behaviors_motion",
@@ -60,7 +51,7 @@ FollowReferenceBehavior::FollowReferenceBehavior(const rclcpp::NodeOptions & opt
   tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
 
   try {
-    std::string plugin_name = this->get_parameter("plugin_name").as_string();
+    std::string plugin_name = this->getParameter<std::string>("plugin_name");
     plugin_name += "::Plugin";
     follow_reference_plugin_ = loader_->createSharedInstance(plugin_name);
 
@@ -140,13 +131,13 @@ bool FollowReferenceBehavior::process_goal(
 
   new_goal.max_speed_x = (goal->max_speed_x != 0.0f) ?
     goal->max_speed_x :
-    this->get_parameter("follow_reference_max_speed_x").as_double();
+    this->getParameter<double>("follow_reference_max_speed_x");
   new_goal.max_speed_y = (goal->max_speed_y != 0.0f) ?
     goal->max_speed_y :
-    this->get_parameter("follow_reference_max_speed_y").as_double();
+    this->getParameter<double>("follow_reference_max_speed_y");
   new_goal.max_speed_z = (goal->max_speed_z != 0.0f) ?
     goal->max_speed_z :
-    this->get_parameter("follow_reference_max_speed_z").as_double();
+    this->getParameter<double>("follow_reference_max_speed_z");
 
   return true;
 }

--- a/as2_behaviors/as2_behaviors_motion/go_to_behavior/src/go_to_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_motion/go_to_behavior/src/go_to_behavior.cpp
@@ -42,33 +42,6 @@ GoToBehavior::GoToBehavior(const rclcpp::NodeOptions & options)
     as2_names::actions::behaviors::gotowaypoint,
     options)
 {
-  try {
-    this->declare_parameter<std::string>("plugin_name");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <plugin_name> not defined or malformed: %s",
-      e.what());
-    this->~GoToBehavior();
-  }
-  try {
-    this->declare_parameter<double>("go_to_speed");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <go_to_speed> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~GoToBehavior();
-  }
-  try {
-    this->declare_parameter<double>("go_to_threshold");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <go_to_threshold> not defined or malformed: %s", e.what());
-    this->~GoToBehavior();
-  }
-
   loader_ = std::make_shared<pluginlib::ClassLoader<go_to_base::GoToBase>>(
     "as2_behaviors_motion",
     "go_to_base::GoToBase");
@@ -76,13 +49,13 @@ GoToBehavior::GoToBehavior(const rclcpp::NodeOptions & options)
   tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
 
   try {
-    std::string plugin_name = this->get_parameter("plugin_name").as_string();
+    std::string plugin_name = this->getParameter<std::string>("plugin_name");
     plugin_name += "::Plugin";
     go_to_plugin_ = loader_->createSharedInstance(plugin_name);
 
     go_to_base::go_to_plugin_params params;
-    params.go_to_speed = this->get_parameter("go_to_speed").as_double();
-    params.go_to_threshold = this->get_parameter("go_to_threshold").as_double();
+    params.go_to_speed = this->getParameter<double>("go_to_speed");
+    params.go_to_threshold = this->getParameter<double>("go_to_threshold");
 
     go_to_plugin_->initialize(this, tf_handler_, params);
 
@@ -161,7 +134,7 @@ bool GoToBehavior::process_goal(
   new_goal.yaw.angle = as2::frame::getYawFromQuaternion(q.quaternion);
 
   new_goal.max_speed =
-    (goal->max_speed != 0.0f) ? goal->max_speed : this->get_parameter("go_to_speed").as_double();
+    (goal->max_speed != 0.0f) ? goal->max_speed : this->getParameter<double>("go_to_speed");
 
   return true;
 }

--- a/as2_behaviors/as2_behaviors_motion/land_behavior/include/land_behavior/land_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_motion/land_behavior/include/land_behavior/land_behavior.hpp
@@ -90,6 +90,8 @@ public:
 
 private:
   std::string base_link_frame_id_;
+  // Default speed [m/s] applied when a goal leaves land_speed at zero
+  double default_land_speed_ = 0.0;
   std::shared_ptr<pluginlib::ClassLoader<land_base::LandBase>> loader_;
   std::shared_ptr<land_base::LandBase> land_plugin_;
   std::shared_ptr<as2::tf::TfHandler> tf_handler_;

--- a/as2_behaviors/as2_behaviors_motion/land_behavior/plugins/land_plugin_position.cpp
+++ b/as2_behaviors/as2_behaviors_motion/land_behavior/plugins/land_plugin_position.cpp
@@ -80,27 +80,24 @@ public:
     // Target z (m, earth frame) for the position reference. Should be well
     // below the ground (e.g. -10 m) so that the platform keeps descending
     // until ground contact stops it.
-    node_ptr_->declare_parameter<double>("land_height");
-    node_ptr_->get_parameter("land_height", land_height_);
+    land_height_ = node_ptr_->getParameter<double>("land_height");
 
     // Fraction of |land_speed| used as the |vz| threshold of the
     // finish-condition: velocity_threshold_ = |land_speed| * pct. The
     // smaller, the stricter "stopped descending" is interpreted.
-    node_ptr_->declare_parameter<double>("land_speed_condition_percentage");
-    node_ptr_->get_parameter("land_speed_condition_percentage", land_speed_condition_percentage_);
+    land_speed_condition_percentage_ = node_ptr_->getParameter<double>(
+      "land_speed_condition_percentage");
 
     // Minimum descended height (m) from activation. The finish condition
     // requires the drone to have descended at least this much from its
     // pose at activation, guarding against accepting "no descent" right
     // after the behavior starts (when |vz| has not yet built up).
-    node_ptr_->declare_parameter<double>("land_condition_height");
-    node_ptr_->get_parameter("land_condition_height", land_condition_height_);
+    land_condition_height_ = node_ptr_->getParameter<double>("land_condition_height");
 
     // Time (s) the slow + low conditions must hold continuously to declare
     // the land as finished. The internal timer resets any time either
     // condition fails.
-    node_ptr_->declare_parameter<double>("land_position_condition_time");
-    node_ptr_->get_parameter("land_position_condition_time", land_position_condition_time_);
+    land_position_condition_time_ = node_ptr_->getParameter<double>("land_position_condition_time");
   }
 
   bool own_activate(as2_msgs::action::Land::Goal & _goal) override

--- a/as2_behaviors/as2_behaviors_motion/land_behavior/plugins/land_plugin_speed.cpp
+++ b/as2_behaviors/as2_behaviors_motion/land_behavior/plugins/land_plugin_speed.cpp
@@ -51,12 +51,10 @@ public:
   {
     speed_motion_handler_ = std::make_shared<as2::motionReferenceHandlers::SpeedMotion>(node_ptr_);
 
-    node_ptr_->declare_parameter<double>("land_speed_condition_percentage");
-    node_ptr_->get_parameter("land_speed_condition_percentage", land_speed_condition_percentage_);
-    node_ptr_->declare_parameter<double>("land_condition_height");
-    node_ptr_->get_parameter("land_condition_height", land_condition_height_);
-    node_ptr_->declare_parameter<double>("land_position_condition_time");
-    node_ptr_->get_parameter("land_position_condition_time", land_position_condition_time_);
+    land_speed_condition_percentage_ = node_ptr_->getParameter<double>(
+      "land_speed_condition_percentage");
+    land_condition_height_ = node_ptr_->getParameter<double>("land_condition_height");
+    land_position_condition_time_ = node_ptr_->getParameter<double>("land_position_condition_time");
   }
 
   bool own_activate(as2_msgs::action::Land::Goal & _goal) override

--- a/as2_behaviors/as2_behaviors_motion/land_behavior/plugins/land_plugin_trajectory.cpp
+++ b/as2_behaviors/as2_behaviors_motion/land_behavior/plugins/land_plugin_trajectory.cpp
@@ -59,14 +59,11 @@ class Plugin : public land_base::LandBase
 public:
   void ownInit()
   {
-    node_ptr_->declare_parameter<double>("land_speed_condition_percentage");
-    node_ptr_->get_parameter("land_speed_condition_percentage", land_speed_condition_percentage_);
-    node_ptr_->declare_parameter<double>("land_condition_height");
-    node_ptr_->get_parameter("land_condition_height", land_condition_height_);
-    node_ptr_->declare_parameter<double>("land_height");
-    node_ptr_->get_parameter("land_height", land_height_);
-    node_ptr_->declare_parameter<double>("land_position_condition_time");
-    node_ptr_->get_parameter("land_position_condition_time", land_position_condition_time_);
+    land_speed_condition_percentage_ = node_ptr_->getParameter<double>(
+      "land_speed_condition_percentage");
+    land_condition_height_ = node_ptr_->getParameter<double>("land_condition_height");
+    land_height_ = node_ptr_->getParameter<double>("land_height");
+    land_position_condition_time_ = node_ptr_->getParameter<double>("land_position_condition_time");
 
     traj_gen_client_ = rclcpp_action::create_client<TrajectoryGeneratorAction>(
       node_ptr_, as2_names::actions::behaviors::trajectorygenerator);

--- a/as2_behaviors/as2_behaviors_motion/land_behavior/src/land_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_motion/land_behavior/src/land_behavior.cpp
@@ -41,27 +41,6 @@ LandBehavior::LandBehavior(const rclcpp::NodeOptions & options)
 : as2_behavior::BehaviorServer<as2_msgs::action::Land>(as2_names::actions::behaviors::land,
     options)
 {
-  try {
-    this->declare_parameter<std::string>("plugin_name");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <plugin_name> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~LandBehavior();
-  }
-  try {
-    this->declare_parameter<double>("land_speed");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <land_speed> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~LandBehavior();
-  }
-
   loader_ = std::make_shared<pluginlib::ClassLoader<land_base::LandBase>>(
     "as2_behaviors_motion",
     "land_base::LandBase");
@@ -69,12 +48,13 @@ LandBehavior::LandBehavior(const rclcpp::NodeOptions & options)
   tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
 
   try {
-    std::string plugin_name = this->get_parameter("plugin_name").as_string();
+    std::string plugin_name = this->getParameter<std::string>("plugin_name");
     plugin_name += "::Plugin";
     land_plugin_ = loader_->createSharedInstance(plugin_name);
 
     land_base::land_plugin_params params;
-    params.land_speed = this->get_parameter("land_speed").as_double();
+    default_land_speed_ = this->getParameter<double>("land_speed");
+    params.land_speed = default_land_speed_;
 
     land_plugin_->initialize(this, tf_handler_, params);
     RCLCPP_INFO(this->get_logger(), "LAND BEHAVIOR PLUGIN LOADED: %s", plugin_name.c_str());
@@ -143,7 +123,7 @@ bool LandBehavior::process_goal(
 {
   new_goal.land_speed = (goal->land_speed != 0.0f) ?
     -fabs(goal->land_speed) :
-    -fabs(this->get_parameter("land_speed").as_double());
+    -fabs(default_land_speed_);
 
   if (!sendEventFSME(PSME::LAND)) {
     RCLCPP_ERROR(this->get_logger(), "LandBehavior: Could not set FSM to land");

--- a/as2_behaviors/as2_behaviors_motion/takeoff_behavior/include/takeoff_behavior/takeoff_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_motion/takeoff_behavior/include/takeoff_behavior/takeoff_behavior.hpp
@@ -88,6 +88,8 @@ public:
 
 private:
   std::string base_link_frame_id_;
+  // Default speed [m/s] applied when a goal leaves takeoff_speed at zero
+  double default_takeoff_speed_ = 0.0;
   std::shared_ptr<pluginlib::ClassLoader<takeoff_base::TakeoffBase>> loader_;
   std::shared_ptr<takeoff_base::TakeoffBase> takeoff_plugin_;
   std::shared_ptr<as2::tf::TfHandler> tf_handler_;

--- a/as2_behaviors/as2_behaviors_motion/takeoff_behavior/src/takeoff_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_motion/takeoff_behavior/src/takeoff_behavior.cpp
@@ -42,61 +42,21 @@ TakeoffBehavior::TakeoffBehavior(const rclcpp::NodeOptions & options)
     as2_names::actions::behaviors::takeoff,
     options)
 {
-  try {
-    this->declare_parameter<std::string>("plugin_name");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <plugin_name> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~TakeoffBehavior();
-  }
-  try {
-    this->declare_parameter<double>("takeoff_height");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <takeoff_height> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~TakeoffBehavior();
-  }
-  try {
-    this->declare_parameter<double>("takeoff_speed");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <takeoff_speed> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~TakeoffBehavior();
-  }
-  try {
-    this->declare_parameter<double>("takeoff_threshold");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <takeoff_threshold> not defined or "
-      "malformed: %s",
-      e.what());
-    this->~TakeoffBehavior();
-  }
-
   loader_ = std::make_shared<pluginlib::ClassLoader<takeoff_base::TakeoffBase>>(
     "as2_behaviors_motion", "takeoff_base::TakeoffBase");
 
   tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
 
   try {
-    std::string plugin_name = this->get_parameter("plugin_name").as_string();
+    std::string plugin_name = this->getParameter<std::string>("plugin_name");
     plugin_name += "::Plugin";
     takeoff_plugin_ = loader_->createSharedInstance(plugin_name);
 
     takeoff_base::takeoff_plugin_params params;
-    params.takeoff_height = this->get_parameter("takeoff_height").as_double();
-    params.takeoff_speed = this->get_parameter("takeoff_speed").as_double();
-    params.takeoff_threshold = this->get_parameter("takeoff_threshold").as_double();
+    params.takeoff_height = this->getParameter<double>("takeoff_height");
+    default_takeoff_speed_ = this->getParameter<double>("takeoff_speed");
+    params.takeoff_speed = default_takeoff_speed_;
+    params.takeoff_threshold = this->getParameter<double>("takeoff_threshold");
 
     takeoff_plugin_->initialize(this, tf_handler_, params);
 
@@ -155,14 +115,12 @@ bool TakeoffBehavior::process_goal(
   }
 
   if (goal->takeoff_speed < 0.0f) {
-    RCLCPP_WARN(
-      this->get_logger(), "TakeoffBehavior: Invalid takeoff speed, using default: %f",
-      this->get_parameter("takeoff_speed").as_double());
+    RCLCPP_ERROR(this->get_logger(), "TakeoffBehavior: Invalid takeoff speed");
     return false;
   }
   new_goal.takeoff_speed = (goal->takeoff_speed != 0.0f) ?
     goal->takeoff_speed :
-    this->get_parameter("takeoff_speed").as_double();
+    default_takeoff_speed_;
 
   if (!sendEventFSME(PSME::TAKE_OFF)) {
     RCLCPP_ERROR(this->get_logger(), "TakeoffBehavior: Could not set FSM to takeoff");

--- a/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/common/common.hpp
+++ b/as2_behaviors/as2_behaviors_object_perception/include/as2_behaviors_object_perception/common/common.hpp
@@ -94,66 +94,6 @@ inline bool isCompressedTopic(const std::string & topic)
          topic.compare(topic.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
-/**
- * @brief Format a scalar parameter value for logging.
- *
- * @tparam T Parameter type, anything streamable.
- * @param value Value to format.
- * @return Value as text.
- */
-template<typename T>
-std::string paramToString(const T & value)
-{
-  std::ostringstream oss;
-  oss << value;  // For "normal" types (int, double, string, etc.)
-  return oss.str();
-}
-
-// Specialization for std::vector
-/**
- * @brief Format a vector parameter value for logging, as "[a, b, c]".
- *
- * @tparam T Element type, anything streamable.
- * @param vec Vector to format.
- * @return Vector as text.
- */
-template<typename T>
-std::string paramToString(const std::vector<T> & vec)
-{
-  std::ostringstream oss;
-  oss << "[";
-  for (size_t i = 0; i < vec.size(); ++i) {
-    oss << vec[i];
-    if (i + 1 < vec.size()) {
-      oss << ", ";
-    }
-  }
-  oss << "]";
-  return oss.str();
-}
-
-template<typename T>
-T getParameter(as2::Node * node_ptr, const std::string & param_name)
-{
-  T param_value;
-  try {
-    if (!node_ptr->has_parameter(param_name)) {
-      param_value = node_ptr->declare_parameter<T>(param_name);
-    } else {
-      node_ptr->get_parameter(param_name, param_value);
-    }
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      node_ptr->get_logger(), "Launch argument <%s> not defined or malformed: %s",
-      param_name.c_str(), e.what());
-    node_ptr->~Node();
-  }
-
-  const std::string value_str = paramToString(param_value);
-  RCLCPP_INFO(node_ptr->get_logger(), "%s = %s", param_name.c_str(), value_str.c_str());
-  return param_value;
-}
-
 // Thread-safe queue with max size
 template<typename T>
 class MutexQueue
@@ -176,7 +116,7 @@ public:
     size_t default_size = 10)
   {
     std::string param_name = param_base_name + "_queue_size";
-    int size_param = getParameter<int>(node_ptr, param_name);
+    int size_param = node_ptr->getParameter<int>(param_name);
     max_size_ = (size_param > 0) ? static_cast<size_t>(size_param) : default_size;
   }
 
@@ -283,7 +223,7 @@ public:
   {
     // Load timer frequency
     std::string freq_param = param_base_name + ".timer_frequency_hz";
-    double frequency_hz = getParameter<double>(node_ptr_, freq_param);
+    double frequency_hz = node_ptr_->getParameter<double>(freq_param);
     if (frequency_hz <= 0.0) {
       frequency_hz = 100.0;
     }

--- a/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/src/aruco.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/plugins/aruco/src/aruco.cpp
@@ -91,24 +91,20 @@ cv::aruco::CornerRefineMethod Plugin::refineMethodFromString(const std::string &
 
 void Plugin::ownInit()
 {
-  const std::string dict_id =
-    node_ptr_->declare_parameter<std::string>("aruco.tag_dict", "6x6_250");
+  const std::string dict_id = node_ptr_->getParameter<std::string>("aruco.tag_dict", "6x6_250");
   tag_dict_name_ = dict_id;
-  marker_size_ =
-    node_ptr_->declare_parameter<double>("aruco.marker_size", 0.1);
-  estimate_pose_ =
-    node_ptr_->declare_parameter<bool>("aruco.estimate_pose", true);
-
-  node_ptr_->get_parameter_or("enable_rectification", enable_rectification_, false);
+  marker_size_ = node_ptr_->getParameter<double>("aruco.marker_size", 0.1);
+  estimate_pose_ = node_ptr_->getParameter<bool>("aruco.estimate_pose", true);
+  enable_rectification_ = node_ptr_->getParameter<bool>("enable_rectification", false);
 
   const std::string corner_refinement =
-    node_ptr_->declare_parameter<std::string>("aruco.corner_refinement", "subpix");
+    node_ptr_->getParameter<std::string>("aruco.corner_refinement", "subpix");
   const int thresh_win_min =
-    node_ptr_->declare_parameter<int>("aruco.adaptive_thresh_win_size_min", 3);
+    node_ptr_->getParameter<int>("aruco.adaptive_thresh_win_size_min", 3);
   const int thresh_win_max =
-    node_ptr_->declare_parameter<int>("aruco.adaptive_thresh_win_size_max", 23);
+    node_ptr_->getParameter<int>("aruco.adaptive_thresh_win_size_max", 23);
   const int thresh_win_step =
-    node_ptr_->declare_parameter<int>("aruco.adaptive_thresh_win_size_step", 10);
+    node_ptr_->getParameter<int>("aruco.adaptive_thresh_win_size_step", 10);
 
 #if AS2_ARUCO_HAS_DETECTOR_CLASS
   cv::aruco::DetectorParameters detector_params;

--- a/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
+++ b/as2_behaviors/as2_behaviors_object_perception/src/as2_behaviors_object_perception.cpp
@@ -58,58 +58,33 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
 {
   const std::string ns = this->get_namespace();
 
-  try {
-    use_embedded_camera = this->declare_parameter<bool>("use_embedded_camera");
-    if (use_embedded_camera) {
-      RCLCPP_INFO(
-        this->get_logger(),
-        "Images will be captured directly from the camera device by this node "
-        "(use_embedded_camera is true), not read from a topic");
-    } else {
-      const auto camera_image_topic_param =
-        this->declare_parameter<std::string>("camera_image_topic");
-      camera_image_topic_ = as2_behaviors_object_perception::getNamespacedTopic(
-        ns, camera_image_topic_param);
-    }
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
+  use_embedded_camera = this->getParameter<bool>("use_embedded_camera");
+  if (use_embedded_camera) {
+    RCLCPP_INFO(
       this->get_logger(),
-      "Launch argument <camera_image_topic> malformed: %s", e.what());
-    throw;
+      "Images will be captured directly from the camera device by this node "
+      "(use_embedded_camera is true), not read from a topic");
+  } else {
+    camera_image_topic_ = as2_behaviors_object_perception::getNamespacedTopic(
+      ns, this->getParameter<std::string>("camera_image_topic"));
   }
 
-  try {
-    const auto camera_info_topic_param =
-      this->declare_parameter<std::string>("camera_info_topic", "");
-    if (!camera_info_topic_param.empty()) {
-      camera_info_topic_ = as2_behaviors_object_perception::getNamespacedTopic(
-        ns,
-        camera_info_topic_param);
-    }
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(),
-      "Launch argument <camera_info_topic> not defined or malformed: %s", e.what());
-    throw;
+  const auto camera_info_topic_param = this->getParameter<std::string>("camera_info_topic", "");
+  if (!camera_info_topic_param.empty()) {
+    camera_info_topic_ = as2_behaviors_object_perception::getNamespacedTopic(
+      ns, camera_info_topic_param);
   }
 
-  try {
-    persistent_ = this->declare_parameter<bool>("persistent");
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <persistent> not defined or malformed: %s", e.what());
-    throw;
-  }
+  persistent_ = this->getParameter<bool>("persistent");
 
-  bool enable_rectification =
-    this->declare_parameter<bool>("enable_rectification", false);
+  const bool enable_rectification = this->getParameter<bool>("enable_rectification", false);
   preprocessor_.setRectificationEnabled(enable_rectification);
 
   // Rectification changes the effective intrinsics, so downstream PnP/pose
   // estimation needs the new K. Only makes sense when rectifying, and it is
   // opt-in: an empty topic (the default) disables it.
   const auto rectified_camera_info_topic_param =
-    this->declare_parameter<std::string>("rectified_camera_info_topic", "");
+    this->getParameter<std::string>("rectified_camera_info_topic", "");
   if (enable_rectification && !rectified_camera_info_topic_param.empty()) {
     rectified_camera_info_topic_ = as2_behaviors_object_perception::getNamespacedTopic(
       ns, rectified_camera_info_topic_param);
@@ -168,8 +143,7 @@ ObjectPerceptionBehavior::ObjectPerceptionBehavior(const rclcpp::NodeOptions & o
 
 void ObjectPerceptionBehavior::loadPipeline()
 {
-  const auto stage_names =
-    this->declare_parameter<std::vector<std::string>>(
+  const auto stage_names = this->getParameter<std::vector<std::string>>(
     "pipeline.stages", std::vector<std::string>{});
 
   if (stage_names.empty()) {
@@ -190,17 +164,17 @@ ObjectPerceptionBehavior::PipelineStage ObjectPerceptionBehavior::loadStage(
   const std::string prefix = "pipeline." + stage_name + ".";
   PipelineStage stage;
   stage.name = stage_name;
-  stage.plugin_name = this->declare_parameter<std::string>(prefix + "plugin");
-  stage.input_source = this->declare_parameter<std::string>(prefix + "input_source", "internal");
-  stage.input_stage = this->declare_parameter<std::string>(prefix + "input_stage", "");
+  stage.plugin_name = this->getParameter<std::string>(prefix + "plugin");
+  stage.input_source = this->getParameter<std::string>(prefix + "input_source", "internal");
+  stage.input_stage = this->getParameter<std::string>(prefix + "input_stage", "");
   stage.input_topic = as2_behaviors_object_perception::getNamespacedTopic(
-    this->get_namespace(), this->declare_parameter<std::string>(prefix + "input_topic", ""));
+    this->get_namespace(), this->getParameter<std::string>(prefix + "input_topic", ""));
   stage.output_topic = as2_behaviors_object_perception::getNamespacedTopic(
-    this->get_namespace(), this->declare_parameter<std::string>(prefix + "output_topic", ""));
-  stage.publish_output = this->declare_parameter<bool>(prefix + "publish_output", false);
-  stage.enable_debug = this->declare_parameter<bool>(prefix + "enable_debug", false);
+    this->get_namespace(), this->getParameter<std::string>(prefix + "output_topic", ""));
+  stage.publish_output = this->getParameter<bool>(prefix + "publish_output", false);
+  stage.enable_debug = this->getParameter<bool>(prefix + "enable_debug", false);
   stage.debug_poses_topic = as2_behaviors_object_perception::getNamespacedTopic(
-    this->get_namespace(), this->declare_parameter<std::string>(prefix + "debug_poses_topic", ""));
+    this->get_namespace(), this->getParameter<std::string>(prefix + "debug_poses_topic", ""));
 
   const std::string full_plugin_name = stage.plugin_name + "::Plugin";
   stage.plugin = detection_loader_.createSharedInstance(full_plugin_name);

--- a/as2_behaviors/as2_behaviors_param_estimation/force_estimation_behavior/src/force_estimation_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_param_estimation/force_estimation_behavior/src/force_estimation_behavior.cpp
@@ -41,26 +41,26 @@ ForceEstimationBehavior::ForceEstimationBehavior(const rclcpp::NodeOptions & opt
     "ForceEstimationBehavior", options)
 {
   // Read parameters
-  controler_node_ = this->declare_parameter<std::string>("controller_node");
-  force_param_name_ = this->declare_parameter<std::string>("force_param_name");
-  mass_param_name_ = this->declare_parameter<std::string>("mass_param_name");
-  alpha_ = this->declare_parameter<double>("alpha");
-  n_samples_ = this->declare_parameter<int>("n_samples");
-  last_filtered_error_ = this->declare_parameter<double>("initial_force_error");
-  threshold_time_sync = this->declare_parameter<double>("threshold_time_sync");
-  fz_filtered_error_ = this->declare_parameter<double>("fz_filtered_error");
-  fz_update_error = this->declare_parameter<double>("fz_update_error");
-  minimum_error_ = this->declare_parameter<double>("minimum_error");
-  maximum_error_ = this->declare_parameter<double>("maximum_error");
-  default_mass = this->declare_parameter<double>("default_mass");
+  controler_node_ = this->getParameter<std::string>("controller_node");
+  force_param_name_ = this->getParameter<std::string>("force_param_name");
+  mass_param_name_ = this->getParameter<std::string>("mass_param_name");
+  alpha_ = this->getParameter<double>("alpha");
+  n_samples_ = this->getParameter<int>("n_samples");
+  last_filtered_error_ = this->getParameter<double>("initial_force_error");
+  threshold_time_sync = this->getParameter<double>("threshold_time_sync");
+  fz_filtered_error_ = this->getParameter<double>("fz_filtered_error");
+  fz_update_error = this->getParameter<double>("fz_update_error");
+  minimum_error_ = this->getParameter<double>("minimum_error");
+  maximum_error_ = this->getParameter<double>("maximum_error");
+  default_mass = this->getParameter<double>("default_mass");
   // Debug parameters
-  force_error_topic_ = this->declare_parameter<std::string>("debug.force_error_topic");
+  force_error_topic_ = this->getParameter<std::string>("debug.force_error_topic");
   force_filtered_error_topic_ =
-    this->declare_parameter<std::string>("debug.force_filtered_error_topic");
+    this->getParameter<std::string>("debug.force_filtered_error_topic");
   force_update_error_topic_ =
-    this->declare_parameter<std::string>("debug.force_update_error_topic");
+    this->getParameter<std::string>("debug.force_update_error_topic");
   force_limited_error_topic_ =
-    this->declare_parameter<std::string>("debug.force_limited_error_topic");
+    this->getParameter<std::string>("debug.force_limited_error_topic");
 
   threshold_time_sync_ = rclcpp::Duration::from_seconds(threshold_time_sync);
   published_force_error_ = 1.0 / fz_update_error;

--- a/as2_behaviors/as2_behaviors_param_estimation/mass_estimation_behavior/src/mass_estimation_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_param_estimation/mass_estimation_behavior/src/mass_estimation_behavior.cpp
@@ -41,10 +41,10 @@ MassEstimationBehavior::MassEstimationBehavior(const rclcpp::NodeOptions & optio
 : as2_behavior::BehaviorServer<as2_msgs::action::MassEstimation>(
     "MassEstimationBehavior", options)
 {
-  mass_threshold_ = this->declare_parameter<double>("mass_threshold");
-  thrust_threshold_ = this->declare_parameter<double>("thrust_threshold");
-  alpha_ = this->declare_parameter<double>("alpha");
-  int n_samples = this->declare_parameter<int>("n_samples");
+  mass_threshold_ = this->getParameter<double>("mass_threshold");
+  thrust_threshold_ = this->getParameter<double>("thrust_threshold");
+  alpha_ = this->getParameter<double>("alpha");
+  int n_samples = this->getParameter<int>("n_samples");
   if (n_samples > 0) {
     n_samples_ = static_cast<size_t>(n_samples);
   } else {
@@ -52,25 +52,25 @@ MassEstimationBehavior::MassEstimationBehavior(const rclcpp::NodeOptions & optio
       this->get_logger(), "n_samples parameter must be a positive integer. Setting to 1.");
     n_samples_ = 1;
   }
-  double mass_fz = this->declare_parameter<double>("mass_fz");
+  double mass_fz = this->getParameter<double>("mass_fz");
   if (mass_fz <= 0) {
     RCLCPP_WARN(
       this->get_logger(), "mass_fz parameter must be a positive number. Setting to 1 Hz.");
     mass_fz = 1.0;
   }
   mass_publish_interval_ = 1.0 / mass_fz;
-  minimum_mass_ = this->declare_parameter<double>("minimum_mass");
-  maximum_mass_ = this->declare_parameter<double>("maximum_mass");
+  minimum_mass_ = this->getParameter<double>("minimum_mass");
+  maximum_mass_ = this->getParameter<double>("maximum_mass");
 
-  controler_node_ = this->declare_parameter<std::string>("controller_node");
-  mass_param_name_ = this->declare_parameter<std::string>("mass_param_name");
-  initial_mass_ = this->declare_parameter<double>("initial_mass");
-  mass_estimation_topic_ = this->declare_parameter<std::string>(
+  controler_node_ = this->getParameter<std::string>("controller_node");
+  mass_param_name_ = this->getParameter<std::string>("mass_param_name");
+  initial_mass_ = this->getParameter<double>("initial_mass");
+  mass_estimation_topic_ = this->getParameter<std::string>(
     "debug.mass_estimation_topic", "");
-  mass_filtered_topic_ = this->declare_parameter<std::string>(
+  mass_filtered_topic_ = this->getParameter<std::string>(
     "debug.mass_filtered_topic", "");
 
-  mass_update_topic_ = this->declare_parameter<std::string>(
+  mass_update_topic_ = this->getParameter<std::string>(
     "debug.mass_update_topic", "");
 
   // Info all params

--- a/as2_behaviors/as2_behaviors_path_planning/plugins/a_star/src/a_star.cpp
+++ b/as2_behaviors/as2_behaviors_path_planning/plugins/a_star/src/a_star.cpp
@@ -47,13 +47,13 @@ void Plugin::initialize(as2::Node * node_ptr, std::shared_ptr<tf2_ros::Buffer> t
   RCLCPP_INFO(node_ptr_->get_logger(), "Initializing A* plugin");
 
   // node_ptr_->declare_parameter("safety_distance", 0.5);
-  safety_distance_ = node_ptr_->get_parameter("safety_distance").as_double();
+  safety_distance_ = node_ptr_->getParameter<double>("safety_distance");
 
   // node_ptr_->declare_parameter("enable_path_optimizer", false);
-  enable_path_optimizer_ = node_ptr_->get_parameter("enable_path_optimizer").as_bool();
+  enable_path_optimizer_ = node_ptr_->getParameter<bool>("enable_path_optimizer");
 
   // node_ptr_->declare_parameter("enable_visualization", true);
-  enable_visualization_ = node_ptr_->get_parameter("enable_visualization").as_bool();
+  enable_visualization_ = node_ptr_->getParameter<bool>("enable_visualization");
   enable_visualization_ = true;  // TODO(pariaspe): not publish when false
 
   occ_grid_sub_ = node_ptr_->create_subscription<nav_msgs::msg::OccupancyGrid>(

--- a/as2_behaviors/as2_behaviors_path_planning/plugins/voronoi/src/voronoi.cpp
+++ b/as2_behaviors/as2_behaviors_path_planning/plugins/voronoi/src/voronoi.cpp
@@ -53,7 +53,7 @@ void Plugin::initialize(as2::Node * node_ptr, std::shared_ptr<tf2_ros::Buffer> t
   RCLCPP_INFO(node_ptr_->get_logger(), "Initializing Voronoi plugin");
 
   // node_ptr_->declare_parameter("enable_visualization", true);
-  enable_visualization_ = node_ptr_->get_parameter("enable_visualization").as_bool();
+  enable_visualization_ = node_ptr_->getParameter<bool>("enable_visualization");
   enable_visualization_ = true;  // TODO(pariaspe): not publish when false
 
   occ_grid_sub_ = node_ptr_->create_subscription<nav_msgs::msg::OccupancyGrid>(

--- a/as2_behaviors/as2_behaviors_path_planning/src/path_planner_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_path_planning/src/path_planner_behavior.cpp
@@ -40,25 +40,11 @@
 PathPlannerBehavior::PathPlannerBehavior(const rclcpp::NodeOptions & options)
 : as2_behavior::BehaviorServer<as2_msgs::action::NavigateToPoint>("path_planner", options)
 {
-  try {
-    this->declare_parameter("plugin_name", "a_star");
-    this->get_parameter("plugin_name", plugin_name_);
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <plugin_name> not defined or malformed: %s",
-      e.what());
-    this->~PathPlannerBehavior();
-  }
-
-  this->declare_parameter("enable_visualization", false);
-  enable_visualization_ = this->get_parameter("enable_visualization").as_bool();
-
-  this->declare_parameter("enable_path_optimizer", false);
-  enable_path_optimizer_ = this->get_parameter("enable_path_optimizer").as_bool();
-
+  plugin_name_ = this->getParameter<std::string>("plugin_name", "a_star");
+  enable_visualization_ = this->getParameter<bool>("enable_visualization", false);
+  enable_path_optimizer_ = this->getParameter<bool>("enable_path_optimizer", false);
   // TODO(pariaspe): move to action_goal
-  this->declare_parameter("safety_distance", 1.0);  // aprox drone size [m]
-  safety_distance_ = this->get_parameter("safety_distance").as_double();
+  safety_distance_ = this->getParameter<double>("safety_distance", 1.0);  // aprox drone size [m]
 
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);

--- a/as2_behaviors/as2_behaviors_payload/gripper_behavior/plugins/dc_servo/src/dc_servo.cpp
+++ b/as2_behaviors/as2_behaviors_payload/gripper_behavior/plugins/dc_servo/src/dc_servo.cpp
@@ -42,12 +42,12 @@ namespace dc_servo
 
 void Plugin::ownInit()
 {
-  angle_to_open_ = node_ptr_->declare_parameter<double>("angle_to_open", 45.0);
-  angle_to_close_ = node_ptr_->declare_parameter<double>("angle_to_close", 62.0);
-  max_angle_ = node_ptr_->declare_parameter<double>("max_angle", 180.0);
-  duty_min_ = node_ptr_->declare_parameter<double>("duty_min", 2.5);
-  duty_max_ = node_ptr_->declare_parameter<double>("duty_max", 12.5);
-  topic_pwm_ = node_ptr_->declare_parameter<std::string>("topic_pwm", "gripper_pwm");
+  angle_to_open_ = node_ptr_->getParameter<double>("angle_to_open", 45.0);
+  angle_to_close_ = node_ptr_->getParameter<double>("angle_to_close", 62.0);
+  max_angle_ = node_ptr_->getParameter<double>("max_angle", 180.0);
+  duty_min_ = node_ptr_->getParameter<double>("duty_min", 2.5);
+  duty_max_ = node_ptr_->getParameter<double>("duty_max", 12.5);
+  topic_pwm_ = node_ptr_->getParameter<std::string>("topic_pwm", "gripper_pwm");
   cbk_group_ = node_ptr_->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
   pub_options.callback_group = cbk_group_;

--- a/as2_behaviors/as2_behaviors_payload/gripper_behavior/plugins/two_fingers/src/two_fingers.cpp
+++ b/as2_behaviors/as2_behaviors_payload/gripper_behavior/plugins/two_fingers/src/two_fingers.cpp
@@ -42,13 +42,13 @@ namespace two_fingers
 
 void Plugin::ownInit()
 {
-  l_finger_open_ = node_ptr_->declare_parameter<double>("l_finger_open", 1.0);
-  r_finger_open_ = node_ptr_->declare_parameter<double>("r_finger_open", -1.0);
-  l_finger_close_ = node_ptr_->declare_parameter<double>("l_finger_close", 0.0);
-  r_finger_close_ = node_ptr_->declare_parameter<double>("r_finger_close", 0.0);
-  topic_l_finger_ = node_ptr_->declare_parameter<std::string>(
+  l_finger_open_ = node_ptr_->getParameter<double>("l_finger_open", 1.0);
+  r_finger_open_ = node_ptr_->getParameter<double>("r_finger_open", -1.0);
+  l_finger_close_ = node_ptr_->getParameter<double>("l_finger_close", 0.0);
+  r_finger_close_ = node_ptr_->getParameter<double>("r_finger_close", 0.0);
+  topic_l_finger_ = node_ptr_->getParameter<std::string>(
     "topic_l_finger", "joint/r_gripper_l_finger_joint/cmd_pos");
-  topic_r_finger_ = node_ptr_->declare_parameter<std::string>(
+  topic_r_finger_ = node_ptr_->getParameter<std::string>(
     "topic_r_finger", "joint/r_gripper_r_finger_joint/cmd_pos");
   cbk_group_ = node_ptr_->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);

--- a/as2_behaviors/as2_behaviors_payload/gripper_behavior/src/gripper_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_payload/gripper_behavior/src/gripper_behavior.cpp
@@ -43,9 +43,8 @@ GripperHandlerBehavior::GripperHandlerBehavior(const rclcpp::NodeOptions & optio
 : as2_behavior::BehaviorServer<as2_msgs::action::GripperHandler>(
     "GripperHandlerBehavior", options)
 {
-  std::string plugin_name = this->declare_parameter<std::string>(
-    "plugin_name",
-    "two_fingers");
+  std::string plugin_name = this->getParameter<std::string>(
+    "plugin_name", "two_fingers");
   plugin_name += "::Plugin";
   RCLCPP_INFO(
     this->get_logger(),

--- a/as2_behaviors/as2_behaviors_payload/point_gimbal_behavior/src/point_gimbal_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_payload/point_gimbal_behavior/src/point_gimbal_behavior.cpp
@@ -46,49 +46,37 @@ PointGimbalBehavior::PointGimbalBehavior(const rclcpp::NodeOptions & options)
   tf_handler_(this)
 {
   // Gimbal name to publish commands
-  this->declare_parameter<std::string>("gimbal_name", "gimbal");
-  this->get_parameter("gimbal_name", gimbal_name_);
+  gimbal_name_ = this->getParameter<std::string>("gimbal_name", "gimbal");
 
   gimbal_control_pub_ = this->create_publisher<as2_msgs::msg::GimbalControl>(
     "platform/" + gimbal_name_ + "/gimbal_command", 10);
 
   // Gimbal frame ids to get state
-  this->declare_parameter<std::string>("gimbal_base_frame_id", "gimbal");
-  this->get_parameter("gimbal_base_frame_id", gimbal_base_frame_id_);
-  this->declare_parameter<std::string>("gimbal_frame_id", "gimbal");
-  this->get_parameter("gimbal_frame_id", gimbal_frame_id_);
+  gimbal_base_frame_id_ = this->getParameter<std::string>("gimbal_base_frame_id", "gimbal");
+  gimbal_frame_id_ = this->getParameter<std::string>("gimbal_frame_id", "gimbal");
 
   base_link_frame_id_ = as2::tf::generateTfName(this, "base_link");
   gimbal_base_frame_id_ = as2::tf::generateTfName(this, gimbal_base_frame_id_);
   gimbal_frame_id_ = as2::tf::generateTfName(this, gimbal_frame_id_);
 
   // Gimbal orientation threshold
-  this->declare_parameter<double>("gimbal_threshold", 0.01);
-  this->get_parameter("gimbal_threshold", gimbal_threshold_);
+  gimbal_threshold_ = this->getParameter<double>("gimbal_threshold", 0.01);
 
   // Gimbal limits (default no limits)
-  this->declare_parameter<double>("roll_range.min", -4 * M_PI);
-  this->get_parameter("roll_range.min", gimbal_roll_min_);
-  this->declare_parameter<double>("roll_range.max", 4 * M_PI);
-  this->get_parameter("roll_range.max", gimbal_roll_max_);
-  this->declare_parameter<double>("pitch_range.min", -4 * M_PI);
-  this->get_parameter("pitch_range.min", gimbal_pitch_min_);
-  this->declare_parameter<double>("pitch_range.max", 4 * M_PI);
-  this->get_parameter("pitch_range.max", gimbal_pitch_max_);
-  this->declare_parameter<double>("yaw_range.min", -4 * M_PI);
-  this->get_parameter("yaw_range.min", gimbal_yaw_min_);
-  this->declare_parameter<double>("yaw_range.max", 4 * M_PI);
-  this->get_parameter("yaw_range.max", gimbal_yaw_max_);
+  gimbal_roll_min_ = this->getParameter<double>("roll_range.min", -4 * M_PI);
+  gimbal_roll_max_ = this->getParameter<double>("roll_range.max", 4 * M_PI);
+  gimbal_pitch_min_ = this->getParameter<double>("pitch_range.min", -4 * M_PI);
+  gimbal_pitch_max_ = this->getParameter<double>("pitch_range.max", 4 * M_PI);
+  gimbal_yaw_min_ = this->getParameter<double>("yaw_range.min", -4 * M_PI);
+  gimbal_yaw_max_ = this->getParameter<double>("yaw_range.max", 4 * M_PI);
 
   RCLCPP_INFO(this->get_logger(), "Roll range: %f to %f", gimbal_roll_min_, gimbal_roll_max_);
   RCLCPP_INFO(this->get_logger(), "Pitch range: %f to %f", gimbal_pitch_min_, gimbal_pitch_max_);
   RCLCPP_INFO(this->get_logger(), "Yaw range: %f to %f", gimbal_yaw_min_, gimbal_yaw_max_);
 
   // Timeout
-  this->declare_parameter<double>("behavior_timeout", 10.0);
-  double behavior_timeout;
-  this->get_parameter("behavior_timeout", behavior_timeout);
-  behavior_timeout_ = rclcpp::Duration::from_seconds(behavior_timeout);
+  behavior_timeout_ = rclcpp::Duration::from_seconds(
+    this->getParameter<double>("behavior_timeout", 10.0));
   RCLCPP_INFO(this->get_logger(), "Behavior timeout: %f", behavior_timeout_.seconds());
 
   // Set internal variables frame ids

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_base.hpp
@@ -65,58 +65,6 @@ namespace generate_polynomial_trajectory_behavior_plugin_base
 {
 
 /**
- * @brief Declare (if needed) and read a ROS 2 parameter on the hosting node.
- *
- * @tparam T          Parameter type.
- * @param node_ptr    Node pointer.
- * @param param_name  Fully-qualified parameter name.
- * @param param_value [in] default value used when @p use_default is true,
- *                    [out] read value on success.
- * @param use_default Whether @p param_value is taken as a fallback default.
- */
-template<typename T>
-inline void getParameter(
-  as2::Node * node_ptr, const std::string & param_name,
-  T & param_value, bool use_default = false)
-{
-  try {
-    if (!node_ptr->has_parameter(param_name)) {
-      if (use_default) {
-        node_ptr->declare_parameter<T>(param_name, param_value);
-      } else {
-        node_ptr->declare_parameter<T>(param_name);
-      }
-    }
-
-    if constexpr (std::is_same<T, std::vector<double>>::value) {
-      param_value = node_ptr->get_parameter(param_name).as_double_array();
-    } else if constexpr (std::is_same<T, double>::value) {
-      param_value = node_ptr->get_parameter(param_name).as_double();
-    } else if constexpr (std::is_same<T, std::string>::value) {
-      param_value = node_ptr->get_parameter(param_name).as_string();
-    } else if constexpr (std::is_same<T, bool>::value) {
-      param_value = node_ptr->get_parameter(param_name).as_bool();
-    } else if constexpr (std::is_same<T, int>::value) {
-      param_value =
-        static_cast<int>(node_ptr->get_parameter(param_name).as_int());
-    } else {
-      RCLCPP_WARN(
-        node_ptr->get_logger(),
-        "Parameter type %s not expected; falling back to generic accessor.",
-        typeid(T).name());
-      param_value = node_ptr->get_parameter(param_name).get_value<T>();
-    }
-    RCLCPP_INFO(
-      node_ptr->get_logger(), "Parameter %s: %s", param_name.c_str(),
-      node_ptr->get_parameter(param_name).value_to_string().c_str());
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(
-      node_ptr->get_logger(), "Error getting parameter %s: %s",
-      param_name.c_str(), e.what());
-  }
-}
-
-/**
  * @brief Distance threshold (in metres) under which the host behaviour
  * short-circuits the plugin and publishes a degenerate-hold trajectory:
  * the last waypoint is sent as a static reference with zero velocity and
@@ -375,12 +323,22 @@ protected:
    * @param use_default Whether to declare with default value.
    */
   template<typename T>
-  inline void getParameter(
-    const std::string & param_name, T & param_value,
-    bool use_default = false)
+  T getParameter(const std::string & param_name, const T & default_value)
   {
-    generate_polynomial_trajectory_behavior_plugin_base::getParameter(
-      node_ptr_, qualifyParameterName(param_name), param_value, use_default);
+    return node_ptr_->getParameter<T>(qualifyParameterName(param_name), default_value);
+  }
+
+  /**
+   * @brief Read a required parameter of this plugin, qualified with its name.
+   *
+   * @tparam T Parameter type.
+   * @param param_name Parameter name, without the plugin namespace.
+   * @return Value of the parameter.
+   */
+  template<typename T>
+  T getParameter(const std::string & param_name)
+  {
+    return node_ptr_->getParameter<T>(qualifyParameterName(param_name));
   }
 
   /**

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/include/generate_polynomial_trajectory_behavior/generate_polynomial_trajectory_behavior.hpp
@@ -167,24 +167,6 @@ private:
   // Utils and internal methods.
 
   /**
-   * @brief Read parameter through shared helper.
-   *
-   * @tparam T Parameter type.
-   * @param param_name Parameter name.
-   * @param param_value [in] default value when @p use_default is true,
-   *                    [out] read value.
-   * @param use_default Whether to use @p param_value as default.
-   */
-  template<typename T>
-  inline void getParameter(
-    const std::string & param_name, T & param_value,
-    bool use_default = false)
-  {
-    generate_polynomial_trajectory_behavior_plugin_base::getParameter(
-      this, param_name, param_value, use_default);
-  }
-
-  /**
    * @brief Load trajectory generation plugin.
    */
   void loadPlugin();

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/src/dynamic_mav_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/src/dynamic_mav_trajectory_generator.cpp
@@ -69,8 +69,8 @@ void Plugin::ownInitialize()
     });
 
   // Low-speed segment factors
-  getParameter<double>("ls_velocity_factor", ls_velocity_factor_, true);
-  getParameter<double>("ls_acceleration_factor", ls_acceleration_factor_, true);
+  ls_velocity_factor_ = getParameter<double>("ls_velocity_factor", ls_velocity_factor_);
+  ls_acceleration_factor_ = getParameter<double>("ls_acceleration_factor", ls_acceleration_factor_);
   RCLCPP_INFO(
     getNodePtr()->get_logger(),
     "Low-speed factors: v_factor=%.2f, a_factor=%.2f",

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/dynamic_mav_trajectory_generator_gtest.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/dynamic_mav_trajectory_generator/tests/dynamic_mav_trajectory_generator_gtest.cpp
@@ -234,8 +234,7 @@ TEST(GetParameter, with_default_and_override) {
   TestParameterPlugin plugin;
   plugin.initialize(node.get(), "test_plugin");
 
-  double value = 0.25;
-  plugin.getParameter("test_param_double", value, true);
+  const double value = plugin.getParameter<double>("test_param_double", 0.25);
   EXPECT_DOUBLE_EQ(value, 1.5);
   EXPECT_TRUE(node->has_parameter("test_plugin.test_param_double"));
 }
@@ -247,8 +246,7 @@ TEST(GetParameter, with_default_no_override_keeps_default) {
   TestParameterPlugin plugin;
   plugin.initialize(node.get(), "test_plugin");
 
-  double value = 0.25;
-  plugin.getParameter("test_param_double", value, true);
+  const double value = plugin.getParameter<double>("test_param_double", 0.25);
   EXPECT_DOUBLE_EQ(value, 0.25);
   EXPECT_TRUE(node->has_parameter("test_plugin.test_param_double"));
 }
@@ -264,22 +262,22 @@ TEST(GetParameter, required_with_override) {
   TestParameterPlugin plugin;
   plugin.initialize(node.get(), "test_plugin");
 
-  std::string value;
-  plugin.getParameter("required_string", value, false);
+  const std::string value = plugin.getParameter<std::string>("required_string");
   EXPECT_EQ(value, "provided");
   EXPECT_TRUE(node->has_parameter("test_plugin.required_string"));
 }
 
-TEST(GetParameter, required_no_override_logs_error) {
+TEST(GetParameter, required_no_override_throws) {
   rclcpp::NodeOptions options;
   auto node =
     std::make_shared<as2::Node>("get_param_required_no_override", options);
   TestParameterPlugin plugin;
   plugin.initialize(node.get(), "test_plugin");
 
-  std::string value = "untouched";
-  plugin.getParameter("missing_required", value, false);
-  EXPECT_EQ(value, "untouched");
+  // A required parameter nothing provides aborts the node
+  EXPECT_ANY_THROW(plugin.getParameter<std::string>("missing_required"));
+  // rclcpp leaves it declared, statically typed and uninitialized
+  EXPECT_TRUE(node->has_parameter("test_plugin.missing_required"));
 }
 
 TEST(GetParameter, unsupported_type_falls_back_to_generic) {
@@ -295,8 +293,7 @@ TEST(GetParameter, unsupported_type_falls_back_to_generic) {
   TestParameterPlugin plugin;
   plugin.initialize(node.get(), "test_plugin");
 
-  int64_t value = 0;
-  plugin.getParameter("test_param_int64", value, true);
+  const int64_t value = plugin.getParameter<int64_t>("test_param_int64", 0);
   EXPECT_EQ(value, static_cast<int64_t>(42));
   EXPECT_TRUE(node->has_parameter("test_plugin.test_param_int64"));
 }

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/src/gcopter_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/gcopter_trajectory_generator/src/gcopter_trajectory_generator.cpp
@@ -63,13 +63,14 @@ void Plugin::readConfigParameters()
   params.vertical_drag = 0.1;
   params.parasitic_drag = 0.01;
   params.speed_smooth_factor = 0.01;
-  getParameter<double>("drone.mass", params.mass, true);
-  getParameter<double>("drone.gravity", params.gravity, true);
-  getParameter<double>("drone.horizontal_drag", params.horizontal_drag, true);
-  getParameter<double>("drone.vertical_drag", params.vertical_drag, true);
-  getParameter<double>("drone.parasitic_drag", params.parasitic_drag, true);
-  getParameter<double>(
-    "drone.speed_smooth_factor", params.speed_smooth_factor, true);
+  params.mass = getParameter<double>("drone.mass", params.mass);
+  params.gravity = getParameter<double>("drone.gravity", params.gravity);
+  params.horizontal_drag = getParameter<double>("drone.horizontal_drag", params.horizontal_drag);
+  params.vertical_drag = getParameter<double>("drone.vertical_drag", params.vertical_drag);
+  params.parasitic_drag = getParameter<double>("drone.parasitic_drag", params.parasitic_drag);
+  params.speed_smooth_factor = getParameter<double>(
+    "drone.speed_smooth_factor",
+    params.speed_smooth_factor);
 
   auto & limits = generator_config_.limits;
   limits.max_velocity = 5.0;
@@ -77,35 +78,33 @@ void Plugin::readConfigParameters()
   limits.max_tilt_angle = 0.785;
   limits.min_thrust = 0.1;
   limits.max_thrust = 30.0;
-  getParameter<double>("limits.max_velocity", limits.max_velocity, true);
-  getParameter<double>("limits.max_body_rate", limits.max_body_rate, true);
-  getParameter<double>("limits.max_tilt_angle", limits.max_tilt_angle, true);
-  getParameter<double>("limits.min_thrust", limits.min_thrust, true);
-  getParameter<double>("limits.max_thrust", limits.max_thrust, true);
+  limits.max_velocity = getParameter<double>("limits.max_velocity", limits.max_velocity);
+  limits.max_body_rate = getParameter<double>("limits.max_body_rate", limits.max_body_rate);
+  limits.max_tilt_angle = getParameter<double>("limits.max_tilt_angle", limits.max_tilt_angle);
+  limits.min_thrust = getParameter<double>("limits.min_thrust", limits.min_thrust);
+  limits.max_thrust = getParameter<double>("limits.max_thrust", limits.max_thrust);
 
   auto & opt = generator_config_.optimization;
   // OptimizationConfig already has reasonable struct-level defaults; only
   // expose the knobs that callers typically tune.
-  getParameter<double>("optimization.time_weight", opt.time_weight, true);
-  getParameter<double>(
-    "optimization.position_weight", opt.position_weight, true);
-  getParameter<double>(
-    "optimization.velocity_weight", opt.velocity_weight, true);
-  getParameter<double>(
-    "optimization.body_rate_weight", opt.body_rate_weight, true);
-  getParameter<double>("optimization.tilt_weight", opt.tilt_weight, true);
-  getParameter<double>("optimization.thrust_weight", opt.thrust_weight, true);
-  getParameter<double>("optimization.smoothing_eps", opt.smoothing_eps, true);
-  getParameter<int>(
-    "optimization.integral_resolution", opt.integral_resolution, true);
-  getParameter<double>("optimization.rel_cost_tol", opt.rel_cost_tol, true);
-  getParameter<double>(
-    "optimization.corridor_margin", opt.corridor_margin, true);
-  getParameter<double>(
-    "optimization.vertical_perturbation", opt.vertical_perturbation, true);
-  getParameter<double>(
-    "optimization.vertical_alignment_threshold",
-    opt.vertical_alignment_threshold, true);
+  opt.time_weight = getParameter<double>("optimization.time_weight", opt.time_weight);
+  opt.position_weight = getParameter<double>("optimization.position_weight", opt.position_weight);
+  opt.velocity_weight = getParameter<double>("optimization.velocity_weight", opt.velocity_weight);
+  opt.body_rate_weight =
+    getParameter<double>("optimization.body_rate_weight", opt.body_rate_weight);
+  opt.tilt_weight = getParameter<double>("optimization.tilt_weight", opt.tilt_weight);
+  opt.thrust_weight = getParameter<double>("optimization.thrust_weight", opt.thrust_weight);
+  opt.smoothing_eps = getParameter<double>("optimization.smoothing_eps", opt.smoothing_eps);
+  opt.integral_resolution = getParameter<int>(
+    "optimization.integral_resolution",
+    opt.integral_resolution);
+  opt.rel_cost_tol = getParameter<double>("optimization.rel_cost_tol", opt.rel_cost_tol);
+  opt.corridor_margin = getParameter<double>("optimization.corridor_margin", opt.corridor_margin);
+  opt.vertical_perturbation = getParameter<double>(
+    "optimization.vertical_perturbation",
+    opt.vertical_perturbation);
+  opt.vertical_alignment_threshold = getParameter<double>(
+    "optimization.vertical_alignment_threshold", opt.vertical_alignment_threshold);
   // length_per_piece intentionally omitted: keep INF default so each segment
   // maps to one waypoint pair (assumed by the arrival-time bookkeeping below).
 
@@ -115,10 +114,10 @@ void Plugin::readConfigParameters()
   // otherwise are only used to grow the AABB Safe Flight Corridor.
   // Setting either to <= 0 disables anchoring and falls back to a uniform
   // corridor margin (`optimization.corridor_margin`).
-  getParameter<double>(
-    "waypoints.waypoint_margin", waypoint_margin_, true);
-  getParameter<double>(
-    "waypoints.waypoint_anchor_radius", waypoint_anchor_radius_, true);
+  waypoint_margin_ = getParameter<double>("waypoints.waypoint_margin", waypoint_margin_);
+  waypoint_anchor_radius_ = getParameter<double>(
+    "waypoints.waypoint_anchor_radius",
+    waypoint_anchor_radius_);
 }
 
 gcopter_lib::Waypoint Plugin::toGcopterWaypoint(

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/src/jerk_limited_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/jerk_limited_trajectory_generator/src/jerk_limited_trajectory_generator.cpp
@@ -66,29 +66,30 @@ void Plugin::readConfigParameters()
   params.acceptance_radius = 1.0;
   params.final_acceptance_radius = 0.05;
   params.trajectory_gain = 1.0;
-  getParameter<double>("limits.max_speed", params.max_speed, true);
-  getParameter<double>(
-    "limits.max_acceleration", params.max_acceleration, true);
-  getParameter<double>("limits.max_jerk", params.max_jerk, true);
-  getParameter<double>(
-    "limits.acceptance_radius", params.acceptance_radius, true);
-  getParameter<double>(
-    "limits.final_acceptance_radius", params.final_acceptance_radius, true);
-  getParameter<double>(
-    "limits.trajectory_gain", params.trajectory_gain, true);
+  params.max_speed = getParameter<double>("limits.max_speed", params.max_speed);
+  params.max_acceleration =
+    getParameter<double>("limits.max_acceleration", params.max_acceleration);
+  params.max_jerk = getParameter<double>("limits.max_jerk", params.max_jerk);
+  params.acceptance_radius = getParameter<double>(
+    "limits.acceptance_radius",
+    params.acceptance_radius);
+  params.final_acceptance_radius = getParameter<double>(
+    "limits.final_acceptance_radius",
+    params.final_acceptance_radius);
+  params.trajectory_gain = getParameter<double>("limits.trajectory_gain", params.trajectory_gain);
 
   // Simulator knobs. Reasonable defaults are already present in the upstream
   // SimulatorConfig struct; expose them so they can be tuned from YAML.
   auto & sim = generator_config_.simulator;
-  getParameter<double>("simulator.step_dt", sim.step_dt, true);
-  getParameter<double>(
-    "simulator.max_simulation_time", sim.max_simulation_time, true);
-  getParameter<double>(
-    "simulator.settle_velocity", sim.settle_velocity, true);
-  getParameter<double>(
-    "simulator.advance_radius_min", sim.advance_radius_min, true);
-  getParameter<int>(
-    "simulator.polynomial_order", sim.polynomial_order, true);
+  sim.step_dt = getParameter<double>("simulator.step_dt", sim.step_dt);
+  sim.max_simulation_time = getParameter<double>(
+    "simulator.max_simulation_time",
+    sim.max_simulation_time);
+  sim.settle_velocity = getParameter<double>("simulator.settle_velocity", sim.settle_velocity);
+  sim.advance_radius_min = getParameter<double>(
+    "simulator.advance_radius_min",
+    sim.advance_radius_min);
+  sim.polynomial_order = getParameter<int>("simulator.polynomial_order", sim.polynomial_order);
 }
 
 tgjl::Waypoint Plugin::toJlWaypoint(

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/src/mav_trajectory_generator.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/plugins/mav_trajectory_generator/src/mav_trajectory_generator.cpp
@@ -72,23 +72,23 @@ void Plugin::readConfigParameters()
   auto & opt = generator_config_.optimization;
 
   std::string solver_str = "linear";
-  getParameter<std::string>("optimization.solver", solver_str, true);
+  solver_str = getParameter<std::string>("optimization.solver", solver_str);
   opt.solver = parseSolver(solver_str);
 
-  getParameter<int>(
-    "optimization.derivative_to_optimize", opt.derivative_to_optimize, true);
-  getParameter<double>("optimization.a_max", opt.a_max, true);
-  getParameter<int>(
-    "optimization.nl_max_iterations", opt.nl_max_iterations, true);
-  getParameter<double>("optimization.nl_f_rel", opt.nl_f_rel, true);
-  getParameter<double>("optimization.nl_x_rel", opt.nl_x_rel, true);
-  getParameter<double>(
-    "optimization.nl_time_penalty", opt.nl_time_penalty, true);
-  getParameter<double>(
-    "optimization.nl_initial_stepsize_rel", opt.nl_initial_stepsize_rel, true);
-  getParameter<double>(
-    "optimization.nl_inequality_constraint_tolerance",
-    opt.nl_inequality_constraint_tolerance, true);
+  opt.derivative_to_optimize = getParameter<int>(
+    "optimization.derivative_to_optimize",
+    opt.derivative_to_optimize);
+  opt.a_max = getParameter<double>("optimization.a_max", opt.a_max);
+  opt.nl_max_iterations =
+    getParameter<int>("optimization.nl_max_iterations", opt.nl_max_iterations);
+  opt.nl_f_rel = getParameter<double>("optimization.nl_f_rel", opt.nl_f_rel);
+  opt.nl_x_rel = getParameter<double>("optimization.nl_x_rel", opt.nl_x_rel);
+  opt.nl_time_penalty = getParameter<double>("optimization.nl_time_penalty", opt.nl_time_penalty);
+  opt.nl_initial_stepsize_rel = getParameter<double>(
+    "optimization.nl_initial_stepsize_rel",
+    opt.nl_initial_stepsize_rel);
+  opt.nl_inequality_constraint_tolerance = getParameter<double>(
+    "optimization.nl_inequality_constraint_tolerance", opt.nl_inequality_constraint_tolerance);
 }
 
 mav_trajectory_generation_cpp::Waypoint Plugin::toMavWaypoint(

--- a/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/generate_polynomial_trajectory_behavior/src/generate_polynomial_trajectory_behavior.cpp
@@ -63,18 +63,18 @@ GeneratePolynomialTrajectoryBehavior::GeneratePolynomialTrajectoryBehavior(
   map_frame_id_ = as2::tf::generateTfName(this, "map");
 
   std::string desired_frame_id;
-  getParameter("desired_frame_id", desired_frame_id);
+  desired_frame_id = getParameter<std::string>("desired_frame_id");
   RCLCPP_INFO(this->get_logger(), "Using desired_frame_id: %s", desired_frame_id.c_str());
   desired_frame_id_ = as2::tf::generateTfName(this, desired_frame_id);
 
   // Parameters
-  getParameter("sampling_n", sampling_n_);
-  getParameter("sampling_dt", sampling_dt_);
-  getParameter("transform_threshold", transform_threshold_);
-  getParameter("frequency_update_frame", frequency_update_frame_);
-  getParameter("yaw_threshold", yaw_threshold_);
-  getParameter("yaw_speed_threshold", yaw_speed_threshold_);
-  getParameter("path_length", path_length_);
+  sampling_n_ = getParameter<int>("sampling_n");
+  sampling_dt_ = getParameter<double>("sampling_dt");
+  transform_threshold_ = getParameter<double>("transform_threshold");
+  frequency_update_frame_ = getParameter<double>("frequency_update_frame");
+  yaw_threshold_ = getParameter<double>("yaw_threshold");
+  yaw_speed_threshold_ = getParameter<double>("yaw_speed_threshold");
+  path_length_ = getParameter<int>("path_length");
 
   // Parameters checks
   if (path_length_ < 0) {
@@ -124,7 +124,7 @@ GeneratePolynomialTrajectoryBehavior::GeneratePolynomialTrajectoryBehavior(
 void GeneratePolynomialTrajectoryBehavior::loadPlugin()
 {
   try {
-    getParameter("plugin_name", plugin_name_);
+    plugin_name_ = getParameter<std::string>("plugin_name");
 
     plugin_loader_ = std::make_shared<pluginlib::ClassLoader<PluginBase>>(
       "as2_behaviors_trajectory_generation",
@@ -1339,11 +1339,11 @@ void GeneratePolynomialTrajectoryBehavior::initDebugPublishers()
   std::string ref_waypoints;
   std::string generation_time_topic;
 
-  getParameter("debug.path_topic", path_topic);
-  getParameter("debug.reference_setpoint", ref_setpoint);
-  getParameter("debug.reference_end_waypoint", ref_end_waypoint);
-  getParameter("debug.reference_waypoints", ref_waypoints);
-  getParameter("debug.generation_time_topic", generation_time_topic);
+  path_topic = getParameter<std::string>("debug.path_topic");
+  ref_setpoint = getParameter<std::string>("debug.reference_setpoint");
+  ref_end_waypoint = getParameter<std::string>("debug.reference_end_waypoint");
+  ref_waypoints = getParameter<std::string>("debug.reference_waypoints");
+  generation_time_topic = getParameter<std::string>("debug.generation_time_topic");
 
   if (!path_topic.empty()) {
     debug_path_pub_ =

--- a/as2_core/include/as2_core/node.hpp
+++ b/as2_core/include/as2_core/node.hpp
@@ -76,15 +76,28 @@ class Node : public AS2_NODE_FATHER_TYPE
 {
 private:
   /**
+   * @brief Read a parameter that is already declared, and log its value.
+   *
+   * @tparam T Parameter type.
+   * @param name Parameter name.
+   * @return Value of the parameter.
+   */
+  template<typename T>
+  T readParameter(const std::string & name)
+  {
+    const rclcpp::Parameter parameter = this->get_parameter(name);
+    RCLCPP_INFO(
+      this->get_logger(), "[%s] = %s", name.c_str(), parameter.value_to_string().c_str());
+    return parameter.template get_value<T>();
+  }
+
+  /**
    * @brief Read the node frequency parameter and create the loop rate.
    * Called by both constructors.
    */
   void init()
   {
-    if (!this->has_parameter("node_frequency")) {
-      this->declare_parameter<float>("node_frequency", -1.0);
-    }
-    this->get_parameter("node_frequency", loop_frequency_);
+    loop_frequency_ = getParameter<float>("node_frequency", -1.0);
     RCLCPP_DEBUG(
       this->get_logger(), "node [%s] base frequency= %f", this->get_name(), loop_frequency_);
 
@@ -197,6 +210,43 @@ public:
    * @param name source string
    * @return std::string result name
    */
+  /**
+   * @brief Read an optional node parameter, declaring it with a default value
+   * when it is not declared yet.
+   *
+   * @tparam T Parameter type, deduced from @p default_value.
+   * @param name Parameter name.
+   * @param default_value Value the parameter takes when nothing provides it.
+   * @return Value of the parameter.
+   */
+  template<typename T>
+  T getParameter(const std::string & name, const T & default_value)
+  {
+    if (!this->has_parameter(name)) {
+      this->declare_parameter<T>(name, default_value);
+    }
+    return readParameter<T>(name);
+  }
+
+  /**
+   * @brief Read a required node parameter, declaring it without a default value
+   * when it is not declared yet.
+   *
+   * @tparam T Parameter type.
+   * @param name Parameter name.
+   * @return Value of the parameter.
+   * @throw rclcpp::exceptions::ParameterUninitializedException when nothing
+   *        provides the parameter.
+   */
+  template<typename T>
+  T getParameter(const std::string & name)
+  {
+    if (!this->has_parameter(name)) {
+      this->declare_parameter<T>(name);
+    }
+    return readParameter<T>(name);
+  }
+
   std::string generate_global_name(const std::string & name);
 
 protected:

--- a/as2_core/include/as2_core/polynomial_thrust_map.hpp
+++ b/as2_core/include/as2_core/polynomial_thrust_map.hpp
@@ -110,15 +110,6 @@ public:
   std::string to_string() const;
 
   /**
-   * @brief Read a ROS 2 parameter from platform config file, declaring it if not yet set.
-   * @tparam T Type to cast the parameter value to.
-   * @param param_name Name of the ROS 2 parameter to read.
-   * @return The parameter value cast to type T.
-   */
-  template<typename T>
-  T getParameter(std::string param_name) const;
-
-  /**
    * @brief Set all thrust map parameters.
    */
   void set_parameters(

--- a/as2_core/src/aerial_platform.cpp
+++ b/as2_core/src/aerial_platform.cpp
@@ -45,25 +45,10 @@ void AerialPlatform::initialize()
 {
   {
     resetPlatform();
-    this->declare_parameter<float>("cmd_freq", 100.0);
-    this->declare_parameter<float>("info_freq", 10.0);
+    cmd_freq_ = this->getParameter<float>("cmd_freq", 100.0);
+    info_freq_ = this->getParameter<float>("info_freq", 10.0);
 
-    try {
-      this->declare_parameter<std::string>("control_modes_file");
-    } catch (const rclcpp::ParameterTypeException & e) {
-      RCLCPP_FATAL(
-        this->get_logger(), "Launch argument <control_modes_file> not defined or malformed: %s",
-        e.what());
-      this->~AerialPlatform();
-    }
-
-    this->get_parameter("cmd_freq", cmd_freq_);
-    this->get_parameter("info_freq", info_freq_);
-
-    std::string control_modes_file;
-    this->get_parameter("control_modes_file", control_modes_file);
-
-    this->loadControlModes(control_modes_file);
+    this->loadControlModes(this->getParameter<std::string>("control_modes_file"));
 
     trajectory_command_sub_ = this->create_subscription<as2_msgs::msg::TrajectorySetpoints>(
       this->generate_global_name(as2_names::topics::actuator_command::trajectory),

--- a/as2_core/src/polynomial_thrust_map.cpp
+++ b/as2_core/src/polynomial_thrust_map.cpp
@@ -51,15 +51,6 @@ std::string PolynomialThrustMap::to_string() const
   return tm_string;
 }
 
-template<typename T>
-T PolynomialThrustMap::getParameter(std::string param_name) const
-{
-  if (!platform_node_ptr_->has_parameter(param_name)) {
-    platform_node_ptr_->declare_parameter<T>(param_name);
-  }
-  return platform_node_ptr_->get_parameter(param_name).get_value<T>();
-}
-
 void PolynomialThrustMap::set_parameters(
   double max_throttle, double min_throttle, double a, double b, double c, double d, double e,
   double f,
@@ -82,18 +73,18 @@ void PolynomialThrustMap::set_parameters(
 void PolynomialThrustMap::readParameters()
 {
   set_parameters(
-    getParameter<double>("polynomial_thrust_map.max_throttle"),
-    getParameter<double>("polynomial_thrust_map.min_throttle"),
-    getParameter<double>("polynomial_thrust_map.a"),
-    getParameter<double>("polynomial_thrust_map.b"),
-    getParameter<double>("polynomial_thrust_map.c"),
-    getParameter<double>("polynomial_thrust_map.d"),
-    getParameter<double>("polynomial_thrust_map.e"),
-    getParameter<double>("polynomial_thrust_map.f"),
-    getParameter<bool>("polynomial_thrust_map.use_correction_factor"),
-    getParameter<double>("polynomial_thrust_map.gamma2"),
-    getParameter<double>("polynomial_thrust_map.gamma1"),
-    getParameter<double>("polynomial_thrust_map.gamma0"));
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.max_throttle"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.min_throttle"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.a"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.b"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.c"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.d"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.e"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.f"),
+    platform_node_ptr_->getParameter<bool>("polynomial_thrust_map.use_correction_factor"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.gamma2"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.gamma1"),
+    platform_node_ptr_->getParameter<double>("polynomial_thrust_map.gamma0"));
 }
 
 void PolynomialThrustMap::initialize(as2::AerialPlatform * platform_node_ptr)

--- a/as2_core/src/sensor.cpp
+++ b/as2_core/src/sensor.cpp
@@ -197,18 +197,16 @@ Camera::Camera(
   // Check if ROS 2 camera_nameparameter is set
   std::string ros_param_prefix = processParametersPrefix(prefix);
 
-  // Get camera name from ROS 2 parameters
-  try {
-    node_ptr->declare_parameter<std::string>(ros_param_prefix + "camera_name", "");
-  } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException & e) {
+  if (node_ptr->has_parameter(ros_param_prefix + "camera_name")) {
     RCLCPP_ERROR(
       node_ptr->get_logger(),
-      "Camera sensor constructor failed."
-      "Parameter %s already declared."
-      "Cannot create two camera sensors with the same name."
-      "%s", (ros_param_prefix + "camera_name").c_str(), e.what());
+      "Camera sensor constructor failed. Parameter %s already declared. "
+      "Cannot create two camera sensors with the same name.",
+      (ros_param_prefix + "camera_name").c_str());
   }
-  node_ptr->get_parameter(ros_param_prefix + "camera_name", camera_name_);
+
+  camera_name_ = node_ptr->getParameter<std::string>(
+    ros_param_prefix + "camera_name", std::string());
 
   bool enable_parameters = true;
   if (camera_name_.empty()) {
@@ -307,32 +305,23 @@ void Camera::readCameraInfoFromROSParameters(
 {
   std::string ros_param_prefix = processParametersPrefix(prefix);
 
-  node_ptr_->declare_parameter<std::string>(ros_param_prefix + "encoding");
-  node_ptr_->declare_parameter<int>(ros_param_prefix + "image_width");
-  node_ptr_->declare_parameter<int>(ros_param_prefix + "image_height");
-  node_ptr_->declare_parameter<std::vector<double>>(ros_param_prefix + "camera_matrix.data");
-  node_ptr_->declare_parameter<std::string>(ros_param_prefix + "distortion_model");
-  node_ptr_->declare_parameter<std::vector<double>>(
-    ros_param_prefix + "distortion_coefficients.data");
-  node_ptr_->declare_parameter<std::vector<double>>(ros_param_prefix + "rectification_matrix.data");
-  node_ptr_->declare_parameter<std::vector<double>>(ros_param_prefix + "projection_matrix.data");
-
-  // Get parameters
   sensor_msgs::msg::CameraInfo cam_info;
-  std::vector<double> matrix;
-  std::string encoding;
-  node_ptr_->get_parameter(ros_param_prefix + "encoding", encoding);
-  setEncoding(encoding);
-  node_ptr_->get_parameter(ros_param_prefix + "image_width", cam_info.width);
-  node_ptr_->get_parameter(ros_param_prefix + "image_height", cam_info.height);
-  node_ptr_->get_parameter(ros_param_prefix + "camera_matrix.data", matrix);
-  convertVectorToArray(matrix, cam_info.k);
-  node_ptr_->get_parameter(ros_param_prefix + "distortion_model", cam_info.distortion_model);
-  node_ptr_->get_parameter(ros_param_prefix + "distortion_coefficients.data", cam_info.d);
-  node_ptr_->get_parameter(ros_param_prefix + "rectification_matrix.data", matrix);
-  convertVectorToArray(matrix, cam_info.r);
-  node_ptr_->get_parameter(ros_param_prefix + "projection_matrix.data", matrix);
-  convertVectorToArray(matrix, cam_info.p);
+  setEncoding(node_ptr_->getParameter<std::string>(ros_param_prefix + "encoding"));
+  cam_info.width = node_ptr_->getParameter<int>(ros_param_prefix + "image_width");
+  cam_info.height = node_ptr_->getParameter<int>(ros_param_prefix + "image_height");
+  cam_info.distortion_model =
+    node_ptr_->getParameter<std::string>(ros_param_prefix + "distortion_model");
+  cam_info.d = node_ptr_->getParameter<std::vector<double>>(
+    ros_param_prefix + "distortion_coefficients.data");
+  convertVectorToArray(
+    node_ptr_->getParameter<std::vector<double>>(ros_param_prefix + "camera_matrix.data"),
+    cam_info.k);
+  convertVectorToArray(
+    node_ptr_->getParameter<std::vector<double>>(ros_param_prefix + "rectification_matrix.data"),
+    cam_info.r);
+  convertVectorToArray(
+    node_ptr_->getParameter<std::vector<double>>(ros_param_prefix + "projection_matrix.data"),
+    cam_info.p);
 
   // Set header
   cam_info.header.frame_id = camera_link_frame_;
@@ -347,25 +336,15 @@ void Camera::readCameraTranformFromROSParameters(
   std::string ros_param_prefix = processParametersPrefix(prefix);
 
   // Declare camera parameters
-  node_ptr_->declare_parameter<std::string>(ros_param_prefix + "camera_transform.parent_frame");
-  node_ptr_->declare_parameter<double>(ros_param_prefix + "camera_transform.x");
-  node_ptr_->declare_parameter<double>(ros_param_prefix + "camera_transform.y");
-  node_ptr_->declare_parameter<double>(ros_param_prefix + "camera_transform.z");
-  node_ptr_->declare_parameter<double>(ros_param_prefix + "camera_transform.roll");
-  node_ptr_->declare_parameter<double>(ros_param_prefix + "camera_transform.pitch");
-  node_ptr_->declare_parameter<double>(ros_param_prefix + "camera_transform.yaw");
-
-  // Get parameters
-  std::string parent_frame;
-  double x, y, z, roll, pitch, yaw;
-  node_ptr_->get_parameter(ros_param_prefix + "camera_transform.parent_frame", parent_frame);
-  node_ptr_->get_parameter(ros_param_prefix + "camera_transform.x", x);
-  node_ptr_->get_parameter(ros_param_prefix + "camera_transform.y", y);
-  node_ptr_->get_parameter(ros_param_prefix + "camera_transform.z", z);
-  node_ptr_->get_parameter(ros_param_prefix + "camera_transform.roll", roll);
-  node_ptr_->get_parameter(ros_param_prefix + "camera_transform.pitch", pitch);
-  node_ptr_->get_parameter(ros_param_prefix + "camera_transform.yaw", yaw);
-  parent_frame = as2::tf::generateTfName(node_ptr_->get_namespace(), parent_frame);
+  const std::string parent_frame = as2::tf::generateTfName(
+    node_ptr_->get_namespace(),
+    node_ptr_->getParameter<std::string>(ros_param_prefix + "camera_transform.parent_frame"));
+  const double x = node_ptr_->getParameter<double>(ros_param_prefix + "camera_transform.x");
+  const double y = node_ptr_->getParameter<double>(ros_param_prefix + "camera_transform.y");
+  const double z = node_ptr_->getParameter<double>(ros_param_prefix + "camera_transform.z");
+  const double roll = node_ptr_->getParameter<double>(ros_param_prefix + "camera_transform.roll");
+  const double pitch = node_ptr_->getParameter<double>(ros_param_prefix + "camera_transform.pitch");
+  const double yaw = node_ptr_->getParameter<double>(ros_param_prefix + "camera_transform.yaw");
   setCameraLinkTransform(parent_frame, x, y, z, roll, pitch, yaw);
 }
 

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -112,13 +112,7 @@ TfHandler::TfHandler(as2::Node * _node)
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
   // Read tf_timeout_threshold from the parameter server
-  double tf_timeout_threshold = 0.05;
-  if (!_node->has_parameter("tf_timeout_threshold")) {
-    // Declare the parameter
-    _node->declare_parameter("tf_timeout_threshold", tf_timeout_threshold);
-  }
-  _node->get_parameter("tf_timeout_threshold", tf_timeout_threshold);
-  setTfTimeoutThreshold(tf_timeout_threshold);
+  setTfTimeoutThreshold(_node->getParameter<double>("tf_timeout_threshold", 0.05));
 }
 
 void TfHandler::setTfTimeoutThreshold(double tf_timeout_threshold)

--- a/as2_hardware_drivers/as2_realsense_interface/src/as2_realsense_interface.cpp
+++ b/as2_hardware_drivers/as2_realsense_interface/src/as2_realsense_interface.cpp
@@ -63,8 +63,7 @@ RealsenseInterface::RealsenseInterface(const rclcpp::NodeOptions & options)
 
 bool RealsenseInterface::setup()
 {
-  this->declare_parameter<std::string>("tf_device.frame_id", "realsense_link");
-  this->get_parameter("tf_device.frame_id", realsense_name_);
+  realsense_name_ = this->getParameter<std::string>("tf_device.frame_id", "realsense_link");
   RCLCPP_INFO(get_logger(), "Read device: %s", realsense_name_.c_str());
 
 
@@ -75,34 +74,21 @@ bool RealsenseInterface::setup()
   }
 
   // Get parameters
-  this->get_parameter("rs_name", realsense_name_);
-  verbose_ = this->declare_parameter("verbose", true);
+  verbose_ = this->getParameter<bool>("verbose", true);
 
-  std::string tf_link_frame;
-  std::string tf_ref_frame;
-  std::array<double, 3> tf_translation;
-  std::array<double, 3> tf_rotation;
+  const std::array<double, 3> tf_translation{
+    this->getParameter<double>("tf_device.x"),
+    this->getParameter<double>("tf_device.y"),
+    this->getParameter<double>("tf_device.z")};
+  const std::array<double, 3> tf_rotation{
+    this->getParameter<double>("tf_device.roll"),
+    this->getParameter<double>("tf_device.pitch"),
+    this->getParameter<double>("tf_device.yaw")};
 
-  this->declare_parameter<std::string>("tf_device.reference_frame");
-  this->declare_parameter<double>("tf_device.x");
-  this->declare_parameter<double>("tf_device.y");
-  this->declare_parameter<double>("tf_device.z");
-  this->declare_parameter<double>("tf_device.roll");
-  this->declare_parameter<double>("tf_device.pitch");
-  this->declare_parameter<double>("tf_device.yaw");
-
-  // tf
-  this->get_parameter("tf_device.frame_id", tf_link_frame);
-  this->get_parameter("tf_device.reference_frame", tf_ref_frame);
-  this->get_parameter("tf_device.x", tf_translation[0]);
-  this->get_parameter("tf_device.y", tf_translation[1]);
-  this->get_parameter("tf_device.z", tf_translation[2]);
-  this->get_parameter("tf_device.roll", tf_rotation[0]);
-  this->get_parameter("tf_device.pitch", tf_rotation[1]);
-  this->get_parameter("tf_device.yaw", tf_rotation[2]);
-
-  tf_link_frame = as2::tf::generateTfName(this->get_namespace(), tf_link_frame);
-  tf_ref_frame = as2::tf::generateTfName(this->get_namespace(), tf_ref_frame);
+  const std::string tf_link_frame =
+    as2::tf::generateTfName(this->get_namespace(), realsense_name_);
+  const std::string tf_ref_frame = as2::tf::generateTfName(
+    this->get_namespace(), this->getParameter<std::string>("tf_device.reference_frame"));
 
   // Publish device static transform
   setStaticTransform(tf_link_frame, tf_ref_frame, tf_translation, tf_rotation);

--- a/as2_hardware_drivers/as2_usb_camera_interface/include/as2_usb_camera_interface/common.hpp
+++ b/as2_hardware_drivers/as2_usb_camera_interface/include/as2_usb_camera_interface/common.hpp
@@ -51,77 +51,6 @@
 namespace as2_usb_camera_interface
 {
 
-/**
- * @brief Format a scalar parameter value for logging.
- *
- * @tparam T Parameter type, anything streamable.
- * @param value Value to format.
- * @return Value as text.
- */
-template<typename T>
-std::string paramToString(const T & value)
-{
-  std::ostringstream oss;
-  oss << value;
-  return oss.str();
-}
-
-/**
- * @brief Format a vector parameter value for logging, as "[a, b, c]".
- *
- * @tparam T Element type, anything streamable.
- * @param vec Vector to format.
- * @return Vector as text.
- */
-template<typename T>
-std::string paramToString(const std::vector<T> & vec)
-{
-  std::ostringstream oss;
-  oss << "[";
-  for (size_t i = 0; i < vec.size(); ++i) {
-    oss << vec[i];
-    if (i + 1 < vec.size()) {
-      oss << ", ";
-    }
-  }
-  oss << "]";
-  return oss.str();
-}
-
-template<typename T>
-T getParameter(as2::Node * node_ptr, const std::string & param_name)
-{
-  T param_value;
-  try {
-    if (!node_ptr->has_parameter(param_name)) {
-      param_value = node_ptr->declare_parameter<T>(param_name);
-    } else {
-      node_ptr->get_parameter(param_name, param_value);
-    }
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      node_ptr->get_logger(), "Launch argument <%s> not defined or malformed: %s",
-      param_name.c_str(), e.what());
-    node_ptr->~Node();
-  }
-
-  const std::string value_str = paramToString(param_value);
-  RCLCPP_INFO(node_ptr->get_logger(), "%s = %s", param_name.c_str(), value_str.c_str());
-  return param_value;
-}
-
-// Like getParameter but returns default_value when the parameter is not provided
-template<typename T>
-T getParameterOr(as2::Node * node_ptr, const std::string & param_name, const T & default_value)
-{
-  if (node_ptr->has_parameter(param_name)) {
-    T value;
-    node_ptr->get_parameter(param_name, value);
-    return value;
-  }
-  return node_ptr->declare_parameter<T>(param_name, default_value);
-}
-
 // Thread-safe queue with max size
 template<typename T>
 class MutexQueue
@@ -144,7 +73,7 @@ public:
     size_t default_size = 10)
   {
     std::string param_name = param_base_name + "_queue_size";
-    int size_param = getParameter<int>(node_ptr, param_name);
+    int size_param = node_ptr->getParameter<int>(param_name);
     max_size_ = (size_param > 0) ? static_cast<size_t>(size_param) : default_size;
   }
 

--- a/as2_hardware_drivers/as2_usb_camera_interface/src/as2_usb_camera_interface.cpp
+++ b/as2_hardware_drivers/as2_usb_camera_interface/src/as2_usb_camera_interface.cpp
@@ -59,10 +59,10 @@ UsbCameraInterface::UsbCameraInterface(as2::Node * node_ptr)
   setupCamera();
   cameraInfoSetup();
 
-  publish_images_ = as2_usb_camera_interface::getParameter<bool>(node_ptr_, "publish_images");
+  publish_images_ = node_ptr_->getParameter<bool>("publish_images");
 
   const int output_queue_size =
-    as2_usb_camera_interface::getParameterOr<int>(node_ptr_, "output_queue_size", 1);
+    node_ptr_->getParameter<int>("output_queue_size", 1);
   output_queue_.setMaxSize(output_queue_size > 0 ? static_cast<size_t>(output_queue_size) : 1);
 
   const int64_t milliseconds_from_framerate =
@@ -85,12 +85,12 @@ void UsbCameraInterface::setupCamera()
 
   // "image_width"/"image_height"/"camera_name" are already declared by the
   // as2::sensors::Camera constructor; the getParameter helper only reads them.
-  arducam = as2_usb_camera_interface::getParameter<bool>(node_ptr_, "arducam");
-  device_port = as2_usb_camera_interface::getParameter<std::string>(node_ptr_, "device");
-  framerate = as2_usb_camera_interface::getParameter<double>(node_ptr_, "framerate");
-  image_height = as2_usb_camera_interface::getParameter<int>(node_ptr_, "image_height");
-  image_width = as2_usb_camera_interface::getParameter<int>(node_ptr_, "image_width");
-  camera_name_ = as2_usb_camera_interface::getParameter<std::string>(node_ptr_, "camera_name");
+  arducam = node_ptr_->getParameter<bool>("arducam");
+  device_port = node_ptr_->getParameter<std::string>("device");
+  framerate = node_ptr_->getParameter<double>("framerate");
+  image_height = node_ptr_->getParameter<int>("image_height");
+  image_width = node_ptr_->getParameter<int>("image_width");
+  camera_name_ = node_ptr_->getParameter<std::string>("camera_name");
   framerate_ = framerate;
 
   RCLCPP_INFO(node_ptr_->get_logger(), "Video device: %s", device_port.c_str());
@@ -106,16 +106,15 @@ void UsbCameraInterface::setupCamera()
     // Optional nvarguscamerasrc image controls, built like as2_gates_localization:
     // ranges/compensation/wbmode/saturation are only set when they differ from the
     // sensor default, so leaving them at the default keeps the auto behaviour.
-    namespace ns = as2_usb_camera_interface;
     const double exposure_recompensation =
-      ns::getParameterOr<double>(node_ptr_, "exposure_recompensation", 0.0);
-    const int exposure_range = ns::getParameterOr<int>(node_ptr_, "exposure_range", 0);
-    const int gain = ns::getParameterOr<int>(node_ptr_, "gain", 0);
-    const bool aelock = ns::getParameterOr<bool>(node_ptr_, "aelock", true);
-    const bool awblock = ns::getParameterOr<bool>(node_ptr_, "awblock", false);
-    const int wbmode = ns::getParameterOr<int>(node_ptr_, "wbmode", 1);
-    const int aeantibanding = ns::getParameterOr<int>(node_ptr_, "aeantibanding", 1);
-    const double saturation = ns::getParameterOr<double>(node_ptr_, "saturation", 1.0);
+      node_ptr_->getParameter<double>("exposure_recompensation", 0.0);
+    const int exposure_range = node_ptr_->getParameter<int>("exposure_range", 0);
+    const int gain = node_ptr_->getParameter<int>("gain", 0);
+    const bool aelock = node_ptr_->getParameter<bool>("aelock", true);
+    const bool awblock = node_ptr_->getParameter<bool>("awblock", false);
+    const int wbmode = node_ptr_->getParameter<int>("wbmode", 1);
+    const int aeantibanding = node_ptr_->getParameter<int>("aeantibanding", 1);
+    const double saturation = node_ptr_->getParameter<double>("saturation", 1.0);
 
     std::string source = "nvarguscamerasrc sensor-id=" + device_port;
     if (exposure_recompensation != 0.0) {
@@ -176,21 +175,21 @@ void UsbCameraInterface::cameraInfoSetup()
 {
   // Mirror the intrinsics read by as2::sensors::Camera so in-process consumers
   // (via getCameraInfoMessage) get the same calibration that is published.
-  camera_info_.width = as2_usb_camera_interface::getParameter<int>(node_ptr_, "image_width");
-  camera_info_.height = as2_usb_camera_interface::getParameter<int>(node_ptr_, "image_height");
+  camera_info_.width = node_ptr_->getParameter<int>("image_width");
+  camera_info_.height = node_ptr_->getParameter<int>("image_height");
   camera_info_.distortion_model =
-    as2_usb_camera_interface::getParameter<std::string>(node_ptr_, "distortion_model");
+    node_ptr_->getParameter<std::string>("distortion_model");
   convertVectorToArray(
-    as2_usb_camera_interface::getParameter<std::vector<double>>(node_ptr_, "camera_matrix.data"),
+    node_ptr_->getParameter<std::vector<double>>("camera_matrix.data"),
     camera_info_.k);
   convertVectorToArray(
-    as2_usb_camera_interface::getParameter<std::vector<double>>(
-      node_ptr_, "projection_matrix.data"), camera_info_.p);
+    node_ptr_->getParameter<std::vector<double>>("projection_matrix.data"),
+    camera_info_.p);
   convertVectorToArray(
-    as2_usb_camera_interface::getParameter<std::vector<double>>(
-      node_ptr_, "rectification_matrix.data"), camera_info_.r);
-  camera_info_.d = as2_usb_camera_interface::getParameter<std::vector<double>>(
-    node_ptr_, "distortion_coefficients.data");
+    node_ptr_->getParameter<std::vector<double>>("rectification_matrix.data"),
+    camera_info_.r);
+  camera_info_.d =
+    node_ptr_->getParameter<std::vector<double>>("distortion_coefficients.data");
   camera_info_.header.frame_id = as2::tf::generateTfName(
     node_ptr_->get_namespace(), camera_name_ + "/camera_link");
 }

--- a/as2_map_server/plugins/scan2occ_grid/src/scan2occ_grid.cpp
+++ b/as2_map_server/plugins/scan2occ_grid/src/scan2occ_grid.cpp
@@ -41,19 +41,13 @@ void scan2occ_grid::Plugin::on_setup()
 {
   RCLCPP_INFO(node_ptr_->get_logger(), "2D Mapping plugin setup");
 
-  node_ptr_->declare_parameter("scan_range_max", 0.0);
-  scan_range_max_ = node_ptr_->get_parameter("scan_range_max").as_double();
-  node_ptr_->declare_parameter("map_resolution", 0.0);
-  map_resolution_ = node_ptr_->get_parameter("map_resolution").as_double();
-  node_ptr_->declare_parameter("hit_confidence", 40);
-  hit_confidence_ = node_ptr_->get_parameter("hit_confidence").as_int();
-  node_ptr_->declare_parameter("miss_confidence", 10);
-  miss_confidence_ = node_ptr_->get_parameter("miss_confidence").as_int();
+  scan_range_max_ = node_ptr_->getParameter<double>("scan_range_max", 0.0);
+  map_resolution_ = node_ptr_->getParameter<double>("map_resolution", 0.0);
+  hit_confidence_ = node_ptr_->getParameter<int>("hit_confidence", 40);
+  miss_confidence_ = node_ptr_->getParameter<int>("miss_confidence", 10);
   // TODO(parias): Check if map_width and map_height units, meters or cell?
-  node_ptr_->declare_parameter("map_width", 0);
-  map_width_ = node_ptr_->get_parameter("map_width").as_int();
-  node_ptr_->declare_parameter("map_height", 0);
-  map_height_ = node_ptr_->get_parameter("map_height").as_int();
+  map_width_ = node_ptr_->getParameter<int>("map_width", 0);
+  map_height_ = node_ptr_->getParameter<int>("map_height", 0);
 
   RCLCPP_INFO(
     node_ptr_->get_logger(), "Parameters: scan_range_max: %f, map_resolution: %f, map_width: %d, "

--- a/as2_map_server/src/map_server.cpp
+++ b/as2_map_server/src/map_server.cpp
@@ -40,16 +40,7 @@ namespace as2_map_server
 MapServer::MapServer()
 : as2::Node("as2_map_server")
 {
-  try {
-    this->declare_parameter("plugin_name", "scan2occ_grid");
-    this->get_parameter("plugin_name", plugin_name_);
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <plugin_name> not defined or malformed: %s",
-      e.what());
-    this->~MapServer();
-  }
-  plugin_name_ += "::Plugin";
+  plugin_name_ = this->getParameter<std::string>("plugin_name", "scan2occ_grid") + "::Plugin";
   RCLCPP_INFO(this->get_logger(), "Loading plugin: %s", plugin_name_.c_str());
   loader_ =
     std::make_shared<pluginlib::ClassLoader<as2_map_server_plugin_base::MapServerBase>>(

--- a/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
@@ -553,18 +553,10 @@ private:
    */
   void declareFrameParameters()
   {
-    if (!node_ptr_->has_parameter("desired_pose_frame")) {
-      node_ptr_->declare_parameter<std::string>("desired_pose_frame", "odom");
-    }
-    if (!node_ptr_->has_parameter("desired_twist_frame")) {
-      node_ptr_->declare_parameter<std::string>("desired_twist_frame", "base_link");
-    }
-    const std::string pose_param =
-      node_ptr_->get_parameter("desired_pose_frame").as_string();
-    const std::string twist_param =
-      node_ptr_->get_parameter("desired_twist_frame").as_string();
-    desired_pose_frame_id_ = as2::tf::generateTfName(node_ptr_, pose_param);
-    desired_twist_frame_id_ = as2::tf::generateTfName(node_ptr_, twist_param);
+    desired_pose_frame_id_ = as2::tf::generateTfName(
+      node_ptr_, node_ptr_->getParameter<std::string>("desired_pose_frame", "odom"));
+    desired_twist_frame_id_ = as2::tf::generateTfName(
+      node_ptr_, node_ptr_->getParameter<std::string>("desired_twist_frame", "base_link"));
     RCLCPP_INFO(
       node_ptr_->get_logger(),
       "Controller desired_pose_frame = '%s', desired_twist_frame = '%s'",

--- a/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
@@ -44,7 +44,7 @@
 #include <vector>
 #include <rclcpp/exceptions.hpp>
 #include <rclcpp/logging.hpp>
-#include <rclcpp/node.hpp>
+#include <as2_core/node.hpp>
 #include <rclcpp/parameter.hpp>
 
 namespace as2_motion_controller_param_utils
@@ -53,51 +53,19 @@ namespace as2_motion_controller_param_utils
 /**
  * @brief Read a scalar parameter of type T from the node.
  *
- * Specializations are provided for bool, int64_t, double and std::string.
- * Throws rclcpp::exceptions::ParameterNotDeclaredException if the parameter
- * was not declared, or rclcpp::ParameterTypeException on type mismatch.
+ * @deprecated Kept for out-of-tree controller plugins. Call
+ * as2::Node::getParameter directly instead.
  *
- * @param node Pointer to the ROS 2 node holding the parameters.
+ * @tparam T Parameter type.
+ * @param node Pointer to the aerostack2 node.
  * @param name Fully-qualified parameter name.
  * @return Parameter value of type T.
  */
 template<typename T>
-T readParam(rclcpp::Node * node, const std::string & name);
-
-/**
- * @brief readParam specialization for bool.
- */
-template<>
-inline bool readParam<bool>(rclcpp::Node * node, const std::string & name)
+[[deprecated("use as2::Node::getParameter")]]
+T readParam(as2::Node * node, const std::string & name)
 {
-  return node->get_parameter(name).as_bool();
-}
-
-/**
- * @brief readParam specialization for int64_t.
- */
-template<>
-inline int64_t readParam<int64_t>(rclcpp::Node * node, const std::string & name)
-{
-  return node->get_parameter(name).as_int();
-}
-
-/**
- * @brief readParam specialization for double.
- */
-template<>
-inline double readParam<double>(rclcpp::Node * node, const std::string & name)
-{
-  return node->get_parameter(name).as_double();
-}
-
-/**
- * @brief readParam specialization for std::string.
- */
-template<>
-inline std::string readParam<std::string>(rclcpp::Node * node, const std::string & name)
-{
-  return node->get_parameter(name).as_string();
+  return node->getParameter<T>(name);
 }
 
 /**
@@ -109,14 +77,14 @@ inline std::string readParam<std::string>(rclcpp::Node * node, const std::string
  * not silently run with a half-configured solver.
  *
  * @tparam N Expected number of elements in the array.
- * @param node Pointer to the ROS 2 node.
+ * @param node Pointer to the aerostack2 node.
  * @param name Fully-qualified parameter name.
  * @return Fixed-size std::array<double, N> with the values.
  */
 template<std::size_t N>
-std::array<double, N> readArray(rclcpp::Node * node, const std::string & name)
+std::array<double, N> readArray(as2::Node * node, const std::string & name)
 {
-  const auto values = node->get_parameter(name).as_double_array();
+  const auto values = node->getParameter<std::vector<double>>(name);
   if (values.size() != N) {
     RCLCPP_FATAL(
       node->get_logger(),
@@ -136,24 +104,24 @@ std::array<double, N> readArray(rclcpp::Node * node, const std::string & name)
  * If expected_size != 0, the size is validated and a mismatch is fatal
  * (RCLCPP_FATAL + throw). When expected_size == 0, any size is accepted.
  *
- * @param node Pointer to the ROS 2 node.
+ * @param node Pointer to the aerostack2 node.
  * @param name Fully-qualified parameter name.
  * @param expected_size Expected number of elements, or 0 to skip the check.
  * @return Vector with the parameter values.
  */
 std::vector<double> readDoubleArray(
-  rclcpp::Node * node,
+  as2::Node * node,
   const std::string & name,
   std::size_t expected_size = 0);
 
 /**
  * @brief Read a 3-component double array parameter as Eigen::Vector3d.
  *
- * @param node Pointer to the ROS 2 node.
+ * @param node Pointer to the aerostack2 node.
  * @param name Fully-qualified parameter name.
  * @return Eigen::Vector3d with the values.
  */
-inline Eigen::Vector3d readVector3(rclcpp::Node * node, const std::string & name)
+inline Eigen::Vector3d readVector3(as2::Node * node, const std::string & name)
 {
   const auto a = readArray<3>(node, name);
   return Eigen::Vector3d(a[0], a[1], a[2]);

--- a/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
@@ -38,28 +38,13 @@
 namespace differential_flatness_controller
 {
 
-namespace
-{
-
-// Lazily declare and read an optional string parameter that holds a topic
-// name. An empty value disables the publisher.
-std::string declareOptionalTopic(rclcpp::Node * node, const std::string & name)
-{
-  if (!node->has_parameter(name)) {
-    node->declare_parameter<std::string>(name, "");
-  }
-  return node->get_parameter(name).as_string();
-}
-
-}  // namespace
-
 void Plugin::ownInitialize()
 {
   // TrajectorySetpoints encodes pose and twist in the same frame.
   setDesiredTwistFrameId(getDesiredPoseFrameId());
 
   const std::string desired_velocity_topic =
-    declareOptionalTopic(getNodePtr(), param("debug.desired_velocity_topic"));
+    getNodePtr()->getParameter<std::string>(param("debug.desired_velocity_topic"), "");
   if (!desired_velocity_topic.empty()) {
     debug_desired_velocity_pub_ =
       getNodePtr()->create_publisher<geometry_msgs::msg::TwistStamped>(

--- a/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
@@ -38,21 +38,6 @@
 namespace pid_speed_controller
 {
 
-namespace
-{
-
-// Lazily declare and read an optional string parameter that holds a topic
-// name. An empty value disables the publisher.
-std::string declareOptionalTopic(rclcpp::Node * node, const std::string & name)
-{
-  if (!node->has_parameter(name)) {
-    node->declare_parameter<std::string>(name, "");
-  }
-  return node->get_parameter(name).as_string();
-}
-
-}  // namespace
-
 void Plugin::ownInitialize()
 {
   speed_limits_ = Eigen::Vector3d::Zero();
@@ -69,7 +54,7 @@ void Plugin::ownInitialize()
   trajectory_control_parameters_to_read_ = trajectory_control_parameters_tail_;
 
   const std::string desired_velocity_topic =
-    declareOptionalTopic(getNodePtr(), param("debug.desired_velocity_topic"));
+    getNodePtr()->getParameter<std::string>(param("debug.desired_velocity_topic"), "");
   if (!desired_velocity_topic.empty()) {
     debug_desired_velocity_pub_ =
       getNodePtr()->create_publisher<geometry_msgs::msg::TwistStamped>(

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -71,13 +71,13 @@ ControllerHandler::ControllerHandler(
   as2::tf::TfHandler * tf_handler)
 : controller_ptr_(controller), node_ptr_(node), tf_handler_(tf_handler)
 {
-  node_ptr_->get_parameter("use_bypass", use_bypass_);
-  node_ptr_->get_parameter("odom_frame_id", enu_frame_id_);
-  node_ptr_->get_parameter("base_frame_id", flu_frame_id_);
+  use_bypass_ = node_ptr_->getParameter<bool>("use_bypass", false);
 
   // Frame ids
-  enu_frame_id_ = as2::tf::generateTfName(node_ptr_, enu_frame_id_);
-  flu_frame_id_ = as2::tf::generateTfName(node_ptr_, flu_frame_id_);
+  enu_frame_id_ = as2::tf::generateTfName(
+    node_ptr_, node_ptr_->getParameter<std::string>("odom_frame_id", "odom"));
+  flu_frame_id_ = as2::tf::generateTfName(
+    node_ptr_, node_ptr_->getParameter<std::string>("base_frame_id", "base_link"));
   input_pose_frame_id_ = as2::tf::generateTfName(node_ptr_, input_pose_frame_id_);
   input_twist_frame_id_ = as2::tf::generateTfName(node_ptr_, input_twist_frame_id_);
   output_pose_frame_id_ = as2::tf::generateTfName(node_ptr_, output_pose_frame_id_);
@@ -131,8 +131,7 @@ ControllerHandler::ControllerHandler(
     as2_names::services::platform::list_control_modes, node_ptr_);
 
   // Timers
-  double cmd_freq = 0.0;
-  node_ptr_->get_parameter("cmd_freq", cmd_freq);
+  const double cmd_freq = node_ptr_->getParameter<double>("cmd_freq");
   control_timer_ =
     node_ptr_->create_timer(
     std::chrono::duration<double>(1.0 / cmd_freq),
@@ -815,22 +814,17 @@ void ControllerHandler::publishCommand()
 
 void ControllerHandler::initializeDebugPublishers()
 {
-  // Helper that declares an optional string parameter holding a topic name and
-  // returns it. An empty value (default) keeps the publisher disabled.
-  auto declare_topic = [this](const std::string & name) -> std::string {
-      if (!node_ptr_->has_parameter(name)) {
-        node_ptr_->declare_parameter<std::string>(name, "");
-      }
-      return node_ptr_->get_parameter(name).as_string();
+  auto topic = [this](const std::string & name) {
+      return node_ptr_->getParameter<std::string>(name, "");
     };
 
-  const std::string state_pose_topic = declare_topic("debug.state_pose_topic");
-  const std::string state_twist_topic = declare_topic("debug.state_twist_topic");
-  const std::string ref_pose_topic = declare_topic("debug.reference_pose_topic");
-  const std::string ref_twist_topic = declare_topic("debug.reference_twist_topic");
-  const std::string ref_traj_topic = declare_topic("debug.reference_trajectory_topic");
-  const std::string ref_thrust_topic = declare_topic("debug.reference_thrust_topic");
-  const std::string compute_output_time_topic = declare_topic("debug.compute_output_time_topic");
+  const std::string state_pose_topic = topic("debug.state_pose_topic");
+  const std::string state_twist_topic = topic("debug.state_twist_topic");
+  const std::string ref_pose_topic = topic("debug.reference_pose_topic");
+  const std::string ref_twist_topic = topic("debug.reference_twist_topic");
+  const std::string ref_traj_topic = topic("debug.reference_trajectory_topic");
+  const std::string ref_thrust_topic = topic("debug.reference_thrust_topic");
+  const std::string compute_output_time_topic = topic("debug.compute_output_time_topic");
 
   const auto qos = rclcpp::SensorDataQoS();
   if (!state_pose_topic.empty()) {

--- a/as2_motion_controller/src/controller_manager.cpp
+++ b/as2_motion_controller/src/controller_manager.cpp
@@ -42,35 +42,27 @@ ControllerManager::ControllerManager(const rclcpp::NodeOptions & options)
 : as2::Node("controller_manager", get_modified_options(options)),
   tf_handler_(this)
 {
-  try {
-    this->get_parameter("plugin_name", plugin_name_);
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <plugin_name> not defined or malformed: %s",
-      e.what());
-    this->~ControllerManager();
-  }
+  plugin_name_ = this->getParameter<std::string>("plugin_name");
+  cmd_freq_ = this->getParameter<double>("cmd_freq");
+  info_freq_ = this->getParameter<double>("info_freq");
+  available_modes_config_file_ =
+    this->getParameter<std::string>("plugin_available_modes_config_file");
 
-  this->get_parameter("cmd_freq", cmd_freq_);
   if (cmd_freq_ <= 0.0f) {
     RCLCPP_ERROR(this->get_logger(), "Param cmd_freq must be greater than 0.0");
     assert(cmd_freq_ > 0.0f);
     return;
   }
 
-  this->get_parameter("info_freq", info_freq_);
   if (info_freq_ <= 0.0f) {
     RCLCPP_ERROR(this->get_logger(), "Param info_freq must be greater than 0.0");
     assert(info_freq_ > 0.0f);
     return;
   }
 
-  this->get_parameter("plugin_available_modes_config_file", available_modes_config_file_);
-
   // Resolve the body frame id once, namespaced
-  std::string base_frame = "base_link";
-  this->get_parameter("base_frame_id", base_frame);
-  base_link_frame_id_ = as2::tf::generateTfName(this, base_frame);
+  base_link_frame_id_ =
+    as2::tf::generateTfName(this, this->getParameter<std::string>("base_frame_id", "base_link"));
 
   loader_ =
     std::make_shared<pluginlib::ClassLoader<as2_motion_controller_plugin_base::ControllerBase>>(
@@ -194,7 +186,6 @@ void ControllerManager::modeTimerCallback()
 
 rclcpp::NodeOptions ControllerManager::get_modified_options(const rclcpp::NodeOptions & options)
 {
-  // Create a copy of the options and modify it
   rclcpp::NodeOptions modified_options = options;
   modified_options.allow_undeclared_parameters(true);
   modified_options.automatically_declare_parameters_from_overrides(true);

--- a/as2_motion_controller/src/param_utils.cpp
+++ b/as2_motion_controller/src/param_utils.cpp
@@ -40,11 +40,11 @@ namespace as2_motion_controller_param_utils
 {
 
 std::vector<double> readDoubleArray(
-  rclcpp::Node * node,
+  as2::Node * node,
   const std::string & name,
   std::size_t expected_size)
 {
-  auto values = node->get_parameter(name).as_double_array();
+  auto values = node->getParameter<std::vector<double>>(name);
   if (expected_size != 0 && values.size() != expected_size) {
     RCLCPP_FATAL(
       node->get_logger(),

--- a/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
+++ b/as2_state_estimator/include/as2_state_estimator/plugin_base.hpp
@@ -105,19 +105,13 @@ public:
     pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
       as2_names::topics::self_localization::pose, as2_names::topics::self_localization::qos);
 
-    // node_ptr_->declare_parameter<std::string>("base_frame", "base_link");
-    // node_ptr_->declare_parameter<std::string>("global_ref_frame", "earth");
-    // node_ptr_->declare_parameter<std::string>("odom_frame", "odom");
-    // node_ptr_->declare_parameter<std::string>("map_frame", "map");
-
-    node_ptr_->get_parameter("base_frame", base_frame_id_);
-    node_ptr_->get_parameter("global_ref_frame", earth_frame_id_);
-    node_ptr_->get_parameter("odom_frame", odom_frame_id_);
-    node_ptr_->get_parameter("map_frame", map_frame_id_);
-
-    base_frame_id_ = as2::tf::generateTfName(node_ptr_, base_frame_id_);
-    odom_frame_id_ = as2::tf::generateTfName(node_ptr_, odom_frame_id_);
-    map_frame_id_ = as2::tf::generateTfName(node_ptr_, map_frame_id_);
+    earth_frame_id_ = node_ptr_->getParameter<std::string>("global_ref_frame", "earth");
+    base_frame_id_ = as2::tf::generateTfName(
+      node_ptr_, node_ptr_->getParameter<std::string>("base_frame", "base_link"));
+    odom_frame_id_ = as2::tf::generateTfName(
+      node_ptr_, node_ptr_->getParameter<std::string>("odom_frame", "odom"));
+    map_frame_id_ = as2::tf::generateTfName(
+      node_ptr_, node_ptr_->getParameter<std::string>("map_frame", "map"));
     // !! WATCHOUT : earth_frame_id_ is not generated because it is a global frame
 
     on_setup();

--- a/as2_state_estimator/plugins/ground_truth/include/ground_truth.hpp
+++ b/as2_state_estimator/plugins/ground_truth/include/ground_truth.hpp
@@ -84,8 +84,8 @@ public:
   : as2_state_estimator_plugin_base::StateEstimatorBase() {}
   void on_setup() override
   {
-    node_ptr_->get_parameter("use_gps", use_gps_);
-    node_ptr_->get_parameter("set_origin_on_start", set_origin_on_start_);
+    use_gps_ = node_ptr_->getParameter<bool>("use_gps", false);
+    set_origin_on_start_ = node_ptr_->getParameter<bool>("set_origin_on_start", false);
 
     pose_sub_ = node_ptr_->create_subscription<geometry_msgs::msg::PoseStamped>(
       as2_names::topics::ground_truth::pose, as2_names::topics::ground_truth::qos,
@@ -120,9 +120,9 @@ public:
         node_ptr_->has_parameter("set_origin.lon") &&
         node_ptr_->has_parameter("set_origin.alt"))
       {
-        node_ptr_->get_parameter("set_origin.lat", origin_lat_);
-        node_ptr_->get_parameter("set_origin.lon", origin_lon_);
-        node_ptr_->get_parameter("set_origin.alt", origin_alt_);
+        origin_lat_ = node_ptr_->getParameter<double>("set_origin.lat");
+        origin_lon_ = node_ptr_->getParameter<double>("set_origin.lon");
+        origin_alt_ = node_ptr_->getParameter<double>("set_origin.alt");
 
         origin_ = std::make_unique<geographic_msgs::msg::GeoPoint>();
         origin_->latitude = origin_lat_;
@@ -141,12 +141,10 @@ public:
       as2::tf::getTransformation(get_map_frame(), get_odom_frame(), 0, 0, 0, 0, 0, 0);
 
     // TODO(javilinos): Remove for next release
-    if (node_ptr_->has_parameter("use_gazebo_tf")) {
-      node_ptr_->get_parameter("use_gazebo_tf", using_gazebo_tf_);
-      if (using_gazebo_tf_) {
-        RCLCPP_INFO(node_ptr_->get_logger(), "Using gazebo tfs");
-        set_base_frame(as2::tf::generateTfName("", node_ptr_->get_namespace()));
-      }
+    using_gazebo_tf_ = node_ptr_->getParameter<bool>("use_gazebo_tf", false);
+    if (using_gazebo_tf_) {
+      RCLCPP_INFO(node_ptr_->get_logger(), "Using gazebo tfs");
+      set_base_frame(as2::tf::generateTfName("", node_ptr_->get_namespace()));
     }
     publish_static_transform(earth_to_map_);
     publish_static_transform(map_to_odom);

--- a/as2_state_estimator/plugins/ground_truth_odometry_fuse/include/ground_truth_odometry_fuse.hpp
+++ b/as2_state_estimator/plugins/ground_truth_odometry_fuse/include/ground_truth_odometry_fuse.hpp
@@ -87,19 +87,18 @@ public:
   void on_setup() override
   {
     // Odometry
-    std::string odom_topic = as2_names::topics::sensor_measurements::odom;
-    node_ptr_->get_parameter("odom_topic", odom_topic);
+    const std::string odom_topic = node_ptr_->getParameter<std::string>(
+      "odom_topic", as2_names::topics::sensor_measurements::odom);
     odom_sub_ = node_ptr_->create_subscription<nav_msgs::msg::Odometry>(
       odom_topic, as2_names::topics::sensor_measurements::qos,
       std::bind(&Plugin::odomCallback, this, std::placeholders::_1));
 
     // Ground truth
-    std::string mocap_topic;
-    node_ptr_->get_parameter("mocap_topic", mocap_topic);
-    node_ptr_->get_parameter("rigid_body_name", rigid_body_name_);
+    const std::string mocap_topic = node_ptr_->getParameter<std::string>("mocap_topic", "");
+    rigid_body_name_ = node_ptr_->getParameter<std::string>("rigid_body_name", "");
     if (mocap_topic.empty() || rigid_body_name_.empty()) {
-      std::string ground_truth_topic;
-      node_ptr_->get_parameter("ground_truth_topic", ground_truth_topic);
+      const std::string ground_truth_topic =
+        node_ptr_->getParameter<std::string>("ground_truth_topic", "");
       ground_truth_sub_ = node_ptr_->create_subscription<geometry_msgs::msg::PoseStamped>(
         ground_truth_topic,
         as2_names::topics::sensor_measurements::qos,

--- a/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
+++ b/as2_state_estimator/plugins/mocap_pose/include/mocap_pose.hpp
@@ -74,35 +74,20 @@ public:
 
   void on_setup() override
   {
-    node_ptr_->get_parameter("mocap_topic", mocap_topic_);
+    mocap_topic_ = node_ptr_->getParameter<std::string>("mocap_topic", "");
     if (mocap_topic_.empty()) {
       RCLCPP_ERROR(node_ptr_->get_logger(), "Parameter 'mocap_topic' not set");
       throw std::runtime_error("Parameter 'mocap_topic' not set");
     }
-    node_ptr_->get_parameter("rigid_body_name", rigid_body_name_);
+    rigid_body_name_ = node_ptr_->getParameter<std::string>("rigid_body_name", "");
     if (rigid_body_name_.empty()) {
       RCLCPP_ERROR(node_ptr_->get_logger(), "Parameter 'rigid_body_name' not set");
       throw std::runtime_error("Parameter 'rigid_body_name' not set");
     }
 
-    try {
-      twist_alpha_ = node_ptr_->get_parameter("twist_smooth_filter_cte").as_double();
-    } catch (const rclcpp::ParameterTypeException & e) {
-      RCLCPP_INFO(
-        node_ptr_->get_logger(),
-        "Parameter 'twist_smooth_filter_cte' not set. Filter disabled. Using default value: %f",
-        twist_alpha_);
-    }
-
-    try {
-      orientation_alpha_ = node_ptr_->get_parameter("orientation_smooth_filter_cte").as_double();
-    } catch (const rclcpp::ParameterTypeException & e) {
-      RCLCPP_INFO(
-        node_ptr_->get_logger(),
-        "Parameter 'orientation_smooth_filter_cte' not set. Filter disabled. Using "
-        "default value: %f",
-        orientation_alpha_);
-    }
+    twist_alpha_ = node_ptr_->getParameter<double>("twist_smooth_filter_cte", twist_alpha_);
+    orientation_alpha_ =
+      node_ptr_->getParameter<double>("orientation_smooth_filter_cte", orientation_alpha_);
 
     rigid_bodies_sub_ = node_ptr_->create_subscription<mocap4r2_msgs::msg::RigidBodies>(
       mocap_topic_, rclcpp::QoS(10),

--- a/as2_state_estimator/plugins/raw_odometry/include/raw_odometry.hpp
+++ b/as2_state_estimator/plugins/raw_odometry/include/raw_odometry.hpp
@@ -84,17 +84,15 @@ public:
 
   void on_setup() override
   {
-    std::string odom_topic = as2_names::topics::sensor_measurements::odom;
-    node_ptr_->get_parameter("odom_topic", odom_topic);
+    const std::string odom_topic = node_ptr_->getParameter<std::string>(
+      "odom_topic", as2_names::topics::sensor_measurements::odom);
     odom_sub_ = node_ptr_->create_subscription<nav_msgs::msg::Odometry>(
       odom_topic, as2_names::topics::sensor_measurements::qos,
       std::bind(&Plugin::odom_callback, this, std::placeholders::_1));
 
-    node_ptr_->get_parameter("use_gps", use_gps_);
-
-    node_ptr_->get_parameter("set_origin_on_start", set_origin_on_start_);
-
-    node_ptr_->get_parameter("set_map_to_odom", set_map_to_odom_);
+    use_gps_ = node_ptr_->getParameter<bool>("use_gps", false);
+    set_origin_on_start_ = node_ptr_->getParameter<bool>("set_origin_on_start", false);
+    set_map_to_odom_ = node_ptr_->getParameter<bool>("set_map_to_odom", true);
     if (!set_map_to_odom_ && use_gps_) {
       RCLCPP_WARN(
         node_ptr_->get_logger(),
@@ -115,19 +113,9 @@ public:
     // If use gps, use earth_to_map_height from parameters and
     // wait for gps origin (parameters, service or topic) to set earth_to_map
     if (!use_gps_) {
-      double earth_to_map_x = 0.0;
-      double earth_to_map_y = 0.0;
-      double earth_to_map_z = 0.0;
-
-      if (node_ptr_->has_parameter("earth_to_map.x")) {
-        node_ptr_->get_parameter("earth_to_map.x", earth_to_map_x);
-      }
-      if (node_ptr_->has_parameter("earth_to_map.y")) {
-        node_ptr_->get_parameter("earth_to_map.y", earth_to_map_y);
-      }
-      if (node_ptr_->has_parameter("earth_to_map.z")) {
-        node_ptr_->get_parameter("earth_to_map.z", earth_to_map_z);
-      }
+      const double earth_to_map_x = node_ptr_->getParameter<double>("earth_to_map.x", 0.0);
+      const double earth_to_map_y = node_ptr_->getParameter<double>("earth_to_map.y", 0.0);
+      const double earth_to_map_z = node_ptr_->getParameter<double>("earth_to_map.z", 0.0);
       RCLCPP_INFO(
         node_ptr_->get_logger(), "Earth to map set to %f, %f, %f", earth_to_map_x, earth_to_map_y,
         earth_to_map_z);
@@ -152,18 +140,15 @@ public:
         as2_names::topics::sensor_measurements::gps, as2_names::topics::sensor_measurements::qos,
         std::bind(&Plugin::gps_callback, this, std::placeholders::_1));
 
-      if (node_ptr_->has_parameter("earth_to_map_height")) {
-        node_ptr_->get_parameter("earth_to_map_height", earth_to_map_height_);
-        RCLCPP_INFO(node_ptr_->get_logger(), "Earth to map height set to %f", earth_to_map_height_);
-      }
+      earth_to_map_height_ = node_ptr_->getParameter<double>("earth_to_map_height", 0.0);
 
       if (set_origin_on_start_ && node_ptr_->has_parameter("set_origin.lat") &&
         node_ptr_->has_parameter("set_origin.lon") &&
         node_ptr_->has_parameter("set_origin.alt"))
       {
-        node_ptr_->get_parameter("set_origin.lat", origin_lat_);
-        node_ptr_->get_parameter("set_origin.lon", origin_lon_);
-        node_ptr_->get_parameter("set_origin.alt", origin_alt_);
+        origin_lat_ = node_ptr_->getParameter<double>("set_origin.lat");
+        origin_lon_ = node_ptr_->getParameter<double>("set_origin.lon");
+        origin_alt_ = node_ptr_->getParameter<double>("set_origin.alt");
 
         origin_ = std::make_unique<geographic_msgs::msg::GeoPoint>();
         origin_->latitude = origin_lat_;

--- a/as2_state_estimator/src/as2_state_estimator.cpp
+++ b/as2_state_estimator/src/as2_state_estimator.cpp
@@ -48,15 +48,7 @@ StateEstimator::StateEstimator(const rclcpp::NodeOptions & options)
   tf_handler_ = std::make_shared<as2::tf::TfHandler>(this);
   tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
   tfstatic_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
-  try {
-    this->get_parameter("plugin_name", plugin_name_);
-  } catch (const rclcpp::ParameterTypeException & e) {
-    RCLCPP_FATAL(
-      this->get_logger(), "Launch argument <plugin_name> not defined or malformed: %s",
-      e.what());
-    this->~StateEstimator();
-  }
-  plugin_name_ += "::Plugin";
+  plugin_name_ = this->getParameter<std::string>("plugin_name") + "::Plugin";
   loader_ =
     std::make_shared<pluginlib::ClassLoader<as2_state_estimator_plugin_base::StateEstimatorBase>>(
     "as2_state_estimator", "as2_state_estimator_plugin_base::StateEstimatorBase");

--- a/as2_utilities/as2_external_object_to_tf/src/as2_external_object_to_tf.cpp
+++ b/as2_utilities/as2_external_object_to_tf/src/as2_external_object_to_tf.cpp
@@ -41,22 +41,9 @@
 As2ExternalObjectToTf::As2ExternalObjectToTf()
 : as2::Node("external_object_to_tf")
 {
-  try {
-    this->declare_parameter("config_file", "config/external_objects.yaml");
-    this->get_parameter("config_file", config_path_);
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(this->get_logger(), "config_file parameter not set: %s", e.what());
-    config_path_ = "config/external_objects.yaml";
-  }
-
-  try {
-    this->declare_parameter("mocap_topic", "/mocap/rigid_bodies");
-    this->get_parameter("mocap_topic", mocap_topic_);
-  } catch (const std::exception & e) {
-    RCLCPP_WARN(this->get_logger(), "mocap_topic parameter not set: %s", e.what());
-    mocap_topic_ = "mocap/pose";
-  }
-  this->get_parameter("use_sim_time", use_sim_time);
+  config_path_ = this->getParameter<std::string>("config_file", "config/external_objects.yaml");
+  mocap_topic_ = this->getParameter<std::string>("mocap_topic", "/mocap/rigid_bodies");
+  use_sim_time = this->getParameter<bool>("use_sim_time", false);
 }
 
 void As2ExternalObjectToTf::poseCallback(

--- a/as2_utilities/as2_geozones/src/as2_geozones.cpp
+++ b/as2_utilities/as2_geozones/src/as2_geozones.cpp
@@ -39,11 +39,6 @@
 Geozones::Geozones()
 : as2::Node("geozones")
 {
-  this->declare_parameter<std::string>(
-    "config_file",
-    "geozones/geofences.yaml");
-
-  this->declare_parameter<bool>("debug_rviz", true);
 }
 
 void Geozones::run()
@@ -426,8 +421,8 @@ using CallbackReturn =
 
 CallbackReturn Geozones::on_configure(const rclcpp_lifecycle::State & _state)
 {
-  this->get_parameter("config_file", config_path_);
-  this->get_parameter("debug_rviz", rviz_visualization_);
+  config_path_ = this->getParameter<std::string>("config_file", "geozones/geofences.yaml");
+  rviz_visualization_ = this->getParameter<bool>("debug_rviz", true);
 
   setupNode();
 


### PR DESCRIPTION
> Based on #985. Review that one first: this branch contains its commit.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Gazebo, Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Adds `as2::Node::getParameter<T>(name, default_value, required)`: declares the parameter when it is not declared yet, reads it, and logs `name = value`. Six packages had grown their own near-identical helper; this is now the only one.
* Removes those helpers. Net **-242 lines**:
  * `getParameter<T>` in `as2_usb_camera_interface` and `as2_behaviors_object_perception` were **byte-identical duplicates**, and so were their `paramToString<T>` helpers.
  * `getParam<T>` in `as2_platform_multirotor_simulator` was duplicated between two headers of the same package.
  * The free `getParameter()` of `as2_behaviors_trajectory_generation` added nothing over the node one. Its two member wrappers stay: they qualify the parameter name with the plugin namespace, which `as2::Node` cannot know.
  * `readParam<T>` in `as2_motion_controller/param_utils.hpp` had no callers at all.
* Fixes a latent bug: the deleted helpers called `node_ptr->~Node()` on a missing parameter, explicitly destroying a live object that is destroyed again later. The exception now propagates instead.

### Behaviour change, worth a changelog line

The old helpers caught every exception, logged an error and **left the destination variable untouched**, so a parameter declared without a default silently fell back to whatever the variable held. Reading a required parameter that nothing provides now aborts node construction.

Every migrated call site was checked against the yaml files that ship with each package: all 48 parameters of the multirotor simulator and all 14 of the trajectory generation behaviour are provided, so none of them relied on that fallback.
