### PR TITLE
[as2_msgs] Add an id to the trajectory point

### DIFF
--- a/as2_msgs/msg/TrajectoryPoint.msg
+++ b/as2_msgs/msg/TrajectoryPoint.msg
@@ -1,5 +1,7 @@
 # Definition of a point of a trajectory
 
+string id                  # Unique identifier for the trajectory point
+
 geometry_msgs/Vector3 position      # Position of the vehicle in the frame_id frame
 geometry_msgs/Vector3 twist         # Twist of the vehicle in the frame_id frame
 geometry_msgs/Vector3 acceleration  # Acceleration of the vehicle in the frame_id frame


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | — |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* **A trajectory point can carry an identifier.** A waypoint already has one,
  through `PoseStampedWithID`, but the trajectory points generated from it did
  not, so the link between a setpoint and the waypoint it came from was lost.
  A consumer that needs to tell them apart can now read it from the point.