### PR TITLE
[as2_motion_reference_handlers] Implement direct platform command handlers

### DIFF
--- a/as2_motion_reference_handlers/CMakeLists.txt
+++ b/as2_motion_reference_handlers/CMakeLists.txt
@@ -45,6 +45,7 @@ include_directories(
 
 set(SOURCE_CPP_FILES
   src/basic_motion_references.cpp
+  src/motion_reference_bus.cpp
   src/hover_motion.cpp
   src/trajectory_motion.cpp
   src/position_motion.cpp

--- a/as2_motion_reference_handlers/CMakeLists.txt
+++ b/as2_motion_reference_handlers/CMakeLists.txt
@@ -70,6 +70,8 @@ ament_export_libraries(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  add_subdirectory(tests)
 endif()
 
 install(

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
@@ -37,6 +37,7 @@ __version__ = '0.1.0'
 
 from dataclasses import dataclass
 import time
+import weakref
 
 from as2_core import as2_names
 from as2_msgs.msg import ControllerInfo, ControlMode, PlatformInfo, Thrust, TrajectorySetpoints
@@ -45,6 +46,7 @@ from geometry_msgs.msg import PoseStamped, TwistStamped
 from rclpy.node import MutuallyExclusiveCallbackGroup, Node
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_sensor_data, qos_profile_system_default
+from rclpy.subscription import Subscription
 
 COMMAND_QOS = qos_profile_sensor_data
 CONTROL_MODE_INFO_QOS = qos_profile_system_default
@@ -82,29 +84,45 @@ class Singleton(type):
 
 @dataclass
 class MotionReferenceHandlerBaseData:
-    """Implementation of a motion reference handler base data."""
+    """Resources shared by every handler built on the same node."""
 
     command_pose_pub_: Publisher
     command_twist_pub_: Publisher
     command_traj_pub_: Publisher
     command_thrust_pub_: Publisher
+    info_sub_: Subscription
+    current_mode_: ControlMode
 
 
 class BasicMotionReferencesBase(metaclass=Singleton):
-    """Implementation of a motion reference handler base for singletons."""
+    """
+    Owner of the resources every handler of a node shares.
 
-    _instances_list = {}
-    number_of_instances_ = -1
+    Several handlers on one node talk to the same controller or platform, so they must
+    share one set of publishers and, above all, one view of the active control mode: if
+    each kept its own, a mode settled by one handler would be unknown to the others.
+
+    Entries are held in a WeakKeyDictionary, so a node that goes away takes its publishers
+    with it instead of leaking them for the life of the process.
+    """
+
+    _instances_list = weakref.WeakKeyDictionary()
 
     def __init__(self, _node: Node):
-        """Construct of the motion reference handler."""
+        """
+        Build the shared resources of a node, or do nothing if they already exist.
+
+        :param _node: node the references are published from
+        :type _node: Node
+        """
         if _node in self._instances_list:
             _node.get_logger().debug(
                 f'Instance of motion reference with {_node.get_namespace()} node already exists')
             return
 
-        topics = as2_names.topics.actuator_command if uses_actuator_commands(
-            _node) else as2_names.topics.motion_reference
+        use_actuator_commands = uses_actuator_commands(_node)
+        topics = as2_names.topics.actuator_command if use_actuator_commands \
+            else as2_names.topics.motion_reference
 
         _command_pose_pub = _node.create_publisher(
             PoseStamped, topics.pose, COMMAND_QOS)
@@ -122,11 +140,49 @@ class BasicMotionReferencesBase(metaclass=Singleton):
             command_pose_pub_=_command_pose_pub,
             command_twist_pub_=_command_twist_pub,
             command_traj_pub_=_command_traj_pub,
-            command_thrust_pub_=_command_thrust_pub)
+            command_thrust_pub_=_command_thrust_pub,
+            info_sub_=None,
+            current_mode_=ControlMode())
+
+        # The subscription writes into data, so that every handler of this node reads the
+        # same active mode
+        callback_group = MutuallyExclusiveCallbackGroup()
+        if use_actuator_commands:
+            data.info_sub_ = _node.create_subscription(
+                PlatformInfo, as2_names.topics.platform.info,
+                lambda msg: setattr(data, 'current_mode_', msg.current_control_mode),
+                CONTROL_MODE_INFO_QOS, callback_group=callback_group)
+        else:
+            data.info_sub_ = _node.create_subscription(
+                ControllerInfo, as2_names.topics.controller.info,
+                lambda msg: setattr(data, 'current_mode_', msg.input_control_mode),
+                CONTROL_MODE_INFO_QOS, callback_group=callback_group)
 
         self._instances_list[_node] = data
         _node.get_logger().debug(
             f'Instance of motion reference with {_node.get_namespace()} node created')
+
+    def get_current_mode(self, _node: Node) -> ControlMode:
+        """
+        Get the control mode the controller, or the platform, reports as active.
+
+        :param _node: node the handler belongs to
+        :type _node: Node
+        :return: active control mode
+        :rtype: ControlMode
+        """
+        return self._instances_list[_node].current_mode_
+
+    def set_current_mode(self, _node: Node, _mode: ControlMode):
+        """
+        Record a control mode just accepted, so every handler of the node sees it.
+
+        :param _node: node the handler belongs to
+        :type _node: Node
+        :param _mode: mode the controller or platform accepted
+        :type _mode: ControlMode
+        """
+        self._instances_list[_node].current_mode_ = _mode
 
     def publish_command_pose(self, _node: Node, _pose: PoseStamped):
         """Publish a pose command."""
@@ -174,39 +230,7 @@ class BasicMotionReferenceHandler():
 
         self.command_thrust_msg_ = Thrust()
 
-        self.current_mode_ = ControlMode()
         self.use_actuator_commands_ = uses_actuator_commands(node)
-        my_callback_group = MutuallyExclusiveCallbackGroup()
-        if self.use_actuator_commands_:
-            self.platform_info_sub = node.create_subscription(
-                PlatformInfo, as2_names.topics.platform.info,
-                self.__platform_info_callback,
-                CONTROL_MODE_INFO_QOS,
-                callback_group=my_callback_group)
-        else:
-            self.controller_info_sub = node.create_subscription(
-                ControllerInfo, as2_names.topics.controller.info,
-                self.__controller_info_callback,
-                CONTROL_MODE_INFO_QOS,
-                callback_group=my_callback_group)
-
-    def __controller_info_callback(self, msg: ControllerInfo):
-        """
-        Track the mode the motion controller reports as active.
-
-        :param msg: controller info
-        :type msg: ControllerInfo
-        """
-        self.current_mode_ = msg.input_control_mode
-
-    def __platform_info_callback(self, msg: PlatformInfo):
-        """
-        Track the mode the platform reports as active, used with use_actuator_commands.
-
-        :param msg: platform info
-        :type msg: PlatformInfo
-        """
-        self.current_mode_ = msg.current_control_mode
 
     def check_mode(self) -> bool:
         """
@@ -218,11 +242,12 @@ class BasicMotionReferenceHandler():
         :rtype: bool
         """
         # Hovering does not need to be settled again, whatever its yaw mode is
+        current_mode = self.motion_handler_.get_current_mode(self.node)
         if (self.desired_control_mode_.control_mode ==
-                self.current_mode_.control_mode == ControlMode.HOVER):
+                current_mode.control_mode == ControlMode.HOVER):
             return True
-        if (self.desired_control_mode_.yaw_mode != self.current_mode_.yaw_mode or
-                self.desired_control_mode_.control_mode != self.current_mode_.control_mode):
+        if (self.desired_control_mode_.yaw_mode != current_mode.yaw_mode or
+                self.desired_control_mode_.control_mode != current_mode.control_mode):
             if not self.__set_mode(self.desired_control_mode_):
                 return False
         return True
@@ -331,7 +356,8 @@ class BasicMotionReferenceHandler():
         resp = set_control_mode_cli_.call(req)
         if resp.success:
             init_time = self.node.get_clock().now()
-            while self.current_mode_.control_mode != mode.control_mode:
+            while self.motion_handler_.get_current_mode(
+                    self.node).control_mode != mode.control_mode:
                 if (self.node.get_clock().now() - init_time).nanoseconds > 5e9:
                     self.node.get_logger().error(
                         f'Timeout waiting for mode {mode.control_mode}')

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
@@ -171,7 +171,6 @@ class BasicMotionReferenceHandler():
         self.desired_control_mode_ = ControlMode()
         self.desired_control_mode_.yaw_mode = ControlMode.NONE
         self.desired_control_mode_.control_mode = ControlMode.UNSET
-        self.desired_control_mode_.reference_frame = ControlMode.UNDEFINED_FRAME
 
         self.command_thrust_msg_ = Thrust()
 

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
@@ -38,20 +38,31 @@ __version__ = '0.1.0'
 from dataclasses import dataclass
 import time
 
-from as2_msgs.msg import ControllerInfo, ControlMode, TrajectorySetpoints
+from as2_core import as2_names
+from as2_msgs.msg import ControllerInfo, ControlMode, PlatformInfo, Thrust, TrajectorySetpoints
 from as2_msgs.srv import SetControlMode
 from geometry_msgs.msg import PoseStamped, TwistStamped
 from rclpy.node import MutuallyExclusiveCallbackGroup, Node
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_sensor_data, qos_profile_system_default
 
-as2_names_topic_motion_reference_qos = qos_profile_sensor_data
-as2_names_topic_motion_reference_pose = 'motion_reference/pose'
-as2_names_topic_motion_reference_twist = 'motion_reference/twist'
-as2_names_topic_motion_reference_trajectory = 'motion_reference/trajectory'
-as2_names_topic_controller_qos = qos_profile_system_default
-as2_names_topic_controller_info = 'controller/info'
-as2_names_srv_controller_set_control_mode = 'controller/set_control_mode'
+COMMAND_QOS = qos_profile_sensor_data
+CONTROL_MODE_INFO_QOS = qos_profile_system_default
+
+# When true, references are published to the aerial platform instead of to the
+# motion controller, and the control mode is negotiated with the platform
+USE_ACTUATOR_COMMANDS_PARAM = 'use_actuator_commands'
+
+
+def uses_actuator_commands(node: Node) -> bool:
+    """
+    Read the parameter that sends the references straight to the platform.
+
+    Several handlers share the same node, so the parameter may already be declared.
+    """
+    if not node.has_parameter(USE_ACTUATOR_COMMANDS_PARAM):
+        node.declare_parameter(USE_ACTUATOR_COMMANDS_PARAM, False)
+    return node.get_parameter(USE_ACTUATOR_COMMANDS_PARAM).value
 
 
 class Singleton(type):
@@ -76,6 +87,7 @@ class MotionReferenceHandlerBaseData:
     command_pose_pub_: Publisher
     command_twist_pub_: Publisher
     command_traj_pub_: Publisher
+    command_thrust_pub_: Publisher
 
 
 class BasicMotionReferencesBase(metaclass=Singleton):
@@ -91,22 +103,26 @@ class BasicMotionReferencesBase(metaclass=Singleton):
                 f'Instance of motion reference with {_node.get_namespace()} node already exists')
             return
 
