### PR TITLE
Implement direct platform command handlers

### DIFF
--- a/as2_motion_reference_handlers/CMakeLists.txt
+++ b/as2_motion_reference_handlers/CMakeLists.txt
@@ -70,6 +70,8 @@ ament_export_libraries(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  add_subdirectory(tests)
 endif()
 
 install(

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
@@ -38,20 +38,31 @@ __version__ = '0.1.0'
 from dataclasses import dataclass
 import time
 
-from as2_msgs.msg import ControllerInfo, ControlMode, TrajectorySetpoints
+from as2_core import as2_names
+from as2_msgs.msg import ControllerInfo, ControlMode, PlatformInfo, Thrust, TrajectorySetpoints
 from as2_msgs.srv import SetControlMode
 from geometry_msgs.msg import PoseStamped, TwistStamped
 from rclpy.node import MutuallyExclusiveCallbackGroup, Node
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_sensor_data, qos_profile_system_default
 
-as2_names_topic_motion_reference_qos = qos_profile_sensor_data
-as2_names_topic_motion_reference_pose = 'motion_reference/pose'
-as2_names_topic_motion_reference_twist = 'motion_reference/twist'
-as2_names_topic_motion_reference_trajectory = 'motion_reference/trajectory'
-as2_names_topic_controller_qos = qos_profile_system_default
-as2_names_topic_controller_info = 'controller/info'
-as2_names_srv_controller_set_control_mode = 'controller/set_control_mode'
+COMMAND_QOS = qos_profile_sensor_data
+CONTROL_MODE_INFO_QOS = qos_profile_system_default
+
+# When true, references are published to the aerial platform instead of to the
+# motion controller, and the control mode is negotiated with the platform
+USE_ACTUATOR_COMMANDS_PARAM = 'use_actuator_commands'
+
+
+def uses_actuator_commands(node: Node) -> bool:
+    """
+    Read the parameter that sends the references straight to the platform.
+
+    Several handlers share the same node, so the parameter may already be declared.
+    """
+    if not node.has_parameter(USE_ACTUATOR_COMMANDS_PARAM):
+        node.declare_parameter(USE_ACTUATOR_COMMANDS_PARAM, False)
+    return node.get_parameter(USE_ACTUATOR_COMMANDS_PARAM).value
 
 
 class Singleton(type):
@@ -76,6 +87,7 @@ class MotionReferenceHandlerBaseData:
     command_pose_pub_: Publisher
     command_twist_pub_: Publisher
     command_traj_pub_: Publisher
+    command_thrust_pub_: Publisher
 
 
 class BasicMotionReferencesBase(metaclass=Singleton):
@@ -91,22 +103,26 @@ class BasicMotionReferencesBase(metaclass=Singleton):
                 f'Instance of motion reference with {_node.get_namespace()} node already exists')
             return
 
+        topics = as2_names.topics.actuator_command if uses_actuator_commands(
+            _node) else as2_names.topics.motion_reference
+
         _command_pose_pub = _node.create_publisher(
-            PoseStamped, as2_names_topic_motion_reference_pose,
-            as2_names_topic_motion_reference_qos)
+            PoseStamped, topics.pose, COMMAND_QOS)
 
         _command_twist_pub = _node.create_publisher(
-            TwistStamped, as2_names_topic_motion_reference_twist,
-            as2_names_topic_motion_reference_qos)
+            TwistStamped, topics.twist, COMMAND_QOS)
 
         _command_traj_pub = _node.create_publisher(
-            TrajectorySetpoints, as2_names_topic_motion_reference_trajectory,
-            as2_names_topic_motion_reference_qos)
+            TrajectorySetpoints, topics.trajectory, COMMAND_QOS)
+
+        _command_thrust_pub = _node.create_publisher(
+            Thrust, topics.thrust, COMMAND_QOS)
 
         data = MotionReferenceHandlerBaseData(
             command_pose_pub_=_command_pose_pub,
             command_twist_pub_=_command_twist_pub,
-            command_traj_pub_=_command_traj_pub)
+            command_traj_pub_=_command_traj_pub,
+            command_thrust_pub_=_command_thrust_pub)
 
         self._instances_list[_node] = data
         _node.get_logger().debug(
@@ -124,6 +140,10 @@ class BasicMotionReferencesBase(metaclass=Singleton):
         """Publish a trajectory command."""
         self._instances_list[_node].command_traj_pub_.publish(_trajectory)
 
+    def publish_command_thrust(self, _node: Node, _thrust: Thrust):
+        """Publish a thrust command."""
+        self._instances_list[_node].command_thrust_pub_.publish(_thrust)
+
 
 class BasicMotionReferenceHandler():
     """Implementation of a motion reference handler base."""
@@ -140,22 +160,37 @@ class BasicMotionReferenceHandler():
         self.desired_control_mode_.control_mode = ControlMode.UNSET
         self.desired_control_mode_.reference_frame = ControlMode.UNDEFINED_FRAME
 
+        self.command_thrust_msg_ = Thrust()
+
         self.current_mode_ = ControlMode()
+        self.use_actuator_commands_ = uses_actuator_commands(node)
         my_callback_group = MutuallyExclusiveCallbackGroup()
-        self.controller_info_sub = node.create_subscription(
-            ControllerInfo, as2_names_topic_controller_info,
-            self.__controller_info_callback,
-            as2_names_topic_controller_qos,
-            callback_group=my_callback_group)
+        if self.use_actuator_commands_:
+            self.platform_info_sub = node.create_subscription(
+                PlatformInfo, as2_names.topics.platform.info,
+                self.__platform_info_callback,
+                CONTROL_MODE_INFO_QOS,
+                callback_group=my_callback_group)
+        else:
+            self.controller_info_sub = node.create_subscription(
+                ControllerInfo, as2_names.topics.controller.info,
+                self.__controller_info_callback,
+                CONTROL_MODE_INFO_QOS,
+                callback_group=my_callback_group)
 
     def __controller_info_callback(self, msg: ControllerInfo):
         """Call for the controller info topic."""
         self.current_mode_ = msg.input_control_mode
 
+    def __platform_info_callback(self, msg: PlatformInfo):
+        """Call for the platform info topic."""
+        self.current_mode_ = msg.current_control_mode
+
     def check_mode(self) -> bool:
         """Check if the current mode is the desired mode."""
+        # Hovering does not need to be settled again, whatever its yaw mode is
         if (self.desired_control_mode_.control_mode ==
-                self.current_mode_.control_mode) == ControlMode.HOVER:
+                self.current_mode_.control_mode == ControlMode.HOVER):
             return True
         if (self.desired_control_mode_.yaw_mode != self.current_mode_.yaw_mode or
                 self.desired_control_mode_.control_mode != self.current_mode_.control_mode):
