### PR TITLE
[as2_motion_controller] Use the specified available modes config file

### DIFF
--- a/as2_motion_controller/include/as2_motion_controller/controller_manager.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_manager.hpp
@@ -99,11 +99,13 @@ private:
 
 private:
   /**
-   * @brief Read the available control modes file and configure the handler.
+   * @brief Read the available control modes source and configure the handler.
    *
-   * @param project_path Path to the YAML file describing the modes the plugin can handle.
+   * @param config_path Exact YAML file or legacy config directory describing the modes.
+   * @param read_exact_file Whether to read only @p config_path instead of scanning the directory.
    */
-  void configAvailableControlModes(const std::filesystem::path project_path);
+  void configAvailableControlModes(
+    const std::filesystem::path & config_path, bool read_exact_file);
 
   /**
    * @brief Periodic callback that publishes the active control modes on `controller/info`.

--- a/as2_motion_controller/src/controller_manager.cpp
+++ b/as2_motion_controller/src/controller_manager.cpp
@@ -101,8 +101,9 @@ ControllerManager::ControllerManager(const rclcpp::NodeOptions & options)
     return;
   }
 
-  // controller_handler_->initialize(this);
-  if (available_modes_config_file_.empty()) {
+  // Preserve the legacy directory search only when no exact file was configured.
+  const bool read_exact_modes_file = !available_modes_config_file_.empty();
+  if (!read_exact_modes_file) {
     // Get the path of the package
     available_modes_config_file_ = loader_->getPluginManifestPath(pluginlib_class_id);
 
@@ -127,11 +128,14 @@ ControllerManager::ControllerManager(const rclcpp::NodeOptions & options)
     }
   }
 
-  RCLCPP_DEBUG(
-    this->get_logger(), "MODES FILE LOADED: %s",
-    available_modes_config_file_.parent_path().c_str());
+  const auto modes_config_source = read_exact_modes_file ?
+    available_modes_config_file_ : available_modes_config_file_.parent_path();
 
-  configAvailableControlModes(available_modes_config_file_.parent_path());
+  RCLCPP_DEBUG(
+    this->get_logger(), "MODES CONFIG LOADED: %s",
+    modes_config_source.c_str());
+
+  configAvailableControlModes(modes_config_source, read_exact_modes_file);
 
   mode_pub_ = this->create_publisher<as2_msgs::msg::ControllerInfo>(
     as2_names::topics::controller::info, as2_names::topics::controller::qos_info);
@@ -143,12 +147,19 @@ ControllerManager::ControllerManager(const rclcpp::NodeOptions & options)
 
 ControllerManager::~ControllerManager() {}
 
-void ControllerManager::configAvailableControlModes(const std::filesystem::path project_path)
+void ControllerManager::configAvailableControlModes(
+  const std::filesystem::path & config_path, bool read_exact_file)
 {
+  const auto find_modes = [&config_path, read_exact_file](const std::string & tag) {
+      if (read_exact_file) {
+        return as2::yaml::find_tag_in_yaml_file<std::string>(config_path, tag);
+      }
+      return as2::yaml::find_tag_from_project_exports_path<std::string>(config_path, tag);
+    };
+
   auto available_input_modes =
     as2::yaml::parse_uint_from_string(
-    as2::yaml::find_tag_from_project_exports_path<std::string>(
-      project_path, "input_control_modes"));
+    find_modes("input_control_modes"));
   RCLCPP_INFO(this->get_logger(), "==========================================================");
   RCLCPP_INFO(this->get_logger(), "AVAILABLE INPUT MODES: ");
   for (auto mode : available_input_modes) {
@@ -158,8 +169,7 @@ void ControllerManager::configAvailableControlModes(const std::filesystem::path 
   }
   auto available_output_modes =
     as2::yaml::parse_uint_from_string(
-    as2::yaml::find_tag_from_project_exports_path<std::string>(
-      project_path, "output_control_modes"));
+    find_modes("output_control_modes"));
   RCLCPP_INFO(this->get_logger(), "AVAILABLE OUTPUT MODES: ");
   for (auto mode : available_output_modes) {
     RCLCPP_INFO(this->get_logger(), "\t -%s", as2::control_mode::controlModeToString(mode).c_str());

--- a/as2_motion_controller/tests/as2_motion_controller_gtest.cpp
+++ b/as2_motion_controller/tests/as2_motion_controller_gtest.cpp
@@ -35,12 +35,20 @@
 */
 
 #include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
 #include "as2_motion_controller/controller_manager.hpp"
 
 std::shared_ptr<controller_manager::ControllerManager> getControllerManagerNode(
-  const std::string plugin_name)
+  const std::string plugin_name,
+  const std::optional<std::string> & available_modes_config_file = std::nullopt)
 {
   const std::string & name_space = "test_as2_motion_controller";
   const std::string package_path =
@@ -49,8 +57,9 @@ std::shared_ptr<controller_manager::ControllerManager> getControllerManagerNode(
     "/config/motion_controller_default.yaml";
   const std::string plugin_config_file = package_path + "/plugins/" + plugin_name +
     "/config/controller_default.yaml";
-  const std::string available_modes = package_path + "/plugins/" + plugin_name +
-    "/config/available_modes.yaml";
+  const std::string available_modes = !available_modes_config_file.has_value() ?
+    package_path + "/plugins/" + plugin_name + "/config/available_modes.yaml" :
+    available_modes_config_file.value();
 
   std::vector<std::string> node_args = {
     "--ros-args",
@@ -60,8 +69,6 @@ std::shared_ptr<controller_manager::ControllerManager> getControllerManagerNode(
     "namespace:=" + name_space,
     "-p",
     "plugin_name:=" + plugin_name,
-    "-p",
-    "plugin_available_modes_config_file:=" + available_modes,
     "--params-file",
     state_estimator_config_file,
     "--params-file",
@@ -70,6 +77,10 @@ std::shared_ptr<controller_manager::ControllerManager> getControllerManagerNode(
 
   auto node_options = rclcpp::NodeOptions();
   node_options.arguments(node_args);
+  node_options.parameter_overrides(
+  {
+    rclcpp::Parameter("plugin_available_modes_config_file", available_modes),
+  });
 
   return std::make_shared<controller_manager::ControllerManager>(node_options);
 }
@@ -92,6 +103,34 @@ TEST(As2MotionControllerGTest, PluginLoadPidSpeedController) {
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node);
   executor.spin_some();
+}
+
+TEST(As2MotionControllerGTest, PluginLoadWithDefaultModesSearch) {
+  EXPECT_NO_THROW(getControllerManagerNode("pid_speed_controller", std::string("")));
+}
+
+TEST(As2MotionControllerGTest, IgnoresUnrelatedYamlNextToAvailableModes) {
+  const auto temp_dir = std::filesystem::temp_directory_path() /
+    ("as2_motion_controller_test_" + std::to_string(
+      std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(temp_dir);
+
+  const auto available_modes = temp_dir / "available_modes.yaml";
+  std::ofstream(available_modes) <<
+    "input_control_modes:\n"
+    "  - 0b01100000\n"
+    "output_control_modes:\n"
+    "  - 0b01000100\n";
+  std::ofstream(temp_dir / "unrelated.yaml") << "invalid: [\n";
+
+  testing::internal::CaptureStderr();
+  EXPECT_NO_THROW(getControllerManagerNode("pid_speed_controller", available_modes.string()));
+  const auto logs = testing::internal::GetCapturedStderr();
+
+  EXPECT_NE(logs.find("POSITION YAW_ANGLE"), std::string::npos);
+  EXPECT_NE(logs.find("SPEED YAW_SPEED"), std::string::npos);
+
+  std::filesystem::remove_all(temp_dir);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses | Fixes #902 |
| ROS2 version tested on | Not run locally; repository CI covers Humble and Jazzy |
| Aerial platform tested on | Other — not platform-specific; config-loading regression test |

## Description of contribution in a few bullet points

- Preserve the exact `plugin_available_modes_config_file` path instead of reducing it to its parent directory.
- Read both input and output control modes from that configured file, so unrelated sibling YAML files are never parsed.
- Add a regression test with a valid modes file beside malformed unrelated YAML; the old directory-scanning path throws, while the fixed path loads the controller.

## Description of documentation updates required from your changes

None — this does not change the public parameter or YAML schema.

## Future work that may be required in bullet points

None.

## Validation

- `git diff --check` — passed.
- Independent static review of the focused three-file diff — passed.
- Local ROS execution was not completed: the CI-pinned Pixi 0.67.2 bootstrap stalled in concurrent `pixi-build-ros` package-cache lock contention on macOS arm64, including the targeted `--only as2_motion_controller` install. The added gtest is left for the repository's Humble/Jazzy CI matrix.
- Upstream CI on current head `5705b13a5919d264cec9c8589b0e7cfdb5fc5e30`: all 19 Humble, Jazzy, Pixi, platform, and Docker check runs completed successfully.

## GenAI use

Generated-by: OpenAI Codex (GPT-5)