+        topics = as2_names.topics.actuator_command if uses_actuator_commands(
+            _node) else as2_names.topics.motion_reference
+
         _command_pose_pub = _node.create_publisher(
-            PoseStamped, as2_names_topic_motion_reference_pose,
-            as2_names_topic_motion_reference_qos)
+            PoseStamped, topics.pose, COMMAND_QOS)
 
         _command_twist_pub = _node.create_publisher(
-            TwistStamped, as2_names_topic_motion_reference_twist,
-            as2_names_topic_motion_reference_qos)
+            TwistStamped, topics.twist, COMMAND_QOS)
 
         _command_traj_pub = _node.create_publisher(
-            TrajectorySetpoints, as2_names_topic_motion_reference_trajectory,
-            as2_names_topic_motion_reference_qos)
+            TrajectorySetpoints, topics.trajectory, COMMAND_QOS)
+
+        _command_thrust_pub = _node.create_publisher(
+            Thrust, topics.thrust, COMMAND_QOS)
 
         data = MotionReferenceHandlerBaseData(
             command_pose_pub_=_command_pose_pub,
             command_twist_pub_=_command_twist_pub,
-            command_traj_pub_=_command_traj_pub)
+            command_traj_pub_=_command_traj_pub,
+            command_thrust_pub_=_command_thrust_pub)
 
         self._instances_list[_node] = data
         _node.get_logger().debug(
@@ -124,6 +140,10 @@ class BasicMotionReferencesBase(metaclass=Singleton):
         """Publish a trajectory command."""
         self._instances_list[_node].command_traj_pub_.publish(_trajectory)
 
+    def publish_command_thrust(self, _node: Node, _thrust: Thrust):
+        """Publish a thrust command."""
+        self._instances_list[_node].command_thrust_pub_.publish(_thrust)
+
 
 class BasicMotionReferenceHandler():
     """Implementation of a motion reference handler base."""
@@ -138,23 +158,39 @@ class BasicMotionReferenceHandler():
         self.desired_control_mode_ = ControlMode()
         self.desired_control_mode_.yaw_mode = ControlMode.NONE
         self.desired_control_mode_.control_mode = ControlMode.UNSET
+        self.desired_control_mode_.reference_frame = ControlMode.UNDEFINED_FRAME
+
+        self.command_thrust_msg_ = Thrust()
 
         self.current_mode_ = ControlMode()
+        self.use_actuator_commands_ = uses_actuator_commands(node)
         my_callback_group = MutuallyExclusiveCallbackGroup()
-        self.controller_info_sub = node.create_subscription(
-            ControllerInfo, as2_names_topic_controller_info,
-            self.__controller_info_callback,
-            as2_names_topic_controller_qos,
-            callback_group=my_callback_group)
+        if self.use_actuator_commands_:
+            self.platform_info_sub = node.create_subscription(
+                PlatformInfo, as2_names.topics.platform.info,
+                self.__platform_info_callback,
+                CONTROL_MODE_INFO_QOS,
+                callback_group=my_callback_group)
+        else:
+            self.controller_info_sub = node.create_subscription(
+                ControllerInfo, as2_names.topics.controller.info,
+                self.__controller_info_callback,
+                CONTROL_MODE_INFO_QOS,
+                callback_group=my_callback_group)
 
     def __controller_info_callback(self, msg: ControllerInfo):
         """Call for the controller info topic."""
         self.current_mode_ = msg.input_control_mode
 
+    def __platform_info_callback(self, msg: PlatformInfo):
+        """Call for the platform info topic."""
+        self.current_mode_ = msg.current_control_mode
+
     def check_mode(self) -> bool:
         """Check if the current mode is the desired mode."""
+        # Hovering does not need to be settled again, whatever its yaw mode is
         if (self.desired_control_mode_.control_mode ==
-                self.current_mode_.control_mode) == ControlMode.HOVER:
+                self.current_mode_.control_mode == ControlMode.HOVER):
             return True
         if (self.desired_control_mode_.yaw_mode != self.current_mode_.yaw_mode or
                 self.desired_control_mode_.control_mode != self.current_mode_.control_mode):
@@ -162,8 +198,20 @@ class BasicMotionReferenceHandler():
                 return False
         return True
 
+    def check_frame_id(self, frame_id: str, reference: str) -> bool:
+        """Check that a reference carries the frame its data is expressed in."""
+        if frame_id:
+            return True
+        # Without a frame id the reference cannot be converted, and whoever
+        # receives it would act on it as if it were already in its own frame
+        self.node.get_logger().error(
+            f'Not sending {reference} reference without frame_id')
+        return False
+
     def send_pose_command(self) -> bool:
         """Send a pose command."""
+        if not self.check_frame_id(self.command_pose_msg_.header.frame_id, 'pose'):
+            return False
         if not self.check_mode():
             return False
         self.command_pose_msg_.header.stamp = self.node.get_clock().now().to_msg()
@@ -173,6 +221,8 @@ class BasicMotionReferenceHandler():
 
     def send_twist_command(self) -> bool:
         """Send a twist command."""
+        if not self.check_frame_id(self.command_twist_msg_.header.frame_id, 'twist'):
+            return False
         if not self.check_mode():
             return False
         self.command_twist_msg_.header.stamp = self.node.get_clock().now().to_msg()
@@ -182,21 +232,37 @@ class BasicMotionReferenceHandler():
 
     def send_trajectory_command(self) -> bool:
         """Send a trajectory command."""
+        if not self.check_frame_id(self.command_trajectory_msg_.header.frame_id, 'trajectory'):
+            return False
         if not self.check_mode():
             return False
         self.motion_handler_.publish_command_trajectory(
             self.node, self.command_trajectory_msg_)
         return True
 
+    def send_thrust_command(self) -> bool:
+        """Send a thrust command."""
+        if not self.check_mode():
+            return False
+        self.command_thrust_msg_.header.stamp = self.node.get_clock().now().to_msg()
+        self.motion_handler_.publish_command_thrust(
+            self.node, self.command_thrust_msg_)
+        return True
+
     def __set_mode(self, mode: ControlMode) -> bool:
-        """Set the control mode."""
-        set_control_mode_cli_ = self.node.create_client(
-            SetControlMode, as2_names_srv_controller_set_control_mode)
+        """
+        Set the control mode.
+
+        The platform validates the mode against the ones it supports, the
+        controller also looks for a way of synthesizing it with its plugin.
+        """
+        service_name = as2_names.services.platform.set_platform_control_mode \
+            if self.use_actuator_commands_ else as2_names.services.controller.set_control_mode
+        set_control_mode_cli_ = self.node.create_client(SetControlMode, service_name)
 
         if not set_control_mode_cli_.wait_for_service(timeout_sec=3):
             self.node.get_logger().error(
-                f'Service {self.node.get_namespace()}\
-                        /{as2_names_srv_controller_set_control_mode} not available')
+                f'Service {self.node.get_namespace()}/{service_name} not available')
             return False
 
         req = SetControlMode.Request()

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/basic_motion_references.py
@@ -146,10 +146,23 @@ class BasicMotionReferencesBase(metaclass=Singleton):
 
 
 class BasicMotionReferenceHandler():
-    """Implementation of a motion reference handler base."""
+    """
+    Base of the motion reference handlers: publish references and negotiate the mode.
+
+    References go to the motion controller, unless the ROS 2 parameter
+    use_actuator_commands of the node is true: then they go straight to the aerial
+    platform, which is also the one the control mode is negotiated with. The platform must
+    support the control modes the references need, since there is no controller in between
+    to synthesize them.
+    """
 
     def __init__(self, node: Node):
-        """Contructor of the motion reference handler."""
+        """
+        Create the handler, its publishers and the control mode subscription it selects.
+
+        :param node: node the references are published from
+        :type node: Node
+        """
         self.motion_handler_ = BasicMotionReferencesBase(node)
         self.node = node
         self.command_trajectory_msg_ = TrajectorySetpoints()
@@ -179,15 +192,32 @@ class BasicMotionReferenceHandler():
                 callback_group=my_callback_group)
 
     def __controller_info_callback(self, msg: ControllerInfo):
-        """Call for the controller info topic."""
+        """
+        Track the mode the motion controller reports as active.
+
+        :param msg: controller info
+        :type msg: ControllerInfo
+        """
         self.current_mode_ = msg.input_control_mode
 
     def __platform_info_callback(self, msg: PlatformInfo):
-        """Call for the platform info topic."""
+        """
+        Track the mode the platform reports as active, used with use_actuator_commands.
+
+        :param msg: platform info
+        :type msg: PlatformInfo
+        """
         self.current_mode_ = msg.current_control_mode
 
     def check_mode(self) -> bool:
-        """Check if the current mode is the desired mode."""
+        """
+        Settle the desired control mode if the active one does not match it.
+
+        Hovering does not need to be settled again, whatever its yaw mode is.
+
+        :return: True if the desired control mode is the active one
+        :rtype: bool
+        """
         # Hovering does not need to be settled again, whatever its yaw mode is
         if (self.desired_control_mode_.control_mode ==
                 self.current_mode_.control_mode == ControlMode.HOVER):
@@ -199,7 +229,19 @@ class BasicMotionReferenceHandler():
         return True
 
     def check_frame_id(self, frame_id: str, reference: str) -> bool:
-        """Check that a reference carries the frame its data is expressed in."""
+        """
+        Check that a reference carries the frame its data is expressed in.
+
+        Without a frame id the reference cannot be converted, and whoever receives it
+        would act on it as if it were already in its own frame.
+
+        :param frame_id: frame id of the reference message
+        :type frame_id: str
+        :param reference: name of the reference, for the error message
+        :type reference: str
+        :return: True if the reference can be sent
+        :rtype: bool
+        """
         if frame_id:
             return True
         # Without a frame id the reference cannot be converted, and whoever
@@ -209,7 +251,12 @@ class BasicMotionReferenceHandler():
         return False
 
     def send_pose_command(self) -> bool:
-        """Send a pose command."""
+        """
+        Send the current pose reference, settling the control mode first.
+
+        :return: True if the reference was published, False if it has no frame_id
+        :rtype: bool
+        """
         if not self.check_frame_id(self.command_pose_msg_.header.frame_id, 'pose'):
             return False
         if not self.check_mode():