@@ -163,8 +198,20 @@ class BasicMotionReferenceHandler():
                 return False
         return True
 
+    def check_frame_id(self, frame_id: str, reference: str) -> bool:
+        """Check that a reference carries the frame its data is expressed in."""
+        if frame_id:
+            return True
+        # Without a frame id the reference cannot be converted, and whoever
+        # receives it would act on it as if it were already in its own frame
+        self.node.get_logger().error(
+            f'Not sending {reference} reference without frame_id')
+        return False
+
     def send_pose_command(self) -> bool:
         """Send a pose command."""
+        if not self.check_frame_id(self.command_pose_msg_.header.frame_id, 'pose'):
+            return False
         if not self.check_mode():
             return False
         self.command_pose_msg_.header.stamp = self.node.get_clock().now().to_msg()
@@ -174,6 +221,8 @@ class BasicMotionReferenceHandler():
 
     def send_twist_command(self) -> bool:
         """Send a twist command."""
+        if not self.check_frame_id(self.command_twist_msg_.header.frame_id, 'twist'):
+            return False
         if not self.check_mode():
             return False
         self.command_twist_msg_.header.stamp = self.node.get_clock().now().to_msg()
@@ -183,21 +232,37 @@ class BasicMotionReferenceHandler():
 
     def send_trajectory_command(self) -> bool:
         """Send a trajectory command."""