@@ -220,7 +267,12 @@ class BasicMotionReferenceHandler():
         return True
 
     def send_twist_command(self) -> bool:
-        """Send a twist command."""
+        """
+        Send the current twist reference, settling the control mode first.
+
+        :return: True if the reference was published, False if it has no frame_id
+        :rtype: bool
+        """
         if not self.check_frame_id(self.command_twist_msg_.header.frame_id, 'twist'):
             return False
         if not self.check_mode():
@@ -231,7 +283,12 @@ class BasicMotionReferenceHandler():
         return True
 
     def send_trajectory_command(self) -> bool:
-        """Send a trajectory command."""
+        """
+        Send the current trajectory reference, settling the control mode first.
+
+        :return: True if the reference was published, False if it has no frame_id
+        :rtype: bool
+        """
         if not self.check_frame_id(self.command_trajectory_msg_.header.frame_id, 'trajectory'):
             return False
         if not self.check_mode():
@@ -241,7 +298,12 @@ class BasicMotionReferenceHandler():
         return True
 
     def send_thrust_command(self) -> bool:
-        """Send a thrust command."""
+        """
+        Send the current thrust reference, settling the control mode first.
+
+        :return: True if the reference was published
+        :rtype: bool
+        """
         if not self.check_mode():
             return False
         self.command_thrust_msg_.header.stamp = self.node.get_clock().now().to_msg()

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/hover_motion.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/hover_motion.py
@@ -42,16 +42,30 @@ from rclpy.node import Node
 
 
 class HoverMotion(BasicMotionReferenceHandler):
-    """Send hover motion command."""
+    """
+    Ask the platform to hold position.
+
+    HOVER carries no reference of its own: settling the control mode is the whole command.
+    """
 
     def __init__(self, node: Node):
-        """Initialize hover motion handler."""
+        """
+        Create the handler and select the HOVER control mode.
+
+        :param node: node the references are published from
+        :type node: Node
+        """
         super().__init__(node)
         self.desired_control_mode_.yaw_mode = ControlMode.NONE
         self.desired_control_mode_.control_mode = ControlMode.HOVER
 
     def send_hover(self):
-        """Send hover command."""
+        """
+        Settle the HOVER control mode, which is what makes the platform hold position.
+
+        :return: True if the control mode was accepted
+        :rtype: bool
+        """
         self.desired_control_mode_.yaw_mode = ControlMode.NONE
         self.desired_control_mode_.control_mode = ControlMode.HOVER
         return self.check_mode()

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/position_motion.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/position_motion.py
@@ -44,10 +44,21 @@ from rclpy.node import Node
 
 
 class PositionMotion(BasicMotionReferenceHandler):
-    """Send position motion command."""
+    """
+    Send POSITION references: a target pose plus an optional speed limit.
+
+    The pose carries the position and, in yaw angle mode, the desired yaw. The twist is
+    not a velocity reference here but a limit on how fast the vehicle may approach the
+    target; left unset, no limit is imposed.
+    """
 
     def __init__(self, node: Node):
-        """Initialize position motion handler."""
+        """
+        Create the handler and select the POSITION control mode.
+
+        :param node: node the references are published from
+        :type node: Node
+        """
         super().__init__(node)
         self.desired_control_mode_.yaw_mode = ControlMode.NONE
         self.desired_control_mode_.control_mode = ControlMode.POSITION
@@ -55,7 +66,18 @@ class PositionMotion(BasicMotionReferenceHandler):
     def __own_send_command(self, yaw_mode: int,
                            pose_msg: PoseStamped,
                            twist_mgs: TwistStamped) -> bool:
-        """Send command."""
+        """
+        Settle the yaw mode and publish both references.
+
+        :param yaw_mode: ControlMode.YAW_ANGLE or ControlMode.YAW_SPEED
+        :type yaw_mode: int
+        :param pose_msg: target pose
+        :type pose_msg: PoseStamped
+        :param twist_mgs: speed limit
+        :type twist_mgs: TwistStamped
+        :return: True if every reference was published
+        :rtype: bool
+        """
         self.desired_control_mode_.yaw_mode = yaw_mode
         self.command_pose_msg_ = pose_msg
         self.command_twist_msg_ = twist_mgs
@@ -65,7 +87,16 @@ class PositionMotion(BasicMotionReferenceHandler):
 
     def __check_input_pose(self, pose: Union[PoseStamped, list],
                            pose_frame_id: str) -> Union[PoseStamped, None]:
-        """Check input pose."""
+        """
+        Normalize the pose argument into a PoseStamped, rejecting it if it has no frame.
+
+        :param pose: target position, either a message or an [x, y, z] list
+        :type pose: Union[PoseStamped, list]
+        :param pose_frame_id: frame the list is expressed in, unused if pose is a message
+        :type pose_frame_id: str
+        :return: the pose as a message, or None if the type is wrong or the frame is empty
+        :rtype: Union[PoseStamped, None]
+        """
         pose_msg = PoseStamped()
         if isinstance(pose, list):
             pose_msg.pose.position.x = float(pose[0])
@@ -86,7 +117,20 @@ class PositionMotion(BasicMotionReferenceHandler):
     def __check_input_twist(self,
                             twist: Union[float, list, TwistStamped, None],
                             twist_frame_id: str) -> Union[TwistStamped, None]:
-        """Check input twist."""
+        """
+        Normalize the speed limit into a TwistStamped, rejecting it if it has no frame.
+
+        A float applies the same limit to the three axes, a list gives one per axis, and
+        None means no limit. The frame is required in every case, since a limit without a
+        frame cannot be converted.
+
+        :param twist: speed limit, as a single value, a per axis list, a message or None
+        :type twist: Union[float, list, TwistStamped, None]
+        :param twist_frame_id: frame the limit is expressed in
+        :type twist_frame_id: str
+        :return: the limit as a message, or None if the type is wrong or the frame is empty
+        :rtype: Union[TwistStamped, None]
+        """
         twist_mgs = TwistStamped()
 
         if isinstance(twist, float):
@@ -121,7 +165,25 @@ class PositionMotion(BasicMotionReferenceHandler):
                                              pose_frame_id: str = '',
                                              twist_frame_id: str = '',
                                              yaw_angle: Union[float, None] = None) -> bool:
-        """Send position command with yaw angle."""
+        """
+        Send a position reference holding an absolute yaw angle.
+
+        When the pose is given as a list, yaw_angle is required, since the list carries no
+        orientation.
+
+        :param pose: target position, either a message or an [x, y, z] list
+        :type pose: Union[list, PoseStamped]
+        :param twist_limit: speed limit for the approach, None for no limit
+        :type twist_limit: Union[float, list, TwistStamped, None], optional
+        :param pose_frame_id: frame of the pose, when given as a list
+        :type pose_frame_id: str, optional
+        :param twist_frame_id: frame of the speed limit
+        :type twist_frame_id: str, optional
+        :param yaw_angle: desired yaw in radians, required when pose is a list
+        :type yaw_angle: Union[float, None], optional
+        :return: True if the reference was published
+        :rtype: bool
+        """
         pose_msg = self.__check_input_pose(pose, pose_frame_id)
         twist_msg = self.__check_input_twist(twist_limit, twist_frame_id)
 
@@ -145,7 +207,24 @@ class PositionMotion(BasicMotionReferenceHandler):
                                              pose_frame_id: str = '',
                                              twist_frame_id: str = '',
                                              yaw_speed: Union[float, None] = None) -> bool:
-        """Send position command with yaw speed."""
+        """
+        Send a position reference holding a yaw rate.
+
+        The yaw rate travels in the angular z of the speed limit message.
+
+        :param pose: target position, either a message or an [x, y, z] list
+        :type pose: Union[list, PoseStamped]
+        :param twist_limit: speed limit for the approach, None for no limit
+        :type twist_limit: Union[float, list, TwistStamped, None], optional
+        :param pose_frame_id: frame of the pose, when given as a list
+        :type pose_frame_id: str, optional
+        :param twist_frame_id: frame of the speed limit
+        :type twist_frame_id: str, optional
+        :param yaw_speed: desired yaw rate in rad/s
+        :type yaw_speed: Union[float, None], optional
+        :return: True if the reference was published
+        :rtype: bool
+        """
         pose_msg = self.__check_input_pose(pose, pose_frame_id)
         twist_msg = self.__check_input_twist(twist_limit, twist_frame_id)
 

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/speed_in_a_plane.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/speed_in_a_plane.py
@@ -45,17 +45,39 @@ from rclpy.node import Node
 
 
 class SpeedInAPlaneMotion(BasicMotionReferenceHandler):
-    """Send speed motion command."""
+    """
+    Send SPEED_IN_A_PLANE references: horizontal velocity plus a held height.
+
+    This mode splits the reference across the two messages: the twist carries the
+    horizontal velocity and the pose carries the height to hold and the yaw. That is why
+    both are published, each with its own frame.
+    """
 
     def __init__(self, node: Node):
-        """Initialize speed motion handler."""
+        """
+        Create the handler and select the SPEED_IN_A_PLANE control mode.
+
+        :param node: node the references are published from
+        :type node: Node
+        """
         super().__init__(node)
         self.desired_control_mode_.yaw_mode = ControlMode.NONE
         self.desired_control_mode_.control_mode = ControlMode.SPEED_IN_A_PLANE
 
     def __own_send_command(self, yaw_mode: int, pose_msg: PoseStamped,
                            twist_mgs: TwistStamped) -> bool:
-        """Send speed in a plane command."""
+        """
+        Settle the yaw mode and publish both references.
+
+        :param yaw_mode: ControlMode.YAW_ANGLE or ControlMode.YAW_SPEED
+        :type yaw_mode: int
+        :param pose_msg: pose carrying the height to hold, and the yaw in angle mode
+        :type pose_msg: PoseStamped
+        :param twist_mgs: horizontal velocity reference
+        :type twist_mgs: TwistStamped
+        :return: True if every reference was published
+        :rtype: bool
+        """
         self.desired_control_mode_.yaw_mode = yaw_mode
 
         self.command_pose_msg_ = pose_msg
@@ -68,7 +90,16 @@ class SpeedInAPlaneMotion(BasicMotionReferenceHandler):
 
     def __check_input_pose(self, pose: Union[PoseStamped, float],
                            pose_frame_id: str) -> Union[PoseStamped, None]:
-        """Check input pose."""
+        """
+        Normalize the height argument into a PoseStamped, rejecting it if it has no frame.
+
+        :param pose: height to hold, either a full pose or a z value
+        :type pose: Union[PoseStamped, float]
+        :param pose_frame_id: frame the height is expressed in
+        :type pose_frame_id: str
+        :return: the pose as a message, or None if the type is wrong or the frame is empty
+        :rtype: Union[PoseStamped, None]
+        """
         pose_msg = PoseStamped()
         if isinstance(pose, float):
             pose_msg.pose.position.x = 0.0