+        if not self.check_frame_id(self.command_trajectory_msg_.header.frame_id, 'trajectory'):
+            return False
         if not self.check_mode():
             return False
         self.motion_handler_.publish_command_trajectory(
             self.node, self.command_trajectory_msg_)
         return True
 
+    def send_thrust_command(self) -> bool:
+        """Send a thrust command."""
+        if not self.check_mode():
+            return False
+        self.command_thrust_msg_.header.stamp = self.node.get_clock().now().to_msg()
+        self.motion_handler_.publish_command_thrust(
+            self.node, self.command_thrust_msg_)
+        return True
+
     def __set_mode(self, mode: ControlMode) -> bool:
-        """Set the control mode."""
-        set_control_mode_cli_ = self.node.create_client(
-            SetControlMode, as2_names_srv_controller_set_control_mode)
+        """
+        Set the control mode.
+
+        The platform validates the mode against the ones it supports, the
+        controller also looks for a way of synthesizing it with its plugin.
+        """
+        service_name = as2_names.services.platform.set_platform_control_mode \
+            if self.use_actuator_commands_ else as2_names.services.controller.set_control_mode
+        set_control_mode_cli_ = self.node.create_client(SetControlMode, service_name)
 
         if not set_control_mode_cli_.wait_for_service(timeout_sec=3):
             self.node.get_logger().error(
-                f'Service {self.node.get_namespace()}\
-                        /{as2_names_srv_controller_set_control_mode} not available')
+                f'Service {self.node.get_namespace()}/{service_name} not available')
             return False
 
         req = SetControlMode.Request()

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -44,6 +44,7 @@
 #include <as2_msgs/msg/control_mode.hpp>
 #include <as2_msgs/msg/thrust.hpp>
 #include <as2_msgs/msg/controller_info.hpp>
+#include <as2_msgs/msg/platform_info.hpp>
 #include <as2_msgs/msg/trajectory_setpoints.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -54,9 +55,26 @@ namespace as2
 {
 namespace motionReferenceHandlers
 {
+/**
+ * @brief Base class of the motion reference handlers, which publish motion
+ * references and negotiate the control mode they need.
+ *
+ * References are sent to the motion controller, unless the ROS 2 parameter
+ * use_actuator_commands of the node is true: then they are sent straight to the
+ * aerial platform, which is also the one the control mode is negotiated with.
+ * The platform must support the control modes the references need, since there
+ * is no controller in between to synthesize them.
+ */
 class BasicMotionReferenceHandler
 {
 public:
+  /**
+   * @brief Construct the handler, reading use_actuator_commands from the node
+   * and creating the publishers and the control mode subscription it selects.
+   *
+   * @param as2_ptr Node the references are published from.
+   * @param ns      Namespace of the drone. Empty to use the node namespace.
+   */
   explicit BasicMotionReferenceHandler(as2::Node * as2_ptr, const std::string & ns = "");
   ~BasicMotionReferenceHandler();
 
@@ -72,23 +90,59 @@ protected:
   as2_msgs::msg::ControlMode desired_control_mode_;
 
   bool sendThrustCommand();
+
+  /**
+   * @brief Send the current pose reference, settling the control mode first.
+   *
+   * @return true if the reference was published. False if it has no frame_id.
+   */
   bool sendPoseCommand();
+
+  /**
+   * @brief Send the current twist reference, settling the control mode first.
+   *
+   * @return true if the reference was published. False if it has no frame_id.
+   */
   bool sendTwistCommand();
+
+  /**
+   * @brief Send the current trajectory reference, settling the control mode first.
+   *
+   * @return true if the reference was published. False if it has no frame_id.
+   */
   bool sendTrajectoryCommand();
   bool checkMode();
 
 private:
-  static int number_of_instances_;
+  /**
+   * @brief Check that a reference carries the frame its data is expressed in.
+   *
+   * @param frame_id  Frame id of the reference message.
+   * @param reference Name of the reference, for the error message.
+   * @return true if the reference can be sent.
+   */
+  bool checkFrameId(const std::string & frame_id, const std::string & reference);
 
-  static rclcpp::Subscription<as2_msgs::msg::ControllerInfo>
-  ::SharedPtr controller_info_sub_;
-  static as2_msgs::msg::ControlMode current_mode_;
+  // References go straight to the platform, bypassing the motion controller
+  bool use_actuator_commands_ = false;
 
-  static rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr command_traj_pub_;
-  static rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr command_pose_pub_;
-  static rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
-  static rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;
+  // Only one of the two is created, depending on use_actuator_commands_
+  rclcpp::Subscription<as2_msgs::msg::ControllerInfo>::SharedPtr controller_info_sub_;
+  rclcpp::Subscription<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_sub_;
+  as2_msgs::msg::ControlMode current_mode_;
 
+  rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr command_traj_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr command_pose_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
+  rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;
+
+  /**
+   * @brief Negotiate a control mode with the motion controller, or with the
+   * aerial platform when use_actuator_commands is true.
+   *
+   * @param mode Control mode to request.
+   * @return true if the mode was accepted.
+   */
   bool setMode(const as2_msgs::msg::ControlMode & mode);
 };
 

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -52,65 +52,63 @@ BasicMotionReferenceHandler::BasicMotionReferenceHandler(
   const std::string & ns)
 : node_ptr_(as2_ptr), namespace_(ns)
 {
-  if (number_of_instances_ == 0) {
-    namespace_ = ns == "" ? ns : "/" + ns + "/";
+  namespace_ = ns == "" ? ns : "/" + ns + "/";
 
-    // Publisher
-    command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
-      namespace_ + as2_names::topics::motion_reference::trajectory,
-      as2_names::topics::motion_reference::qos);
+  use_actuator_commands_ = node_ptr_->getParameter<bool>("use_actuator_commands", false);
 
-    command_pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
-      namespace_ + as2_names::topics::motion_reference::pose,
-      as2_names::topics::motion_reference::qos);
+  // Publishers. Commands go to the platform, or to the motion controller
+  const std::string trajectory_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::trajectory :
+    as2_names::topics::motion_reference::trajectory;
+  const std::string pose_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::pose : as2_names::topics::motion_reference::pose;
+  const std::string twist_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::twist : as2_names::topics::motion_reference::twist;
+  const std::string thrust_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::thrust : as2_names::topics::motion_reference::thrust;
+  const rclcpp::QoS command_qos = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::qos : as2_names::topics::motion_reference::qos;
 
-    command_twist_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::TwistStamped>(
-      namespace_ + as2_names::topics::motion_reference::twist,
-      as2_names::topics::motion_reference::qos);
+  command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
+    namespace_ + trajectory_topic, command_qos);
 
-    command_thrust_pub_ = node_ptr_->create_publisher<as2_msgs::msg::Thrust>(
-      namespace_ + as2_names::topics::motion_reference::thrust,
-      as2_names::topics::motion_reference::qos);
+  command_pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
+    namespace_ + pose_topic, command_qos);
 