@@ -88,7 +119,16 @@ class SpeedInAPlaneMotion(BasicMotionReferenceHandler):
 
     def __check_input_twist(self, twist: Union[TwistStamped, list],
                             twist_frame_id: str) -> Union[TwistStamped, None]:
-        """Check if the input twist is valid and return a TwistStamped message."""
+        """
+        Normalize the twist argument into a TwistStamped, rejecting it if it has no frame.
+
+        :param twist: horizontal velocity, either a message or an [x, y] list
+        :type twist: Union[TwistStamped, list]
+        :param twist_frame_id: frame the list is expressed in, unused if twist is a message
+        :type twist_frame_id: str
+        :return: the twist as a message, or None if the type is wrong or the frame is empty
+        :rtype: Union[TwistStamped, None]
+        """
         twist_mgs = TwistStamped()
 
         if isinstance(twist, list):
@@ -115,7 +155,25 @@ class SpeedInAPlaneMotion(BasicMotionReferenceHandler):
             pose_frame_id: str = '',
             twist_frame_id: str = '',
             yaw_angle: Union[Quaternion, float, None] = None) -> bool:
-        """Send speed in a plane command with yaw angle."""
+        """
+        Send a speed in a plane reference holding an absolute yaw angle.
+
+        The yaw may come as a quaternion, as an angle, or already inside the height pose;
+        in that last case yaw_angle is left unset.
+
+        :param twist: horizontal velocity, either a message or an [x, y] list
+        :type twist: Union[TwistStamped, list]
+        :param height: height to hold, either a full pose or a z value
+        :type height: Union[PoseStamped, float]
+        :param pose_frame_id: frame of the height
+        :type pose_frame_id: str, optional
+        :param twist_frame_id: frame of the twist, when given as a list
+        :type twist_frame_id: str, optional
+        :param yaw_angle: desired yaw, as a quaternion or radians
+        :type yaw_angle: Union[Quaternion, float, None], optional
+        :return: True if the reference was published
+        :rtype: bool
+        """
         twist_msg = self.__check_input_twist(twist, twist_frame_id)
         pose_msg = self.__check_input_pose(height, pose_frame_id)
 
@@ -143,7 +201,22 @@ class SpeedInAPlaneMotion(BasicMotionReferenceHandler):
             pose_frame_id: str = '',
             twist_frame_id: str = '',
             yaw_speed: Union[float, None] = None) -> bool:
-        """Send speed in a plane command with yaw angle."""
+        """
+        Send a speed in a plane reference holding a yaw rate.
+
+        :param twist: horizontal velocity, either a message or an [x, y] list
+        :type twist: Union[TwistStamped, list]
+        :param height: height to hold, either a full pose or a z value
+        :type height: Union[PoseStamped, float]
+        :param pose_frame_id: frame of the height
+        :type pose_frame_id: str, optional
+        :param twist_frame_id: frame of the twist, when given as a list
+        :type twist_frame_id: str, optional
+        :param yaw_speed: desired yaw rate in rad/s
+        :type yaw_speed: Union[float, None], optional
+        :return: True if the reference was published
+        :rtype: bool
+        """
         twist_msg = self.__check_input_twist(twist, twist_frame_id)
         pose_msg = self.__check_input_pose(height, pose_frame_id)
 

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/speed_motion.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/speed_motion.py
@@ -45,7 +45,13 @@ from rclpy.node import Node
 
 
 class SpeedMotion(BasicMotionReferenceHandler):
-    """Send speed motion command."""
+    """
+    Send SPEED references: a linear velocity plus a yaw angle or a yaw rate.
+
+    The twist carries the linear velocity and must always name the frame it is expressed
+    in. Yaw is commanded either as an absolute angle, through a pose, or as a rate, in the
+    angular z component of the twist.
+    """
 
     def __init__(self, node: Node):
         super().__init__(node)
@@ -54,7 +60,18 @@ class SpeedMotion(BasicMotionReferenceHandler):
 
     def __own_send_command(self, yaw_mode: int, twist_mgs: TwistStamped,
                            pose_msg: Union[PoseStamped, None] = None) -> bool:
-        """Send speed command."""
+        """
+        Settle the yaw mode and publish the references.
+
+        :param yaw_mode: ControlMode.YAW_ANGLE or ControlMode.YAW_SPEED
+        :type yaw_mode: int
+        :param twist_mgs: linear velocity reference
+        :type twist_mgs: TwistStamped
+        :param pose_msg: pose carrying the yaw angle, only for YAW_ANGLE
+        :type pose_msg: Union[PoseStamped, None], optional
+        :return: True if every reference was published
+        :rtype: bool
+        """
         self.desired_control_mode_.yaw_mode = yaw_mode
 
         send_pose = True
@@ -68,7 +85,19 @@ class SpeedMotion(BasicMotionReferenceHandler):
 
     def __check_input_twist(self, twist: Union[TwistStamped, list],
                             twist_frame_id: str) -> Union[TwistStamped, None]:
-        """Check if the input twist is valid and return a TwistStamped message."""
+        """
+        Normalize the twist argument into a TwistStamped, rejecting it if it has no frame.
+
+        A reference without a frame id cannot be converted, and whoever receives it would
+        act on it as if it were already in its own frame, so it is refused here.
+
+        :param twist: linear velocity, either a message or a [x, y, z] list
+        :type twist: Union[TwistStamped, list]
+        :param twist_frame_id: frame the list is expressed in, unused if twist is a message
+        :type twist_frame_id: str
+        :return: the twist as a message, or None if the type is wrong or the frame is empty
+        :rtype: Union[TwistStamped, None]
+        """
         twist_mgs = TwistStamped()
 
         if isinstance(twist, list):
@@ -94,7 +123,25 @@ class SpeedMotion(BasicMotionReferenceHandler):
                                           twist_frame_id: str = '',
                                           yaw_angle: Union[float, None] = None,
                                           pose_frame_id: str = '') -> bool:
-        """Send speed command with yaw angle."""
+        """
+        Send a speed reference holding an absolute yaw angle.
+
+        The yaw comes either from a full pose or from an angle, in which case the pose is
+        built from it. Exactly one of the two must be given.
+
+        :param twist: linear velocity, either a message or a [x, y, z] list
+        :type twist: Union[TwistStamped, list]
+        :param pose: pose whose orientation holds the desired yaw
+        :type pose: Union[PoseStamped, None], optional
+        :param twist_frame_id: frame of the twist, when given as a list
+        :type twist_frame_id: str, optional
+        :param yaw_angle: desired yaw in radians, used when no pose is given
+        :type yaw_angle: Union[float, None], optional
+        :param pose_frame_id: frame the yaw angle refers to
+        :type pose_frame_id: str, optional
+        :return: True if the reference was published
+        :rtype: bool
+        """
         twist_msg = self.__check_input_twist(twist, twist_frame_id)
 
         if twist_msg is None:
@@ -117,7 +164,21 @@ class SpeedMotion(BasicMotionReferenceHandler):
     def send_speed_command_with_yaw_speed(self, twist: Union[TwistStamped, list],
                                           twist_frame_id: str = '',
                                           yaw_speed: Union[float, None] = None) -> bool:
-        """Send speed command with yaw speed."""
+        """
+        Send a speed reference holding a yaw rate.
+
+        When the twist is given as a message its angular z is used as the yaw rate; when
+        it is given as a list, yaw_speed is required.
+
+        :param twist: linear velocity, either a message or a [x, y, z] list
+        :type twist: Union[TwistStamped, list]
+        :param twist_frame_id: frame of the twist, when given as a list
+        :type twist_frame_id: str, optional
+        :param yaw_speed: desired yaw rate in rad/s, required when twist is a list
+        :type yaw_speed: Union[float, None], optional
+        :return: True if the reference was published
+        :rtype: bool
+        """
         twist_msg = self.__check_input_twist(twist, twist_frame_id)
 
         if twist_msg is None:

--- a/as2_motion_reference_handlers/as2_motion_reference_handlers/utils.py
+++ b/as2_motion_reference_handlers/as2_motion_reference_handlers/utils.py
@@ -43,7 +43,14 @@ from scipy.spatial.transform import Rotation
 
 
 def get_quaternion_from_yaw_angle(yaw_angle: float):
-    """Get quaternion from yaw angle."""
+    """
+    Build a quaternion from a yaw angle, with zero roll and pitch.
+
+    :param yaw_angle: rotation about the z axis, in radians
+    :type yaw_angle: float
+    :return: equivalent orientation
+    :rtype: Quaternion
+    """
     rot = Rotation.from_euler(
         'xyz', [0.0, 0.0, yaw_angle], degrees=False)
     rot_quat = rot.as_quat()
@@ -52,7 +59,21 @@ def get_quaternion_from_yaw_angle(yaw_angle: float):
 
 
 def generate_tf_name(namespace: str, frame_name: str):
-    """Generate tf name."""
+    """
+    Prefix a TF frame name with a namespace, following aerostack2 conventions.
+
+    A frame name starting with '/' is absolute: it is returned without the leading '/'
+    and is not namespaced. A name that already contains a '/' is taken as fully
+    qualified and returned unchanged. Otherwise the namespace is prepended.
+
+    :param namespace: robot namespace, may be empty or start with '/'
+    :type namespace: str
+    :param frame_name: frame name, possibly absolute or already qualified
+    :type frame_name: str
+    :raises RuntimeError: if frame_name is empty
+    :return: fully qualified TF frame id
+    :rtype: str
+    """
     if len(frame_name) == 0:
         raise RuntimeError('Empty frame name')
     if frame_name[0] == '/':
@@ -72,5 +93,14 @@ def generate_tf_name(namespace: str, frame_name: str):
 
 
 def get_tf_name(node: Node, frame_name: str):
-    """Get tf name."""
+    """
+    Prefix a TF frame name with the namespace of a node.
+
+    :param node: node whose namespace is used as prefix
+    :type node: Node
+    :param frame_name: frame name, see generate_tf_name() for the rules
+    :type frame_name: str
+    :return: fully qualified TF frame id
+    :rtype: str
+    """
     return generate_tf_name(node.get_namespace(), frame_name)

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -39,7 +39,11 @@
 #ifndef AS2_MOTION_REFERENCE_HANDLERS__BASIC_MOTION_REFERENCES_HPP_
 #define AS2_MOTION_REFERENCE_HANDLERS__BASIC_MOTION_REFERENCES_HPP_
 
+#include <map>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <utility>
 
 #include <as2_msgs/msg/control_mode.hpp>
 #include <as2_msgs/msg/thrust.hpp>