-    // Subscriber
+  command_twist_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::TwistStamped>(
+    namespace_ + twist_topic, command_qos);
+
+  command_thrust_pub_ = node_ptr_->create_publisher<as2_msgs::msg::Thrust>(
+    namespace_ + thrust_topic, command_qos);
+
+  // Subscriber to the current control mode, from the platform or the controller
+  if (use_actuator_commands_) {
+    platform_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::PlatformInfo>(
+      namespace_ + as2_names::topics::platform::info, rclcpp::QoS(1),
+      [this](const as2_msgs::msg::PlatformInfo::SharedPtr msg) {
+        current_mode_ = msg->current_control_mode;
+      });
+  } else {
     controller_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::ControllerInfo>(
       namespace_ + as2_names::topics::controller::info, rclcpp::QoS(1),
-      [](const as2_msgs::msg::ControllerInfo::SharedPtr msg) {
+      [this](const as2_msgs::msg::ControllerInfo::SharedPtr msg) {
         current_mode_ = msg->input_control_mode;
       });
-
-    // Set initial control mode
-    desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::NONE;
-    desired_control_mode_.control_mode = as2_msgs::msg::ControlMode::UNSET;
-    desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
   }
 
-  number_of_instances_++;
-  RCLCPP_DEBUG(
-    node_ptr_->get_logger(),
-    "There are %d instances of BasicMotionReferenceHandler created",
-    number_of_instances_);
+  // Set initial control mode
+  desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::NONE;
+  desired_control_mode_.control_mode = as2_msgs::msg::ControlMode::UNSET;
+  desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
 }
 
-BasicMotionReferenceHandler::~BasicMotionReferenceHandler()
-{
-  number_of_instances_--;
-  if (number_of_instances_ == 0 && node_ptr_ != nullptr) {
-    RCLCPP_DEBUG(node_ptr_->get_logger(), "Deleting node_ptr_");
-    controller_info_sub_.reset();
-    command_traj_pub_.reset();
-    command_pose_pub_.reset();
-    command_twist_pub_.reset();
-    command_thrust_pub_.reset();
-  }
-}
+BasicMotionReferenceHandler::~BasicMotionReferenceHandler() {}
 
 bool BasicMotionReferenceHandler::checkMode()
 {
-  // TODO(rps): Check comparation
-  // if (this->current_mode_ != desired_control_mode_)
+  // Hovering does not need to be settled again, whatever its yaw mode is
   if ((this->current_mode_.control_mode == desired_control_mode_.control_mode) &&
-    (this->current_mode_.control_mode == as2_msgs::msg::ControlMode::HOVER))
+    (desired_control_mode_.control_mode == as2_msgs::msg::ControlMode::HOVER))
   {
     return true;
   }
@@ -125,9 +123,22 @@ bool BasicMotionReferenceHandler::checkMode()
   return true;
 }
 