@@ -55,6 +59,8 @@ namespace as2
 {
 namespace motionReferenceHandlers
 {
+class MotionReferenceBus;
+
 /**
  * @brief Base class of the motion reference handlers, which publish motion
  * references and negotiate the control mode they need.
@@ -142,18 +148,16 @@ private:
    */
   bool checkFrameId(const std::string & frame_id, const std::string & reference);
 
-  // References go straight to the platform, bypassing the motion controller
-  bool use_actuator_commands_ = false;
-
-  // Only one of the two is created, depending on use_actuator_commands_
-  rclcpp::Subscription<as2_msgs::msg::ControllerInfo>::SharedPtr controller_info_sub_;
-  rclcpp::Subscription<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_sub_;
-  as2_msgs::msg::ControlMode current_mode_;
-
-  rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr command_traj_pub_;
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr command_pose_pub_;
-  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
-  rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;
+  /**
+   * @brief Publishers, control mode subscription and active mode, shared by every handler
+   * built on the same node and namespace.
+   *
+   * Several handlers on one node talk to the same controller or platform, so they must
+   * share one set of publishers and, above all, one view of the active control mode: if
+   * each kept its own, a mode settled by one handler would be unknown to the others.
+   * Defined in the implementation, since it is not part of the public interface.
+   */
+  std::shared_ptr<MotionReferenceBus> shared_;
 
   /**
    * @brief Negotiate a control mode with the motion controller, or with the

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -76,6 +76,10 @@ public:
    * @param ns      Namespace of the drone. Empty to use the node namespace.
    */
   explicit BasicMotionReferenceHandler(as2::Node * as2_ptr, const std::string & ns = "");
+
+  /**
+   * @brief Destroy the handler, releasing its publishers and subscription.
+   */
   ~BasicMotionReferenceHandler();
 
 protected:
@@ -89,6 +93,13 @@ protected:
 
   as2_msgs::msg::ControlMode desired_control_mode_;
 
+  /**
+   * @brief Send the current thrust reference, settling the control mode first.
+   *
+   * Unlike the other references, thrust carries no frame, so there is no frame check.
+   *
+   * @return true if the reference was published.
+   */
   bool sendThrustCommand();
 
   /**
@@ -111,6 +122,14 @@ protected:
    * @return true if the reference was published. False if it has no frame_id.
    */
   bool sendTrajectoryCommand();
+
+  /**
+   * @brief Negotiate the desired control mode if the active one does not match it.
+   *
+   * Hovering does not need to be settled again, whatever its yaw mode is.
+   *
+   * @return true if the desired control mode is the active one.
+   */
   bool checkMode();
 
 private:

--- a/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
+++ b/as2_motion_reference_handlers/include/as2_motion_reference_handlers/basic_motion_references.hpp
@@ -44,6 +44,7 @@
 #include <as2_msgs/msg/control_mode.hpp>
 #include <as2_msgs/msg/thrust.hpp>
 #include <as2_msgs/msg/controller_info.hpp>
+#include <as2_msgs/msg/platform_info.hpp>
 #include <as2_msgs/msg/trajectory_setpoints.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -54,21 +55,27 @@ namespace as2
 {
 namespace motionReferenceHandlers
 {
+/**
+ * @brief Base class of the motion reference handlers, which publish motion
+ * references and negotiate the control mode they need.
+ *
+ * References are sent to the motion controller, unless the ROS 2 parameter
+ * use_actuator_commands of the node is true: then they are sent straight to the
+ * aerial platform, which is also the one the control mode is negotiated with.
+ * The platform must support the control modes the references need, since there
+ * is no controller in between to synthesize them.
+ */
 class BasicMotionReferenceHandler
 {
 public:
   /**
-   * @brief Construct the handler, creating the reference publishers and the
-   * controller info subscription the first time it is instantiated.
+   * @brief Construct the handler, reading use_actuator_commands from the node
+   * and creating the publishers and the control mode subscription it selects.
    *
    * @param as2_ptr Node the references are published from.
-   * @param ns Namespace of the drone. Empty to use the node namespace.
+   * @param ns      Namespace of the drone. Empty to use the node namespace.
    */
   explicit BasicMotionReferenceHandler(as2::Node * as2_ptr, const std::string & ns = "");
-
-  /**
-   * @brief Destroy the Basic Motion Reference Handler object.
-   */
   ~BasicMotionReferenceHandler();
 
 protected:
@@ -82,55 +89,56 @@ protected:
 
   as2_msgs::msg::ControlMode desired_control_mode_;
 
-  /**
-   * @brief Send the current thrust reference, settling the control mode first.
-   *
-   * @return true if the reference was published.
-   */
   bool sendThrustCommand();
 
   /**
    * @brief Send the current pose reference, settling the control mode first.
    *
-   * @return true if the reference was published.
+   * @return true if the reference was published. False if it has no frame_id.
    */
   bool sendPoseCommand();
 
   /**
    * @brief Send the current twist reference, settling the control mode first.
    *
-   * @return true if the reference was published.
+   * @return true if the reference was published. False if it has no frame_id.
    */
   bool sendTwistCommand();
 
   /**
    * @brief Send the current trajectory reference, settling the control mode first.
    *
-   * @return true if the reference was published.
+   * @return true if the reference was published. False if it has no frame_id.
    */
   bool sendTrajectoryCommand();
-
-  /**
-   * @brief Request the desired control mode if the current one does not match it.
-   *
-   * @return true if the desired control mode is the active one.
-   */
   bool checkMode();
 
 private:
-  static int number_of_instances_;
+  /**
+   * @brief Check that a reference carries the frame its data is expressed in.
+   *
+   * @param frame_id  Frame id of the reference message.
+   * @param reference Name of the reference, for the error message.
+   * @return true if the reference can be sent.
+   */
+  bool checkFrameId(const std::string & frame_id, const std::string & reference);
 
-  static rclcpp::Subscription<as2_msgs::msg::ControllerInfo>
-  ::SharedPtr controller_info_sub_;
-  static as2_msgs::msg::ControlMode current_mode_;
+  // References go straight to the platform, bypassing the motion controller
+  bool use_actuator_commands_ = false;
 
-  static rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr command_traj_pub_;
-  static rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr command_pose_pub_;
-  static rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
-  static rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;
+  // Only one of the two is created, depending on use_actuator_commands_
+  rclcpp::Subscription<as2_msgs::msg::ControllerInfo>::SharedPtr controller_info_sub_;
+  rclcpp::Subscription<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_sub_;
+  as2_msgs::msg::ControlMode current_mode_;
+
+  rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr command_traj_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr command_pose_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
+  rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;
 
   /**
-   * @brief Negotiate a control mode with the motion controller.
+   * @brief Negotiate a control mode with the motion controller, or with the
+   * aerial platform when use_actuator_commands is true.
    *
    * @param mode Control mode to request.
    * @return true if the mode was accepted.

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -99,7 +99,6 @@ BasicMotionReferenceHandler::BasicMotionReferenceHandler(
   // Set initial control mode
   desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::NONE;
   desired_control_mode_.control_mode = as2_msgs::msg::ControlMode::UNSET;
-  desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
 }
 
 BasicMotionReferenceHandler::~BasicMotionReferenceHandler() {}

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -52,64 +52,63 @@ BasicMotionReferenceHandler::BasicMotionReferenceHandler(
   const std::string & ns)
 : node_ptr_(as2_ptr), namespace_(ns)
 {
-  if (number_of_instances_ == 0) {
-    namespace_ = ns == "" ? ns : "/" + ns + "/";
+  namespace_ = ns == "" ? ns : "/" + ns + "/";
 
-    // Publisher
-    command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
-      namespace_ + as2_names::topics::motion_reference::trajectory,
-      as2_names::topics::motion_reference::qos);
+  use_actuator_commands_ = node_ptr_->getParameter<bool>("use_actuator_commands", false);
 
-    command_pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
-      namespace_ + as2_names::topics::motion_reference::pose,
-      as2_names::topics::motion_reference::qos);
+  // Publishers. Commands go to the platform, or to the motion controller
+  const std::string trajectory_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::trajectory :
+    as2_names::topics::motion_reference::trajectory;
+  const std::string pose_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::pose : as2_names::topics::motion_reference::pose;
+  const std::string twist_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::twist : as2_names::topics::motion_reference::twist;
+  const std::string thrust_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::thrust : as2_names::topics::motion_reference::thrust;
+  const rclcpp::QoS command_qos = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::qos : as2_names::topics::motion_reference::qos;
 
-    command_twist_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::TwistStamped>(
-      namespace_ + as2_names::topics::motion_reference::twist,
-      as2_names::topics::motion_reference::qos);
+  command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
+    namespace_ + trajectory_topic, command_qos);
 
-    command_thrust_pub_ = node_ptr_->create_publisher<as2_msgs::msg::Thrust>(
-      namespace_ + as2_names::topics::motion_reference::thrust,
-      as2_names::topics::motion_reference::qos);
+  command_pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
+    namespace_ + pose_topic, command_qos);
 
-    // Subscriber
+  command_twist_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::TwistStamped>(
+    namespace_ + twist_topic, command_qos);
+
+  command_thrust_pub_ = node_ptr_->create_publisher<as2_msgs::msg::Thrust>(
+    namespace_ + thrust_topic, command_qos);
+
+  // Subscriber to the current control mode, from the platform or the controller
+  if (use_actuator_commands_) {
+    platform_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::PlatformInfo>(
+      namespace_ + as2_names::topics::platform::info, rclcpp::QoS(1),
+      [this](const as2_msgs::msg::PlatformInfo::SharedPtr msg) {
+        current_mode_ = msg->current_control_mode;
+      });
+  } else {
     controller_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::ControllerInfo>(
       namespace_ + as2_names::topics::controller::info, rclcpp::QoS(1),
-      [](const as2_msgs::msg::ControllerInfo::SharedPtr msg) {
+      [this](const as2_msgs::msg::ControllerInfo::SharedPtr msg) {
         current_mode_ = msg->input_control_mode;
       });
-
-    // Set initial control mode
-    desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::NONE;
-    desired_control_mode_.control_mode = as2_msgs::msg::ControlMode::UNSET;
   }
 
-  number_of_instances_++;
-  RCLCPP_DEBUG(
-    node_ptr_->get_logger(),
-    "There are %d instances of BasicMotionReferenceHandler created",
-    number_of_instances_);
+  // Set initial control mode
+  desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::NONE;
+  desired_control_mode_.control_mode = as2_msgs::msg::ControlMode::UNSET;
+  desired_control_mode_.reference_frame = as2_msgs::msg::ControlMode::UNDEFINED_FRAME;
 }
 
-BasicMotionReferenceHandler::~BasicMotionReferenceHandler()
-{
-  number_of_instances_--;
-  if (number_of_instances_ == 0 && node_ptr_ != nullptr) {
-    RCLCPP_DEBUG(node_ptr_->get_logger(), "Deleting node_ptr_");
-    controller_info_sub_.reset();
-    command_traj_pub_.reset();
-    command_pose_pub_.reset();
-    command_twist_pub_.reset();
-    command_thrust_pub_.reset();
-  }
-}
+BasicMotionReferenceHandler::~BasicMotionReferenceHandler() {}
 
 bool BasicMotionReferenceHandler::checkMode()
 {
-  // TODO(rps): Check comparation
-  // if (this->current_mode_ != desired_control_mode_)
+  // Hovering does not need to be settled again, whatever its yaw mode is
   if ((this->current_mode_.control_mode == desired_control_mode_.control_mode) &&
-    (this->current_mode_.control_mode == as2_msgs::msg::ControlMode::HOVER))
+    (desired_control_mode_.control_mode == as2_msgs::msg::ControlMode::HOVER))
   {
     return true;
   }
@@ -124,9 +123,22 @@ bool BasicMotionReferenceHandler::checkMode()
   return true;
 }
 
+bool BasicMotionReferenceHandler::checkFrameId(
+  const std::string & frame_id, const std::string & reference)
+{
+  if (!frame_id.empty()) {
+    return true;
+  }
+  // Without a frame id the reference cannot be converted, and whoever receives
+  // it would act on it as if it were already in its own frame
+  RCLCPP_ERROR(
+    node_ptr_->get_logger(), "Not sending %s reference without frame_id", reference.c_str());
+  return false;
+}
+
 bool BasicMotionReferenceHandler::sendPoseCommand()
 {
-  if (!checkMode()) {
+  if (!checkFrameId(command_pose_msg_.header.frame_id, "pose") || !checkMode()) {
     return false;
   }
   command_pose_pub_->publish(command_pose_msg_);
@@ -135,7 +147,7 @@ bool BasicMotionReferenceHandler::sendPoseCommand()
 
 bool BasicMotionReferenceHandler::sendTwistCommand()
 {
-  if (!checkMode()) {
+  if (!checkFrameId(command_twist_msg_.header.frame_id, "twist") || !checkMode()) {
     return false;
   }
   command_twist_pub_->publish(command_twist_msg_);
@@ -144,7 +156,7 @@ bool BasicMotionReferenceHandler::sendTwistCommand()
 
 bool BasicMotionReferenceHandler::sendTrajectoryCommand()
 {
-  if (!checkMode()) {
+  if (!checkFrameId(command_trajectory_msg_.header.frame_id, "trajectory") || !checkMode()) {
     return false;
   }
   command_traj_pub_->publish(command_trajectory_msg_);
@@ -171,39 +183,26 @@ bool BasicMotionReferenceHandler::setMode(const as2_msgs::msg::ControlMode & mod
   auto response = as2_msgs::srv::SetControlMode::Response();
   request.control_mode = mode;
 
+  const std::string set_mode_service = use_actuator_commands_ ?
+    as2_names::services::platform::set_platform_control_mode :
+    as2_names::services::controller::set_control_mode;
+
   auto set_mode_cli = as2::SynchronousServiceClient<as2_msgs::srv::SetControlMode>(
-    namespace_ + as2_names::services::controller::set_control_mode, node_ptr_);
+    namespace_ + set_mode_service, node_ptr_);
 
   bool out = set_mode_cli.sendRequest(request, response);
 
   if (out && response.success) {
     this->current_mode_ = mode;
-    // Sleep for controller info callback to update
+    // Sleep for the control mode callback to update
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     return true;
   }
   RCLCPP_ERROR(
     node_ptr_->get_logger(),
-    " Controller Control Mode was not able to be settled sucessfully");
+    "Control Mode was not able to be settled sucessfully");
   return false;
 }
-
-int BasicMotionReferenceHandler::number_of_instances_ = 0;
-
-rclcpp::Subscription<as2_msgs::msg::ControllerInfo>::SharedPtr
-BasicMotionReferenceHandler::controller_info_sub_ = nullptr;
-
-as2_msgs::msg::ControlMode BasicMotionReferenceHandler::current_mode_ =
-  as2_msgs::msg::ControlMode();
-
-rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr
-BasicMotionReferenceHandler::command_traj_pub_ = nullptr;
-rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr
-BasicMotionReferenceHandler::command_pose_pub_ = nullptr;
-rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr
-BasicMotionReferenceHandler::command_twist_pub_ = nullptr;
-rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr
-BasicMotionReferenceHandler::command_thrust_pub_ = nullptr;
 
 }    // namespace motionReferenceHandlers
 }  // namespace as2

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -37,6 +37,7 @@
  ********************************************************************************/
 
 #include "as2_motion_reference_handlers/basic_motion_references.hpp"
+#include "motion_reference_bus.hpp"
 #include "as2_core/names/services.hpp"
 #include "as2_core/names/topics.hpp"
 #include "as2_core/synchronous_service_client.hpp"
@@ -47,54 +48,14 @@ namespace as2
 {
 namespace motionReferenceHandlers
 {
+
 BasicMotionReferenceHandler::BasicMotionReferenceHandler(
   as2::Node * as2_ptr,
   const std::string & ns)
 : node_ptr_(as2_ptr), namespace_(ns)
 {
   namespace_ = ns == "" ? ns : "/" + ns + "/";
-
-  use_actuator_commands_ = node_ptr_->getParameter<bool>("use_actuator_commands", false);
-
-  // Publishers. Commands go to the platform, or to the motion controller
-  const std::string trajectory_topic = use_actuator_commands_ ?
-    as2_names::topics::actuator_command::trajectory :
-    as2_names::topics::motion_reference::trajectory;
-  const std::string pose_topic = use_actuator_commands_ ?
-    as2_names::topics::actuator_command::pose : as2_names::topics::motion_reference::pose;
-  const std::string twist_topic = use_actuator_commands_ ?
-    as2_names::topics::actuator_command::twist : as2_names::topics::motion_reference::twist;
-  const std::string thrust_topic = use_actuator_commands_ ?
-    as2_names::topics::actuator_command::thrust : as2_names::topics::motion_reference::thrust;
-  const rclcpp::QoS command_qos = use_actuator_commands_ ?
-    as2_names::topics::actuator_command::qos : as2_names::topics::motion_reference::qos;
-
-  command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
-    namespace_ + trajectory_topic, command_qos);
-
-  command_pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
-    namespace_ + pose_topic, command_qos);
-
-  command_twist_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::TwistStamped>(
-    namespace_ + twist_topic, command_qos);
-
-  command_thrust_pub_ = node_ptr_->create_publisher<as2_msgs::msg::Thrust>(
-    namespace_ + thrust_topic, command_qos);
-
-  // Subscriber to the current control mode, from the platform or the controller
-  if (use_actuator_commands_) {
-    platform_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::PlatformInfo>(
-      namespace_ + as2_names::topics::platform::info, rclcpp::QoS(1),
-      [this](const as2_msgs::msg::PlatformInfo::SharedPtr msg) {
-        current_mode_ = msg->current_control_mode;
-      });
-  } else {
-    controller_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::ControllerInfo>(
-      namespace_ + as2_names::topics::controller::info, rclcpp::QoS(1),
-      [this](const as2_msgs::msg::ControllerInfo::SharedPtr msg) {
-        current_mode_ = msg->input_control_mode;
-      });
-  }
+  shared_ = MotionReferenceBus::get(as2_ptr, namespace_);
 
   // Set initial control mode
   desired_control_mode_.yaw_mode = as2_msgs::msg::ControlMode::NONE;
@@ -106,14 +67,14 @@ BasicMotionReferenceHandler::~BasicMotionReferenceHandler() {}
 bool BasicMotionReferenceHandler::checkMode()
 {
   // Hovering does not need to be settled again, whatever its yaw mode is
-  if ((this->current_mode_.control_mode == desired_control_mode_.control_mode) &&
+  if ((shared_->current_mode_.control_mode == desired_control_mode_.control_mode) &&
     (desired_control_mode_.control_mode == as2_msgs::msg::ControlMode::HOVER))
   {
     return true;
   }
 
-  if (this->current_mode_.yaw_mode != desired_control_mode_.yaw_mode ||
-    this->current_mode_.control_mode != desired_control_mode_.control_mode)
+  if (shared_->current_mode_.yaw_mode != desired_control_mode_.yaw_mode ||
+    shared_->current_mode_.control_mode != desired_control_mode_.control_mode)
   {
     if (!setMode(desired_control_mode_)) {
       return false;
@@ -140,7 +101,7 @@ bool BasicMotionReferenceHandler::sendPoseCommand()
   if (!checkFrameId(command_pose_msg_.header.frame_id, "pose") || !checkMode()) {
     return false;
   }
-  command_pose_pub_->publish(command_pose_msg_);
+  shared_->command_pose_pub_->publish(command_pose_msg_);
   return true;
 }
 
@@ -149,7 +110,7 @@ bool BasicMotionReferenceHandler::sendTwistCommand()
   if (!checkFrameId(command_twist_msg_.header.frame_id, "twist") || !checkMode()) {
     return false;
   }
-  command_twist_pub_->publish(command_twist_msg_);
+  shared_->command_twist_pub_->publish(command_twist_msg_);
   return true;
 }
 
@@ -158,7 +119,7 @@ bool BasicMotionReferenceHandler::sendTrajectoryCommand()
   if (!checkFrameId(command_trajectory_msg_.header.frame_id, "trajectory") || !checkMode()) {
     return false;
   }
-  command_traj_pub_->publish(command_trajectory_msg_);
+  shared_->command_traj_pub_->publish(command_trajectory_msg_);
   return true;
 }
 
@@ -167,7 +128,7 @@ bool BasicMotionReferenceHandler::sendThrustCommand()
   if (!checkMode()) {
     return false;
   }
-  command_thrust_pub_->publish(command_thrust_msg_);
+  shared_->command_thrust_pub_->publish(command_thrust_msg_);
   return true;
 }
 
@@ -182,7 +143,7 @@ bool BasicMotionReferenceHandler::setMode(const as2_msgs::msg::ControlMode & mod
   auto response = as2_msgs::srv::SetControlMode::Response();
   request.control_mode = mode;
 
-  const std::string set_mode_service = use_actuator_commands_ ?
+  const std::string set_mode_service = shared_->use_actuator_commands_ ?
     as2_names::services::platform::set_platform_control_mode :
     as2_names::services::controller::set_control_mode;
 
@@ -192,7 +153,7 @@ bool BasicMotionReferenceHandler::setMode(const as2_msgs::msg::ControlMode & mod
   bool out = set_mode_cli.sendRequest(request, response);
 
   if (out && response.success) {
-    this->current_mode_ = mode;
+    shared_->current_mode_ = mode;
     // Sleep for the control mode callback to update
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     return true;

--- a/as2_motion_reference_handlers/src/basic_motion_references.cpp
+++ b/as2_motion_reference_handlers/src/basic_motion_references.cpp
@@ -199,7 +199,7 @@ bool BasicMotionReferenceHandler::setMode(const as2_msgs::msg::ControlMode & mod
   }
   RCLCPP_ERROR(
     node_ptr_->get_logger(),
-    "Control Mode was not able to be settled sucessfully");
+    "Control Mode was not able to be settled successfully");
   return false;
 }
 

--- a/as2_motion_reference_handlers/src/motion_reference_bus.cpp
+++ b/as2_motion_reference_handlers/src/motion_reference_bus.cpp
@@ -1,0 +1,123 @@
+// Copyright 2023 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+/*!*******************************************************************************************
+ *  \file       motion_reference_bus.cpp
+ *  \brief      Implementation of the resources shared by the handlers of one node
+ *  \authors    Rafael Pérez Seguí
+ ********************************************************************************/
+
+#include "motion_reference_bus.hpp"
+
+#include <memory>
+#include <string>
+
+#include "as2_core/names/topics.hpp"
+
+namespace as2
+{
+namespace motionReferenceHandlers
+{
+
+std::map<MotionReferenceBus::Key, std::weak_ptr<MotionReferenceBus>>
+MotionReferenceBus::registry_;
+std::mutex MotionReferenceBus::registry_mutex_;
+
+std::shared_ptr<MotionReferenceBus> MotionReferenceBus::get(
+  as2::Node * node, const std::string & ns)
+{
+  const Key key{node, ns};
+  std::lock_guard<std::mutex> lock(registry_mutex_);
+
+  auto it = registry_.find(key);
+  if (it != registry_.end()) {
+    if (auto existing = it->second.lock()) {
+      return existing;
+    }
+  }
+  // make_shared is not usable here: the constructor is private
+  std::shared_ptr<MotionReferenceBus> created(new MotionReferenceBus(node, ns));
+  registry_[key] = created;
+  return created;
+}
+
+MotionReferenceBus::~MotionReferenceBus()
+{
+  std::lock_guard<std::mutex> lock(registry_mutex_);
+  registry_.erase(Key{node_ptr_, namespace_});
+}
+
+MotionReferenceBus::MotionReferenceBus(as2::Node * node, const std::string & ns)
+: node_ptr_(node), namespace_(ns)
+{
+  use_actuator_commands_ = node_ptr_->getParameter<bool>("use_actuator_commands", false);
+
+  // Publishers. Commands go to the platform, or to the motion controller
+  const std::string trajectory_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::trajectory :
+    as2_names::topics::motion_reference::trajectory;
+  const std::string pose_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::pose : as2_names::topics::motion_reference::pose;
+  const std::string twist_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::twist : as2_names::topics::motion_reference::twist;
+  const std::string thrust_topic = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::thrust : as2_names::topics::motion_reference::thrust;
+  const rclcpp::QoS command_qos = use_actuator_commands_ ?
+    as2_names::topics::actuator_command::qos : as2_names::topics::motion_reference::qos;
+
+  command_traj_pub_ = node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(
+    namespace_ + trajectory_topic, command_qos);
+
+  command_pose_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::PoseStamped>(
+    namespace_ + pose_topic, command_qos);
+
+  command_twist_pub_ = node_ptr_->create_publisher<geometry_msgs::msg::TwistStamped>(
+    namespace_ + twist_topic, command_qos);
+
+  command_thrust_pub_ = node_ptr_->create_publisher<as2_msgs::msg::Thrust>(
+    namespace_ + thrust_topic, command_qos);
+
+  // Subscriber to the current control mode, from the platform or the controller
+  if (use_actuator_commands_) {
+    platform_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::PlatformInfo>(
+      namespace_ + as2_names::topics::platform::info, rclcpp::QoS(1),
+      [this](const as2_msgs::msg::PlatformInfo::SharedPtr msg) {
+        current_mode_ = msg->current_control_mode;
+      });
+  } else {
+    controller_info_sub_ = node_ptr_->create_subscription<as2_msgs::msg::ControllerInfo>(
+      namespace_ + as2_names::topics::controller::info, rclcpp::QoS(1),
+      [this](const as2_msgs::msg::ControllerInfo::SharedPtr msg) {
+        current_mode_ = msg->input_control_mode;
+      });
+  }
+}
+
+}    // namespace motionReferenceHandlers
+}  // namespace as2

--- a/as2_motion_reference_handlers/src/motion_reference_bus.hpp
+++ b/as2_motion_reference_handlers/src/motion_reference_bus.hpp
@@ -1,0 +1,139 @@
+// Copyright 2023 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+/*!*******************************************************************************************
+ *  \file       motion_reference_bus.hpp
+ *  \brief      Resources shared by the motion reference handlers of one node
+ *  \authors    Rafael Pérez Seguí
+ ********************************************************************************/
+
+#ifndef MOTION_REFERENCE_BUS_HPP_
+#define MOTION_REFERENCE_BUS_HPP_
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include <as2_msgs/msg/control_mode.hpp>
+#include <as2_msgs/msg/controller_info.hpp>
+#include <as2_msgs/msg/platform_info.hpp>
+#include <as2_msgs/msg/thrust.hpp>
+#include <as2_msgs/msg/trajectory_setpoints.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include "as2_core/node.hpp"
+
+namespace as2
+{
+namespace motionReferenceHandlers
+{
+
+/**
+ * @brief Publishers, control mode subscription and active mode of one (node, namespace).
+ *
+ * Several handlers on one node talk to the same controller or platform, so they must share
+ * one set of publishers and, above all, one view of the active control mode: if each kept
+ * its own, a mode settled by one handler would be unknown to the others until the next
+ * info message arrived.
+ *
+ * Handlers obtain it through get(), which hands out the existing bus when another handler
+ * of the same node and namespace already built it. The registry holds weak references, so
+ * the resources die with the last handler using them rather than living to the end of the
+ * process.
+ *
+ * Not part of the public interface of the package: it lives next to the implementation.
+ */
+class MotionReferenceBus
+{
+public:
+  /**
+   * @brief Get the bus of a (node, namespace), building it on first use.
+   *
+   * @param node Node the references are published from.
+   * @param ns Namespace prefix already resolved, empty for the node's own namespace.
+   * @return Bus, shared with any other handler of the same node and namespace.
+   */
+  static std::shared_ptr<MotionReferenceBus> get(as2::Node * node, const std::string & ns);
+
+  /**
+   * @brief Destroy the bus and drop its entry from the registry.
+   */
+  ~MotionReferenceBus();
+
+  /**
+   * @brief Node the references are published from.
+   */
+  as2::Node * node_ptr_;
+
+  /**
+   * @brief Namespace prefix prepended to every topic, empty for the node's own namespace.
+   */
+  std::string namespace_;
+
+  /**
+   * @brief References go straight to the platform, bypassing the motion controller.
+   */
+  bool use_actuator_commands_ = false;
+
+  /**
+   * @brief Mode the controller, or the platform, reports as active.
+   */
+  as2_msgs::msg::ControlMode current_mode_;
+
+  rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr command_traj_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr command_pose_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr command_twist_pub_;
+  rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr command_thrust_pub_;
+
+private:
+  using Key = std::pair<as2::Node *, std::string>;
+
+  /**
+   * @brief Build the publishers and the control mode subscription of a (node, namespace).
+   *
+   * @param node Node the references are published from.
+   * @param ns Namespace prefix already resolved.
+   */
+  MotionReferenceBus(as2::Node * node, const std::string & ns);
+
+  // Only one of the two is created, depending on use_actuator_commands_
+  rclcpp::Subscription<as2_msgs::msg::ControllerInfo>::SharedPtr controller_info_sub_;
+  rclcpp::Subscription<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_sub_;
+
+  static std::map<Key, std::weak_ptr<MotionReferenceBus>> registry_;
+  static std::mutex registry_mutex_;
+};
+
+}    // namespace motionReferenceHandlers
+}  // namespace as2
+
+#endif  // MOTION_REFERENCE_BUS_HPP_

--- a/as2_motion_reference_handlers/tests/CMakeLists.txt
+++ b/as2_motion_reference_handlers/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+file(GLOB GTEST_SOURCES *_gtest.cpp)
+
+foreach(GTEST_SOURCE ${GTEST_SOURCES})
+  get_filename_component(TEST_NAME ${GTEST_SOURCE} NAME_WE)
+
+  ament_add_gtest(${TEST_NAME} ${GTEST_SOURCE})
+  ament_target_dependencies(${TEST_NAME} ${PROJECT_DEPENDENCIES})
+  target_link_libraries(${TEST_NAME} ${PROJECT_NAME})
+endforeach()

--- a/as2_motion_reference_handlers/tests/motion_reference_handlers_gtest.cpp
+++ b/as2_motion_reference_handlers/tests/motion_reference_handlers_gtest.cpp
@@ -1,0 +1,265 @@
+// Copyright 2026 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*!*******************************************************************************************
+ *  \file       motion_reference_handlers_gtest.cpp
+ *  \brief      Tests for the destination of the motion references, either the motion
+ *              controller or the aerial platform.
+ *  \authors    Rafael Pérez Seguí
+ ********************************************************************************/
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "as2_motion_reference_handlers/position_motion.hpp"
+#include "as2_core/names/services.hpp"
+#include "as2_core/names/topics.hpp"
+#include "as2_msgs/msg/platform_info.hpp"
+#include "as2_msgs/srv/set_control_mode.hpp"
+#include "gtest/gtest.h"
+
+namespace as2
+{
+
+namespace
+{
+
+using std::chrono_literals::operator""ms;
+
+/**
+ * @class DestinationsMock, node playing both destinations of the motion
+ * references, the aerial platform and the motion controller, to tell which one
+ * the handlers are talking to
+ */
+class DestinationsMock : public rclcpp::Node
+{
+public:
+  DestinationsMock()
+  : rclcpp::Node("destinations_mock")
+  {
+    // Platform side
+    platform_mode_srv_ = create_service<as2_msgs::srv::SetControlMode>(
+      as2_names::services::platform::set_platform_control_mode,
+      [this](
+        const as2_msgs::srv::SetControlMode::Request::SharedPtr request,
+        as2_msgs::srv::SetControlMode::Response::SharedPtr response) {
+        requested_mode_ = request->control_mode;
+        platform_mode_requests_++;
+        response->success = true;
+      });
+
+    platform_info_pub_ = create_publisher<as2_msgs::msg::PlatformInfo>(
+      as2_names::topics::platform::info, as2_names::topics::platform::qos);
+
+    actuator_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+      as2_names::topics::actuator_command::pose, as2_names::topics::actuator_command::qos,
+      [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+        pose_command_ = *msg;
+        actuator_pose_commands_++;
+      });
+
+    actuator_twist_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+      as2_names::topics::actuator_command::twist, as2_names::topics::actuator_command::qos,
+      [this](const geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+        (void)msg;
+        actuator_twist_commands_++;
+      });
+
+    // Controller side
+    controller_mode_srv_ = create_service<as2_msgs::srv::SetControlMode>(
+      as2_names::services::controller::set_control_mode,
+      [this](
+        const as2_msgs::srv::SetControlMode::Request::SharedPtr request,
+        as2_msgs::srv::SetControlMode::Response::SharedPtr response) {
+        requested_mode_ = request->control_mode;
+        controller_mode_requests_++;
+        response->success = true;
+      });
+
+    controller_info_pub_ = create_publisher<as2_msgs::msg::ControllerInfo>(
+      as2_names::topics::controller::info, rclcpp::QoS(1));
+
+    reference_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+      as2_names::topics::motion_reference::pose, as2_names::topics::motion_reference::qos,
+      [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+        pose_command_ = *msg;
+        reference_pose_commands_++;
+      });
+
+    reference_twist_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+      as2_names::topics::motion_reference::twist, as2_names::topics::motion_reference::qos,
+      [this](const geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+        (void)msg;
+        reference_twist_commands_++;
+      });
+
+    info_timer_ = create_wall_timer(
+      100ms, [this]() {
+        as2_msgs::msg::PlatformInfo platform_info;
+        platform_info.header.stamp = now();
+        platform_info.current_control_mode = requested_mode_;
+        platform_info_pub_->publish(platform_info);
+
+        as2_msgs::msg::ControllerInfo controller_info;
+        controller_info.header.stamp = now();
+        controller_info.input_control_mode = requested_mode_;
+        controller_info_pub_->publish(controller_info);
+      });
+  }
+
+  as2_msgs::msg::ControlMode requested_mode_;
+  geometry_msgs::msg::PoseStamped pose_command_;
+  std::atomic_int platform_mode_requests_ = {0};
+  std::atomic_int controller_mode_requests_ = {0};
+  std::atomic_int actuator_pose_commands_ = {0};
+  std::atomic_int actuator_twist_commands_ = {0};
+  std::atomic_int reference_pose_commands_ = {0};
+  std::atomic_int reference_twist_commands_ = {0};
+
+private:
+  rclcpp::Service<as2_msgs::srv::SetControlMode>::SharedPtr platform_mode_srv_;
+  rclcpp::Service<as2_msgs::srv::SetControlMode>::SharedPtr controller_mode_srv_;
+  rclcpp::Publisher<as2_msgs::msg::PlatformInfo>::SharedPtr platform_info_pub_;
+  rclcpp::Publisher<as2_msgs::msg::ControllerInfo>::SharedPtr controller_info_pub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr actuator_pose_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr actuator_twist_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr reference_pose_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr reference_twist_sub_;
+  rclcpp::TimerBase::SharedPtr info_timer_;
+};
+
+std::shared_ptr<as2::Node> makeHandlerNode(const bool use_actuator_commands)
+{
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("use_actuator_commands", use_actuator_commands);
+  return std::make_shared<as2::Node>("motion_reference_test_node", options);
+}
+
+/**
+ * @brief Wait until a condition holds, spinning nothing: the nodes are spun by
+ * the executor thread of the test
+ */
+bool waitFor(const std::function<bool()> & condition, const int timeout_ms = 5000)
+{
+  for (int waited_ms = 0; waited_ms < timeout_ms; waited_ms += 10) {
+    if (condition()) {return true;}
+    std::this_thread::sleep_for(10ms);
+  }
+  return condition();
+}
+
+}  // namespace
+
+TEST(MotionReferenceHandlersTest, ActuatorCommandsGoToThePlatform)
+{
+  auto destinations = std::make_shared<DestinationsMock>();
+  auto node = makeHandlerNode(true);
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(destinations);
+  executor.add_node(node);
+  std::thread executor_thread([&executor]() {executor.spin();});
+
+  as2::motionReferenceHandlers::PositionMotion position_handler(node.get());
+
+  EXPECT_TRUE(
+    position_handler.sendPositionCommandWithYawAngle(
+      "earth", 1.0, 2.0, 3.0, 0.0, "earth", 0.5, 0.5, 0.5));
+
+  EXPECT_TRUE(
+    waitFor(
+      [&destinations]() {
+        return destinations->actuator_pose_commands_ > 0 &&
+        destinations->actuator_twist_commands_ > 0;
+      }));
+
+  // The mode is negotiated with the platform, and the commands reach it
+  EXPECT_EQ(destinations->platform_mode_requests_, 1);
+  EXPECT_EQ(destinations->controller_mode_requests_, 0);
+  EXPECT_EQ(
+    destinations->requested_mode_.control_mode, as2_msgs::msg::ControlMode::POSITION);
+  EXPECT_EQ(destinations->requested_mode_.yaw_mode, as2_msgs::msg::ControlMode::YAW_ANGLE);
+  EXPECT_EQ(destinations->pose_command_.pose.position.x, 1.0);
+
+  // The motion controller is out of the chain
+  EXPECT_EQ(destinations->reference_pose_commands_, 0);
+  EXPECT_EQ(destinations->reference_twist_commands_, 0);
+
+  executor.cancel();
+  executor_thread.join();
+}
+
+TEST(MotionReferenceHandlersTest, MotionReferencesGoToTheControllerByDefault)
+{
+  auto destinations = std::make_shared<DestinationsMock>();
+  auto node = makeHandlerNode(false);
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(destinations);
+  executor.add_node(node);
+  std::thread executor_thread([&executor]() {executor.spin();});
+
+  as2::motionReferenceHandlers::PositionMotion position_handler(node.get());
+
+  EXPECT_TRUE(
+    position_handler.sendPositionCommandWithYawAngle(
+      "earth", 1.0, 2.0, 3.0, 0.0, "earth", 0.5, 0.5, 0.5));
+
+  EXPECT_TRUE(
+    waitFor(
+      [&destinations]() {
+        return destinations->reference_pose_commands_ > 0 &&
+        destinations->reference_twist_commands_ > 0;
+      }));
+
+  // The mode is negotiated with the controller, and the commands reach it
+  EXPECT_EQ(destinations->controller_mode_requests_, 1);
+  EXPECT_EQ(destinations->platform_mode_requests_, 0);
+  EXPECT_EQ(destinations->pose_command_.pose.position.x, 1.0);
+
+  // The platform only gets commands through the controller
+  EXPECT_EQ(destinations->actuator_pose_commands_, 0);
+  EXPECT_EQ(destinations->actuator_twist_commands_, 0);
+
+  executor.cancel();
+  executor_thread.join();
+}
+
+}  // namespace as2
+
+int main(int argc, char * argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  auto result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/as2_motion_reference_handlers/tests/motion_reference_handlers_gtest.cpp
+++ b/as2_motion_reference_handlers/tests/motion_reference_handlers_gtest.cpp
@@ -197,8 +197,9 @@ TEST(MotionReferenceHandlersTest, ActuatorCommandsGoToThePlatform)
   EXPECT_TRUE(
     waitFor(
       [&destinations]() {
-        return destinations->actuator_pose_commands_ > 0 &&
-        destinations->actuator_twist_commands_ > 0;
+        const bool pose_received = destinations->actuator_pose_commands_ > 0;
+        const bool twist_received = destinations->actuator_twist_commands_ > 0;
+        return pose_received && twist_received;
       }));
 
   // The mode is negotiated with the platform, and the commands reach it
@@ -236,8 +237,9 @@ TEST(MotionReferenceHandlersTest, MotionReferencesGoToTheControllerByDefault)
   EXPECT_TRUE(
     waitFor(
       [&destinations]() {
-        return destinations->reference_pose_commands_ > 0 &&
-        destinations->reference_twist_commands_ > 0;
+        const bool pose_received = destinations->reference_pose_commands_ > 0;
+        const bool twist_received = destinations->reference_twist_commands_ > 0;
+        return pose_received && twist_received;
       }));
 
   // The mode is negotiated with the controller, and the commands reach it


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | https://github.com/aerostack2/aerostack2/issues/240 |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Added `use_actuator_commands` parameter to motion reference handlers (C++ and Python)
* When enabled, handlers publish to `actuator_command/*` topics, bypassing motion controller
* Added frame validation: reject commands without `frame_id` to prevent silent frame mismatches
* Implemented dual subscription pattern: subscribes to `platform_info` or `controller_info` depending on parameter
* Handlers of the same node now share their publishers and their view of the active control mode
* Completed the docstrings of the package, in Python and in the C++ headers

## Shared resources: before and after

**Before.** In C++ the publishers were `static` members, so they were shared across the whole
*process* rather than per node: two nodes living in one process overwrote each other's publishers,
and the first one constructed decided the topics for all of them. That matters more with
`use_actuator_commands`, since the destination of the commands depends on a parameter *of the node*.
Python did keep them per node, but only the publishers.

In both languages every handler also created **its own** subscription to `controller/info` (or
`platform/info`) and kept **its own copy** of the active control mode. `land_behavior` holds three
handlers alive at once, so that is three subscriptions to the same topic, and three separate answers
to the question "which mode is active". Worse than the duplication: `setMode()` only updated the
mode of the handler that called it, so a mode settled by one handler was unknown to the others until
the next info message arrived, leaving a window where they disagreed and an extra service call.

**After.** A `MotionReferenceBus`, keyed by `(node, namespace)`, owns the four publishers, the info
subscription and the active mode. Handlers of the same node and namespace share one, so the mode is
now a single value that every handler sees as soon as it is settled. Nodes remain isolated from each
other, which the old `static` members did not guarantee.

The registry holds weak references and the bus erases its own entry on destruction, so the resources
die with the last handler using them. On the Python side the equivalent dictionary never released
its entries: a node that went away left its publishers alive for the rest of the process. It is now
a `WeakKeyDictionary`.

The bus is an implementation detail: it lives under `src/`, is not installed, and the public header
only carries a forward declaration. The public API is unchanged, so no caller needs to be touched.

## Description of documentation updates required from your changes

* Document the `use_actuator_commands` parameter in the handler configuration guide
* Update the motion reference handlers tutorial with the direct platform communication flow

## Future work that may be required in bullet points

* Extend the direct platform path to the remaining behaviors if needed
* The bus registry is still process-wide state, indexed per `(node, namespace)`. Passing the bus
  explicitly to the handlers would remove it, at the cost of changing the public API