+bool BasicMotionReferenceHandler::checkFrameId(
+  const std::string & frame_id, const std::string & reference)
+{
+  if (!frame_id.empty()) {
+    return true;
+  }
+  // Without a frame id the reference cannot be converted, and whoever receives
+  // it would act on it as if it were already in its own frame
+  RCLCPP_ERROR(
+    node_ptr_->get_logger(), "Not sending %s reference without frame_id", reference.c_str());
+  return false;
+}
+
 bool BasicMotionReferenceHandler::sendPoseCommand()
 {
-  if (!checkMode()) {
+  if (!checkFrameId(command_pose_msg_.header.frame_id, "pose") || !checkMode()) {
     return false;
   }
   command_pose_pub_->publish(command_pose_msg_);
@@ -136,7 +147,7 @@ bool BasicMotionReferenceHandler::sendPoseCommand()
 
 bool BasicMotionReferenceHandler::sendTwistCommand()
 {
-  if (!checkMode()) {
+  if (!checkFrameId(command_twist_msg_.header.frame_id, "twist") || !checkMode()) {
     return false;
   }
   command_twist_pub_->publish(command_twist_msg_);
@@ -145,7 +156,7 @@ bool BasicMotionReferenceHandler::sendTwistCommand()
 
 bool BasicMotionReferenceHandler::sendTrajectoryCommand()
 {
-  if (!checkMode()) {
+  if (!checkFrameId(command_trajectory_msg_.header.frame_id, "trajectory") || !checkMode()) {
     return false;
   }
   command_traj_pub_->publish(command_trajectory_msg_);
@@ -172,39 +183,26 @@ bool BasicMotionReferenceHandler::setMode(const as2_msgs::msg::ControlMode & mod
   auto response = as2_msgs::srv::SetControlMode::Response();
   request.control_mode = mode;
 
+  const std::string set_mode_service = use_actuator_commands_ ?
+    as2_names::services::platform::set_platform_control_mode :
+    as2_names::services::controller::set_control_mode;
+
   auto set_mode_cli = as2::SynchronousServiceClient<as2_msgs::srv::SetControlMode>(
-    namespace_ + as2_names::services::controller::set_control_mode, node_ptr_);
+    namespace_ + set_mode_service, node_ptr_);
 
   bool out = set_mode_cli.sendRequest(request, response);
 
   if (out && response.success) {
     this->current_mode_ = mode;
-    // Sleep for controller info callback to update
+    // Sleep for the control mode callback to update
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     return true;
   }
   RCLCPP_ERROR(
     node_ptr_->get_logger(),
-    " Controller Control Mode was not able to be settled sucessfully");
+    "Control Mode was not able to be settled sucessfully");
   return false;
 }
-
-int BasicMotionReferenceHandler::number_of_instances_ = 0;
-
-rclcpp::Subscription<as2_msgs::msg::ControllerInfo>::SharedPtr
-BasicMotionReferenceHandler::controller_info_sub_ = nullptr;
-
-as2_msgs::msg::ControlMode BasicMotionReferenceHandler::current_mode_ =
-  as2_msgs::msg::ControlMode();
-
-rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr
-BasicMotionReferenceHandler::command_traj_pub_ = nullptr;
-rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr
-BasicMotionReferenceHandler::command_pose_pub_ = nullptr;
-rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr
-BasicMotionReferenceHandler::command_twist_pub_ = nullptr;
-rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr
-BasicMotionReferenceHandler::command_thrust_pub_ = nullptr;
 
 }    // namespace motionReferenceHandlers
 }  // namespace as2

--- a/as2_motion_reference_handlers/tests/CMakeLists.txt
+++ b/as2_motion_reference_handlers/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+file(GLOB GTEST_SOURCES *_gtest.cpp)
+
+foreach(GTEST_SOURCE ${GTEST_SOURCES})
+  get_filename_component(TEST_NAME ${GTEST_SOURCE} NAME_WE)
+
+  ament_add_gtest(${TEST_NAME} ${GTEST_SOURCE})
+  ament_target_dependencies(${TEST_NAME} ${PROJECT_DEPENDENCIES})
+  target_link_libraries(${TEST_NAME} ${PROJECT_NAME})
+endforeach()

--- a/as2_motion_reference_handlers/tests/motion_reference_handlers_gtest.cpp
+++ b/as2_motion_reference_handlers/tests/motion_reference_handlers_gtest.cpp
@@ -1,0 +1,265 @@
+// Copyright 2026 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*!*******************************************************************************************
+ *  \file       motion_reference_handlers_gtest.cpp
+ *  \brief      Tests for the destination of the motion references, either the motion
+ *              controller or the aerial platform.
+ *  \authors    Rafael Pérez Seguí
+ ********************************************************************************/
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "as2_motion_reference_handlers/position_motion.hpp"
+#include "as2_core/names/services.hpp"
+#include "as2_core/names/topics.hpp"
+#include "as2_msgs/msg/platform_info.hpp"
+#include "as2_msgs/srv/set_control_mode.hpp"
+#include "gtest/gtest.h"
+
+namespace as2
+{
+
+namespace
+{
+
+using std::chrono_literals::operator""ms;
+
+/**
+ * @class DestinationsMock, node playing both destinations of the motion
+ * references, the aerial platform and the motion controller, to tell which one
+ * the handlers are talking to
+ */
+class DestinationsMock : public rclcpp::Node
+{
+public:
+  DestinationsMock()
+  : rclcpp::Node("destinations_mock")
+  {
+    // Platform side
+    platform_mode_srv_ = create_service<as2_msgs::srv::SetControlMode>(
+      as2_names::services::platform::set_platform_control_mode,
+      [this](
+        const as2_msgs::srv::SetControlMode::Request::SharedPtr request,
+        as2_msgs::srv::SetControlMode::Response::SharedPtr response) {
+        requested_mode_ = request->control_mode;
+        platform_mode_requests_++;
+        response->success = true;
+      });
+
+    platform_info_pub_ = create_publisher<as2_msgs::msg::PlatformInfo>(
+      as2_names::topics::platform::info, as2_names::topics::platform::qos);
+
+    actuator_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+      as2_names::topics::actuator_command::pose, as2_names::topics::actuator_command::qos,
+      [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+        pose_command_ = *msg;
+        actuator_pose_commands_++;
+      });
+
+    actuator_twist_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+      as2_names::topics::actuator_command::twist, as2_names::topics::actuator_command::qos,
+      [this](const geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+        (void)msg;
+        actuator_twist_commands_++;
+      });
+
+    // Controller side
+    controller_mode_srv_ = create_service<as2_msgs::srv::SetControlMode>(
+      as2_names::services::controller::set_control_mode,
+      [this](
+        const as2_msgs::srv::SetControlMode::Request::SharedPtr request,
+        as2_msgs::srv::SetControlMode::Response::SharedPtr response) {
+        requested_mode_ = request->control_mode;
+        controller_mode_requests_++;
+        response->success = true;
+      });
+
+    controller_info_pub_ = create_publisher<as2_msgs::msg::ControllerInfo>(
+      as2_names::topics::controller::info, rclcpp::QoS(1));
+
+    reference_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+      as2_names::topics::motion_reference::pose, as2_names::topics::motion_reference::qos,
+      [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+        pose_command_ = *msg;
+        reference_pose_commands_++;
+      });
+
+    reference_twist_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+      as2_names::topics::motion_reference::twist, as2_names::topics::motion_reference::qos,
+      [this](const geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+        (void)msg;
+        reference_twist_commands_++;
+      });
+
+    info_timer_ = create_wall_timer(
+      100ms, [this]() {
+        as2_msgs::msg::PlatformInfo platform_info;
+        platform_info.header.stamp = now();
+        platform_info.current_control_mode = requested_mode_;
+        platform_info_pub_->publish(platform_info);
+
+        as2_msgs::msg::ControllerInfo controller_info;
+        controller_info.header.stamp = now();
+        controller_info.input_control_mode = requested_mode_;
+        controller_info_pub_->publish(controller_info);
+      });
+  }
+
+  as2_msgs::msg::ControlMode requested_mode_;
+  geometry_msgs::msg::PoseStamped pose_command_;
+  std::atomic_int platform_mode_requests_ = {0};
+  std::atomic_int controller_mode_requests_ = {0};
+  std::atomic_int actuator_pose_commands_ = {0};
+  std::atomic_int actuator_twist_commands_ = {0};
+  std::atomic_int reference_pose_commands_ = {0};
+  std::atomic_int reference_twist_commands_ = {0};
+
+private:
+  rclcpp::Service<as2_msgs::srv::SetControlMode>::SharedPtr platform_mode_srv_;
+  rclcpp::Service<as2_msgs::srv::SetControlMode>::SharedPtr controller_mode_srv_;
+  rclcpp::Publisher<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_pub_;
+  rclcpp::Publisher<as2_msgs::msg::ControllerInfo>::SharedPtr controller_info_pub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr actuator_pose_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr actuator_twist_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr reference_pose_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr reference_twist_sub_;
+  rclcpp::TimerBase::SharedPtr info_timer_;
+};
+
+std::shared_ptr<as2::Node> makeHandlerNode(const bool use_actuator_commands)
+{
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("use_actuator_commands", use_actuator_commands);
+  return std::make_shared<as2::Node>("motion_reference_test_node", options);
+}
+
+/**
+ * @brief Wait until a condition holds, spinning nothing: the nodes are spun by
+ * the executor thread of the test
+ */
+bool waitFor(const std::function<bool()> & condition, const int timeout_ms = 5000)
+{
+  for (int waited_ms = 0; waited_ms < timeout_ms; waited_ms += 10) {
+    if (condition()) {return true;}
+    std::this_thread::sleep_for(10ms);
+  }
+  return condition();
+}
+
+}  // namespace
+
+TEST(MotionReferenceHandlersTest, ActuatorCommandsGoToThePlatform)
+{
+  auto destinations = std::make_shared<DestinationsMock>();
+  auto node = makeHandlerNode(true);
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(destinations);
+  executor.add_node(node);
+  std::thread executor_thread([&executor]() {executor.spin();});
+
+  as2::motionReferenceHandlers::PositionMotion position_handler(node.get());
+
+  EXPECT_TRUE(
+    position_handler.sendPositionCommandWithYawAngle(
+      "earth", 1.0, 2.0, 3.0, 0.0, "earth", 0.5, 0.5, 0.5));
+
+  EXPECT_TRUE(
+    waitFor(
+      [&destinations]() {
+        return destinations->actuator_pose_commands_ > 0 &&
+        destinations->actuator_twist_commands_ > 0;
+      }));
+
+  // The mode is negotiated with the platform, and the commands reach it
+  EXPECT_EQ(destinations->platform_mode_requests_, 1);
+  EXPECT_EQ(destinations->controller_mode_requests_, 0);
+  EXPECT_EQ(
+    destinations->requested_mode_.control_mode, as2_msgs::msg::ControlMode::POSITION);
+  EXPECT_EQ(destinations->requested_mode_.yaw_mode, as2_msgs::msg::ControlMode::YAW_ANGLE);
+  EXPECT_EQ(destinations->pose_command_.pose.position.x, 1.0);
+
+  // The motion controller is out of the chain
+  EXPECT_EQ(destinations->reference_pose_commands_, 0);
+  EXPECT_EQ(destinations->reference_twist_commands_, 0);
+
+  executor.cancel();
+  executor_thread.join();
+}
+
+TEST(MotionReferenceHandlersTest, MotionReferencesGoToTheControllerByDefault)
+{
+  auto destinations = std::make_shared<DestinationsMock>();
+  auto node = makeHandlerNode(false);
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(destinations);
+  executor.add_node(node);
+  std::thread executor_thread([&executor]() {executor.spin();});
+
+  as2::motionReferenceHandlers::PositionMotion position_handler(node.get());
+
+  EXPECT_TRUE(
+    position_handler.sendPositionCommandWithYawAngle(
+      "earth", 1.0, 2.0, 3.0, 0.0, "earth", 0.5, 0.5, 0.5));
+
+  EXPECT_TRUE(
+    waitFor(
+      [&destinations]() {
+        return destinations->reference_pose_commands_ > 0 &&
+        destinations->reference_twist_commands_ > 0;
+      }));
+
+  // The mode is negotiated with the controller, and the commands reach it
+  EXPECT_EQ(destinations->controller_mode_requests_, 1);
+  EXPECT_EQ(destinations->platform_mode_requests_, 0);
+  EXPECT_EQ(destinations->pose_command_.pose.position.x, 1.0);
+
+  // The platform only gets commands through the controller
+  EXPECT_EQ(destinations->actuator_pose_commands_, 0);
+  EXPECT_EQ(destinations->actuator_twist_commands_, 0);
+
+  executor.cancel();
+  executor_thread.join();
+}
+
+}  // namespace as2
+
+int main(int argc, char * argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  auto result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Added `use_actuator_commands` parameter to motion reference handlers (C++ and Python)
* When enabled, handlers publish to `actuator_command/*` topics, bypassing motion controller
* Added frame validation: reject commands without `frame_id` to prevent silent frame mismatches
* Implemented dual subscription pattern: subscribes to `platform_info` or `controller_info` depending on parameter