### PR TITLE
[as2_core] Empty TF frame names resolve to the namespace, and a filterable TF listener

### DIFF
--- a/as2_core/CMakeLists.txt
+++ b/as2_core/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SOURCE_CPP_FILES
     src/polynomial_thrust_map.cpp
     src/utils/control_mode_utils.cpp
     src/utils/tf_utils.cpp
+    src/utils/filtered_transform_listener.cpp
     src/utils/yaml_utils.cpp
     src/utils/frame_utils.cpp
     src/utils/gps_utils.cpp)

--- a/as2_core/include/as2_core/node.hpp
+++ b/as2_core/include/as2_core/node.hpp
@@ -109,9 +109,20 @@ private:
 
   /**
    * @brief Read the four canonical TF frames of the robot from parameters.
-   * Called by init(), so every node exposes them.
+   * Called by init(), so every node exposes them. Logs the namespaced result, and warns
+   * for any frame configured away from its REP-105 name.
    */
   void initializeCanonicalFrames();
+
+  /**
+   * @brief Warn when a frame is configured away from its REP-105 name.
+   *
+   * @param param_name Parameter the value came from, for the message.
+   * @param value Configured frame name, before namespacing.
+   * @param standard REP-105 name expected for that frame.
+   */
+  void warnIfNotStandardFrame(
+    const std::string & param_name, const std::string & value, const std::string & standard);
 
   std::string earth_frame_id_;
   std::string map_frame_id_;

--- a/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
+++ b/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
@@ -1,0 +1,255 @@
+// Copyright 2023 Universidad Politécnica de Madrid
+// Copyright (c) 2008, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*!*******************************************************************************************
+ *  \file       filtered_transform_listener.hpp
+ *  \brief      filtered_transform_listener header file.
+ *  \authors    Tully Foote
+ *              Miguel Fernandez Cortizas
+ *              Rafael Perez Segui
+ ********************************************************************************/
+
+
+#ifndef AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_
+#define AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_
+
+#include <functional>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+
+#include "tf2/tf2/buffer_core.h"
+#include "tf2/tf2/time.h"
+#include "tf2_ros/visibility_control.h"
+#include "tf2_ros/transform_listener.h"
+
+#include "tf2_ros/qos.hpp"
+
+namespace as2
+{
+
+namespace tf
+{
+
+// /**
+//  * @brief This class is similar to the tf2_ros::TransformListener but it allows to filter the
+//  * transforms that are received by the listener and added to the buffer. We based on the code of
+//  * the tf2_ros::TransformListener and we added the filter functionality in the subscribe
+//  * function.
+//  */
+class FilteredTransformListener
+{
+public:
+  /** \brief Simplified constructor for transform listener.
+   *
+   * This constructor will create a new ROS 2 node under the hood.
+   * If you already have access to a ROS 2 node and you want to associate the TransformListener
+   * to it, then it's recommended to use one of the other constructors.
+   */
+  TF2_ROS_PUBLIC
+  explicit FilteredTransformListener(
+    tf2::BufferCore & buffer,
+    bool spin_thread = true,
+    bool static_only = false);
+
+  /** \brief Node constructor */
+  template<class NodeT, class AllocatorT = std::allocator<void>>
+  FilteredTransformListener(
+    tf2::BufferCore & buffer,
+    NodeT && node,
+    bool spin_thread = true,
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
+    tf2_ros::detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    tf2_ros::detail::get_default_transform_listener_static_sub_options<AllocatorT>(),
+    bool static_only = false)
+  : FilteredTransformListener(
+      buffer,
+      node->get_node_base_interface(),
+      node->get_node_logging_interface(),
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface(),
+      spin_thread,
+      qos,
+      static_qos,
+      options,
+      static_options,
+      static_only)
+  {}
+
+  /** \brief Node interface constructor */
+  template<class AllocatorT = std::allocator<void>>
+  FilteredTransformListener(
+    tf2::BufferCore & buffer,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    bool spin_thread = true,
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
+    tf2_ros::detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    tf2_ros::detail::get_default_transform_listener_static_sub_options<AllocatorT>(),
+    bool static_only = false)
+  : buffer_(buffer)
+  {
+    init(
+      node_base,
+      node_logging,
+      node_parameters,
+      node_topics,
+      spin_thread,
+      qos,
+      static_qos,
+      options,
+      static_options,
+      static_only);
+  }
+
+  TF2_ROS_PUBLIC
+  virtual ~FilteredTransformListener();
+
+  /// Callback function for ros message subscription
+  TF2_ROS_PUBLIC
+  virtual void subscription_callback(tf2_msgs::msg::TFMessage::ConstSharedPtr msg, bool is_static);
+
+  // added filter rules vector
+  bool add_filter_rule(
+    std::function<bool(const geometry_msgs::msg::TransformStamped &)> _filter_rule)
+  {
+    filter_rules_.push_back(_filter_rule);
+    return true;
+  }
+
+  // added clear filter rules function
+  void clear_filter_rules()
+  {
+    filter_rules_.clear();
+  }
+
+private:
+  template<class AllocatorT = std::allocator<void>>
+  void init(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    bool spin_thread,
+    const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
+    bool static_only = false)
+  {
+    spin_thread_ = spin_thread;
+    node_base_interface_ = node_base;
+    node_logging_interface_ = node_logging;
+
+    using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
+    callback_t cb = std::bind(
+      &FilteredTransformListener::subscription_callback, this, std::placeholders::_1, false);
+    callback_t static_cb = std::bind(
+      &FilteredTransformListener::subscription_callback, this, std::placeholders::_1, true);
+
+    if (spin_thread_) {
+      // Create new callback group for message_subscription of tf and tf_static
+      callback_group_ = node_base_interface_->create_callback_group(
+        rclcpp::CallbackGroupType::MutuallyExclusive, false);
+
+      if (!static_only) {
+        // Duplicate to modify subscription options
+        rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_options = options;
+        tf_options.callback_group = callback_group_;
+
+        message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+          node_parameters, node_topics, "/tf", qos, std::move(cb), tf_options);
+      }
+
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_static_options = static_options;
+      tf_static_options.callback_group = callback_group_;
+
+      message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node_parameters,
+        node_topics,
+        "/tf_static",
+        static_qos,
+        std::move(static_cb),
+        tf_static_options);
+
+      // Create executor with dedicated thread to spin.
+      executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+      executor_->add_callback_group(callback_group_, node_base_interface_);
+      dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
+      // Tell the buffer we have a dedicated thread to enable timeouts
+      buffer_.setUsingDedicatedThread(true);
+    } else {
+      if (!static_only) {
+        message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+          node_parameters, node_topics, "/tf", qos, std::move(cb), options);
+      }
+      message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node_parameters,
+        node_topics,
+        "/tf_static",
+        static_qos,
+        std::move(static_cb),
+        static_options);
+    }
+  }
+
+  bool spin_thread_{false};
+  std::unique_ptr<std::thread> dedicated_listener_thread_ {nullptr};
+  rclcpp::Executor::SharedPtr executor_ {nullptr};
+
+  rclcpp::Node::SharedPtr optional_default_node_ {nullptr};
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr
+    message_subscription_tf_ {nullptr};
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr
+    message_subscription_tf_static_ {nullptr};
+  tf2::BufferCore & buffer_;
+  tf2::TimePoint last_update_;
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_ {nullptr};
+  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
+
+
+  std::vector<std::function<bool(const geometry_msgs::msg::TransformStamped &)>> filter_rules_;
+};
+
+}  // namespace tf
+
+}  // namespace as2
+
+#endif  // AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_

--- a/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
+++ b/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
@@ -31,11 +31,12 @@
  *  \file       filtered_transform_listener.hpp
  *  \brief      filtered_transform_listener header file.
  *
- *  Copy of tf2_ros/transform_listener.hpp from ROS 2 (jazzy), Copyright (c) 2008 Willow
- *  Garage, Inc., released under the 3-clause BSD licence reproduced above. Kept line by line
- *  identical to the original except for three things: the filter rules, the tf2_ros::detail
- *  helpers, which are used from the original header instead of copied, and the
- *  StaticTransformListener convenience class, which is dropped.
+ *  Copy of tf2_ros/include/tf2_ros/transform_listener.hpp, from ros2/geometry2 at
+ *  b950c7ea204d (2026-05-29, jazzy). Copyright (c) 2008 Willow Garage, Inc., released under
+ *  the 3-clause BSD licence reproduced above. Kept line by line identical to that revision
+ *  except for three things: the filter rules, the tf2_ros::detail helpers, which are used
+ *  from the original header instead of copied, and the StaticTransformListener convenience
+ *  class, which is dropped.
  *
  *  \authors    Tully Foote
  *              Miguel Fernandez Cortizas

--- a/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
+++ b/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
@@ -33,6 +33,7 @@
  *  \authors    Tully Foote
  *              Miguel Fernandez Cortizas
  *              Rafael Perez Segui
+ *              Rodrigo Da Silva Gómez
  ********************************************************************************/
 
 

--- a/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
+++ b/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
@@ -1,46 +1,62 @@
-/*
- * Copyright (c) 2008, Willow Garage, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Willow Garage, Inc. nor the names of its
- *       contributors may be used to endorse or promote products derived from
- *       this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright 2026 Universidad Politécnica de Madrid
+// Copyright (c) 2008, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-/** \file
- *  \brief Author: Tully Foote
- */
+/*!*******************************************************************************************
+ *  \file       filtered_transform_listener.hpp
+ *  \brief      filtered_transform_listener header file.
+ *
+ *  Copy of tf2_ros/transform_listener.hpp from ROS 2 (jazzy), Copyright (c) 2008 Willow
+ *  Garage, Inc., released under the 3-clause BSD licence reproduced above. Kept line by line
+ *  identical to the original except for three things: the filter rules, the tf2_ros::detail
+ *  helpers, which are used from the original header instead of copied, and the
+ *  StaticTransformListener convenience class, which is dropped.
+ *
+ *  \authors    Tully Foote
+ *              Miguel Fernandez Cortizas
+ *              Rafael Perez Segui
+ *              Rodrigo Da Silva Gómez
+ ********************************************************************************/
 
-#ifndef TF2_ROS__TRANSFORM_LISTENER_HPP_
-#define TF2_ROS__TRANSFORM_LISTENER_HPP_
+#ifndef AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_
+#define AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_
 
 #include <functional>
 #include <memory>
 #include <thread>
 #include <utility>
+#include <vector>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
 
 #include "tf2/buffer_core.hpp"
 #include "tf2/time.hpp"
+#include "tf2_ros/transform_listener.hpp"
 #include "tf2_ros/visibility_control.hpp"
 
 #include "tf2_msgs/msg/tf_message.hpp"
@@ -48,77 +64,69 @@
 
 #include "tf2_ros/qos.hpp"
 
-namespace tf2_ros
+namespace as2
 {
 
-namespace detail
+namespace tf
 {
-template<class AllocatorT = std::allocator<void>>
-rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
-get_default_transform_listener_sub_options()
-{
-  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
-  options.qos_overriding_options = rclcpp::QosOverridingOptions{
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::Durability,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Reliability};
-  return options;
-}
 
-template<class AllocatorT = std::allocator<void>>
-rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
-get_default_transform_listener_static_sub_options()
-{
-  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
-  options.qos_overriding_options = rclcpp::QosOverridingOptions{
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Reliability};
-  return options;
-}
-}  // namespace detail
-
-/** \brief This class provides an easy way to request and receive coordinate frame transform information.
+/** \brief This class provides an easy way to request and receive coordinate frame transform
+ * information, dropping the transforms rejected by a set of filter rules.
+ *
+ * The rules cannot be changed after construction: the listener thread reads them without a lock
+ * and is already running when the constructor returns.
+ *
+ * From jazzy on, tf2_ros::TransformListener::subscription_callback() is public and virtual, so
+ * this whole file can be replaced by a subclass overriding it. It is private in humble, which is
+ * why the class is copied instead of derived.
  */
-class TransformListener
+class FilteredTransformListener
 {
 public:
+  /// Rule applied to an incoming transform. Returning false keeps it out of the buffer.
+  using FilterRule = std::function<bool (const geometry_msgs::msg::TransformStamped &)>;
+
   /** \brief Simplified constructor for transform listener.
    *
    * This constructor will create a new ROS 2 node under the hood.
-   * If you already have access to a ROS 2 node and you want to associate the TransformListener
-   * to it, then it's recommended to use one of the other constructors.
+   * If you already have access to a ROS 2 node and you want to associate the
+   * FilteredTransformListener to it, then it's recommended to use one of the other constructors.
    */
   TF2_ROS_PUBLIC
-  explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true);
+  explicit FilteredTransformListener(
+    tf2::BufferCore & buffer,
+    std::vector<FilterRule> filter_rules = {},
+    bool spin_thread = true);
 
   /** \brief Simplified constructor for transform listener with static_only option.
    *
    * This constructor will create a new ROS 2 node under the hood.
-   * If you already have access to a ROS 2 node and you want to associate the TransformListener
-   * to it, then it's recommended to use one of the other constructors.
+   * If you already have access to a ROS 2 node and you want to associate the
+   * FilteredTransformListener to it, then it's recommended to use one of the other constructors.
    */
   TF2_ROS_PUBLIC
-  explicit TransformListener(
+  explicit FilteredTransformListener(
     tf2::BufferCore & buffer,
+    std::vector<FilterRule> filter_rules,
     bool spin_thread,
     bool static_only);
 
   /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
-  TransformListener(
+  FilteredTransformListener(
     tf2::BufferCore & buffer,
+    std::vector<FilterRule> filter_rules,
     NodeT && node,
     bool spin_thread = true,
-    const rclcpp::QoS & qos = DynamicListenerQoS(),
-    const rclcpp::QoS & static_qos = StaticListenerQoS(),
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
-    detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    tf2_ros::detail::get_default_transform_listener_sub_options<AllocatorT>(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
-    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
-  : TransformListener(
+    tf2_ros::detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : FilteredTransformListener(
       buffer,
+      std::move(filter_rules),
       node->get_node_base_interface(),
       node->get_node_logging_interface(),
       node->get_node_parameters_interface(),
@@ -132,8 +140,9 @@ public:
 
   /** \brief Node constructor with static_only option */
   template<class NodeT, class AllocatorT = std::allocator<void>>
-  TransformListener(
+  FilteredTransformListener(
     tf2::BufferCore & buffer,
+    std::vector<FilterRule> filter_rules,
     NodeT && node,
     bool spin_thread,
     const rclcpp::QoS & qos,
@@ -141,8 +150,9 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
     bool static_only)
-  : TransformListener(
+  : FilteredTransformListener(
       buffer,
+      std::move(filter_rules),
       node->get_node_base_interface(),
       node->get_node_logging_interface(),
       node->get_node_parameters_interface(),
@@ -157,20 +167,21 @@ public:
 
   /** \brief Node interface constructor */
   template<class AllocatorT = std::allocator<void>>
-  TransformListener(
+  FilteredTransformListener(
     tf2::BufferCore & buffer,
+    std::vector<FilterRule> filter_rules,
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     bool spin_thread = true,
-    const rclcpp::QoS & qos = DynamicListenerQoS(),
-    const rclcpp::QoS & static_qos = StaticListenerQoS(),
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
-    detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    tf2_ros::detail::get_default_transform_listener_sub_options<AllocatorT>(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
-    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
-  : buffer_(buffer)
+    tf2_ros::detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : buffer_(buffer), filter_rules_(std::move(filter_rules))
   {
     init(
       node_base,
@@ -186,8 +197,9 @@ public:
 
   /** \brief Node interface constructor with static_only option */
   template<class AllocatorT = std::allocator<void>>
-  TransformListener(
+  FilteredTransformListener(
     tf2::BufferCore & buffer,
+    std::vector<FilterRule> filter_rules,
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
@@ -198,7 +210,7 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
     bool static_only)
-  : buffer_(buffer)
+  : buffer_(buffer), filter_rules_(std::move(filter_rules))
   {
     init(
       node_base,
@@ -214,7 +226,7 @@ public:
   }
 
   TF2_ROS_PUBLIC
-  virtual ~TransformListener();
+  virtual ~FilteredTransformListener();
 
   /// Callback function for ros message subscription
   TF2_ROS_PUBLIC
@@ -239,9 +251,9 @@ private:
 
     using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
     callback_t cb = std::bind(
-      &TransformListener::subscription_callback, this, std::placeholders::_1, false);
+      &FilteredTransformListener::subscription_callback, this, std::placeholders::_1, false);
     callback_t static_cb = std::bind(
-      &TransformListener::subscription_callback, this, std::placeholders::_1, true);
+      &FilteredTransformListener::subscription_callback, this, std::placeholders::_1, true);
 
     if (spin_thread_) {
       // Create new callback group for message_subscription of tf and tf_static
@@ -316,7 +328,7 @@ private:
 
     using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
     callback_t static_cb = std::bind(
-      &TransformListener::subscription_callback, this, std::placeholders::_1, true);
+      &FilteredTransformListener::subscription_callback, this, std::placeholders::_1, true);
 
     if (spin_thread_) {
       callback_group_ = node_base_interface_->create_callback_group(
@@ -357,83 +369,15 @@ private:
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr
     message_subscription_tf_static_ {nullptr};
   tf2::BufferCore & buffer_;
+  const std::vector<FilterRule> filter_rules_;
   tf2::TimePoint last_update_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_ {nullptr};
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
 };
 
-/** \brief Convenience class for subscribing to static-only transforms
- *
- * While users can achieve the same thing with a normal TransformListener, the number of parameters that must be
- * provided is unwieldy.
- */
-class StaticTransformListener : public TransformListener
-{
-public:
-  /** \brief Simplified constructor for a static transform listener
-   * \see the simplified TransformListener documentation
-   */
-  TF2_ROS_PUBLIC
-  explicit StaticTransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
-  : TransformListener(buffer, spin_thread, true)
-  {
-  }
+}  // namespace tf
 
-  /** \brief Node constructor */
-  template<class NodeT, class AllocatorT = std::allocator<void>>
-  StaticTransformListener(
-    tf2::BufferCore & buffer,
-    NodeT && node,
-    bool spin_thread = true,
-    const rclcpp::QoS & static_qos = StaticListenerQoS(),
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
-    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
-  : TransformListener(
-      buffer,
-      node,
-      spin_thread,
-      rclcpp::QoS(1),
-      static_qos,
-      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>(),
-      static_options,
-      true)
-  {
-  }
+}  // namespace as2
 
-  /** \brief Node interface constructor */
-  template<class AllocatorT = std::allocator<void>>
-  StaticTransformListener(
-    tf2::BufferCore & buffer,
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
-    bool spin_thread = true,
-    const rclcpp::QoS & static_qos = StaticListenerQoS(),
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
-    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
-  : TransformListener(
-      buffer,
-      node_base,
-      node_logging,
-      node_parameters,
-      node_topics,
-      spin_thread,
-      rclcpp::QoS(1),
-      static_qos,
-      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>(),
-      static_options,
-      true)
-  {
-  }
-
-  TF2_ROS_PUBLIC
-  virtual ~StaticTransformListener()
-  {
-  }
-};
-
-}  // namespace tf2_ros
-
-#endif  // TF2_ROS__TRANSFORM_LISTENER_HPP_
+#endif  // AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_

--- a/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
+++ b/as2_core/include/as2_core/utils/filtered_transform_listener.hpp
@@ -1,72 +1,87 @@
-// Copyright 2023 Universidad Politécnica de Madrid
-// Copyright (c) 2008, Willow Garage, Inc.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-/*!*******************************************************************************************
- *  \file       filtered_transform_listener.hpp
- *  \brief      filtered_transform_listener header file.
- *  \authors    Tully Foote
- *              Miguel Fernandez Cortizas
- *              Rafael Perez Segui
- *              Rodrigo Da Silva Gómez
- ********************************************************************************/
+/** \file
+ *  \brief Author: Tully Foote
+ */
 
-
-#ifndef AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_
-#define AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_
+#ifndef TF2_ROS__TRANSFORM_LISTENER_HPP_
+#define TF2_ROS__TRANSFORM_LISTENER_HPP_
 
 #include <functional>
 #include <memory>
 #include <thread>
 #include <utility>
-#include <vector>
 
+#include "tf2/buffer_core.hpp"
+#include "tf2/time.hpp"
+#include "tf2_ros/visibility_control.hpp"
 
-#include "tf2/tf2/buffer_core.h"
-#include "tf2/tf2/time.h"
-#include "tf2_ros/visibility_control.h"
-#include "tf2_ros/transform_listener.h"
+#include "tf2_msgs/msg/tf_message.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 #include "tf2_ros/qos.hpp"
 
-namespace as2
+namespace tf2_ros
 {
 
-namespace tf
+namespace detail
 {
+template<class AllocatorT = std::allocator<void>>
+rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
+get_default_transform_listener_sub_options()
+{
+  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions{
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability};
+  return options;
+}
 
-// /**
-//  * @brief This class is similar to the tf2_ros::TransformListener but it allows to filter the
-//  * transforms that are received by the listener and added to the buffer. We based on the code of
-//  * the tf2_ros::TransformListener and we added the filter functionality in the subscribe
-//  * function.
-//  */
-class FilteredTransformListener
+template<class AllocatorT = std::allocator<void>>
+rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
+get_default_transform_listener_static_sub_options()
+{
+  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions{
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability};
+  return options;
+}
+}  // namespace detail
+
+/** \brief This class provides an easy way to request and receive coordinate frame transform information.
+ */
+class TransformListener
 {
 public:
   /** \brief Simplified constructor for transform listener.
@@ -76,25 +91,57 @@ public:
    * to it, then it's recommended to use one of the other constructors.
    */
   TF2_ROS_PUBLIC
-  explicit FilteredTransformListener(
+  explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true);
+
+  /** \brief Simplified constructor for transform listener with static_only option.
+   *
+   * This constructor will create a new ROS 2 node under the hood.
+   * If you already have access to a ROS 2 node and you want to associate the TransformListener
+   * to it, then it's recommended to use one of the other constructors.
+   */
+  TF2_ROS_PUBLIC
+  explicit TransformListener(
     tf2::BufferCore & buffer,
-    bool spin_thread = true,
-    bool static_only = false);
+    bool spin_thread,
+    bool static_only);
 
   /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
-  FilteredTransformListener(
+  TransformListener(
     tf2::BufferCore & buffer,
     NodeT && node,
     bool spin_thread = true,
-    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
-    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS(),
+    const rclcpp::QoS & qos = DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
-    tf2_ros::detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    detail::get_default_transform_listener_sub_options<AllocatorT>(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
-    tf2_ros::detail::get_default_transform_listener_static_sub_options<AllocatorT>(),
-    bool static_only = false)
-  : FilteredTransformListener(
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : TransformListener(
+      buffer,
+      node->get_node_base_interface(),
+      node->get_node_logging_interface(),
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface(),
+      spin_thread,
+      qos,
+      static_qos,
+      options,
+      static_options)
+  {}
+
+  /** \brief Node constructor with static_only option */
+  template<class NodeT, class AllocatorT = std::allocator<void>>
+  TransformListener(
+    tf2::BufferCore & buffer,
+    NodeT && node,
+    bool spin_thread,
+    const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
+    bool static_only)
+  : TransformListener(
       buffer,
       node->get_node_base_interface(),
       node->get_node_logging_interface(),
@@ -110,20 +157,47 @@ public:
 
   /** \brief Node interface constructor */
   template<class AllocatorT = std::allocator<void>>
-  FilteredTransformListener(
+  TransformListener(
     tf2::BufferCore & buffer,
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     bool spin_thread = true,
-    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
-    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS(),
+    const rclcpp::QoS & qos = DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
-    tf2_ros::detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    detail::get_default_transform_listener_sub_options<AllocatorT>(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
-    tf2_ros::detail::get_default_transform_listener_static_sub_options<AllocatorT>(),
-    bool static_only = false)
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : buffer_(buffer)
+  {
+    init(
+      node_base,
+      node_logging,
+      node_parameters,
+      node_topics,
+      spin_thread,
+      qos,
+      static_qos,
+      options,
+      static_options);
+  }
+
+  /** \brief Node interface constructor with static_only option */
+  template<class AllocatorT = std::allocator<void>>
+  TransformListener(
+    tf2::BufferCore & buffer,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    bool spin_thread,
+    const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
+    bool static_only)
   : buffer_(buffer)
   {
     init(
@@ -140,25 +214,11 @@ public:
   }
 
   TF2_ROS_PUBLIC
-  virtual ~FilteredTransformListener();
+  virtual ~TransformListener();
 
   /// Callback function for ros message subscription
   TF2_ROS_PUBLIC
   virtual void subscription_callback(tf2_msgs::msg::TFMessage::ConstSharedPtr msg, bool is_static);
-
-  // added filter rules vector
-  bool add_filter_rule(
-    std::function<bool(const geometry_msgs::msg::TransformStamped &)> _filter_rule)
-  {
-    filter_rules_.push_back(_filter_rule);
-    return true;
-  }
-
-  // added clear filter rules function
-  void clear_filter_rules()
-  {
-    filter_rules_.clear();
-  }
 
 private:
   template<class AllocatorT = std::allocator<void>>
@@ -171,8 +231,7 @@ private:
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
-    bool static_only = false)
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options)
   {
     spin_thread_ = spin_thread;
     node_base_interface_ = node_base;
@@ -180,27 +239,22 @@ private:
 
     using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
     callback_t cb = std::bind(
-      &FilteredTransformListener::subscription_callback, this, std::placeholders::_1, false);
+      &TransformListener::subscription_callback, this, std::placeholders::_1, false);
     callback_t static_cb = std::bind(
-      &FilteredTransformListener::subscription_callback, this, std::placeholders::_1, true);
+      &TransformListener::subscription_callback, this, std::placeholders::_1, true);
 
     if (spin_thread_) {
       // Create new callback group for message_subscription of tf and tf_static
       callback_group_ = node_base_interface_->create_callback_group(
         rclcpp::CallbackGroupType::MutuallyExclusive, false);
-
-      if (!static_only) {
-        // Duplicate to modify subscription options
-        rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_options = options;
-        tf_options.callback_group = callback_group_;
-
-        message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-          node_parameters, node_topics, "/tf", qos, std::move(cb), tf_options);
-      }
-
+      // Duplicate to modify option of subscription
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_options = options;
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_static_options = static_options;
+      tf_options.callback_group = callback_group_;
       tf_static_options.callback_group = callback_group_;
 
+      message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node_parameters, node_topics, "/tf", qos, std::move(cb), tf_options);
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
         node_parameters,
         node_topics,
@@ -216,10 +270,73 @@ private:
       // Tell the buffer we have a dedicated thread to enable timeouts
       buffer_.setUsingDedicatedThread(true);
     } else {
-      if (!static_only) {
-        message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-          node_parameters, node_topics, "/tf", qos, std::move(cb), options);
-      }
+      message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node_parameters, node_topics, "/tf", qos, std::move(cb), options);
+      message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node_parameters,
+        node_topics,
+        "/tf_static",
+        static_qos,
+        std::move(static_cb),
+        static_options);
+    }
+  }
+
+  // Overload of init() with the static_only flag
+  template<class AllocatorT = std::allocator<void>>
+  void init(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    bool spin_thread,
+    const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
+    bool static_only)
+  {
+    if (!static_only) {
+      init(
+        node_base,
+        node_logging,
+        node_parameters,
+        node_topics,
+        spin_thread,
+        qos,
+        static_qos,
+        options,
+        static_options);
+      return;
+    }
+
+    spin_thread_ = spin_thread;
+    node_base_interface_ = node_base;
+    node_logging_interface_ = node_logging;
+
+    using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
+    callback_t static_cb = std::bind(
+      &TransformListener::subscription_callback, this, std::placeholders::_1, true);
+
+    if (spin_thread_) {
+      callback_group_ = node_base_interface_->create_callback_group(
+        rclcpp::CallbackGroupType::MutuallyExclusive, false);
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_static_options = static_options;
+      tf_static_options.callback_group = callback_group_;
+
+      message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node_parameters,
+        node_topics,
+        "/tf_static",
+        static_qos,
+        std::move(static_cb),
+        tf_static_options);
+
+      executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+      executor_->add_callback_group(callback_group_, node_base_interface_);
+      dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
+      buffer_.setUsingDedicatedThread(true);
+    } else {
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
         node_parameters,
         node_topics,
@@ -244,13 +361,79 @@ private:
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_ {nullptr};
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
-
-
-  std::vector<std::function<bool(const geometry_msgs::msg::TransformStamped &)>> filter_rules_;
 };
 
-}  // namespace tf
+/** \brief Convenience class for subscribing to static-only transforms
+ *
+ * While users can achieve the same thing with a normal TransformListener, the number of parameters that must be
+ * provided is unwieldy.
+ */
+class StaticTransformListener : public TransformListener
+{
+public:
+  /** \brief Simplified constructor for a static transform listener
+   * \see the simplified TransformListener documentation
+   */
+  TF2_ROS_PUBLIC
+  explicit StaticTransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
+  : TransformListener(buffer, spin_thread, true)
+  {
+  }
 
-}  // namespace as2
+  /** \brief Node constructor */
+  template<class NodeT, class AllocatorT = std::allocator<void>>
+  StaticTransformListener(
+    tf2::BufferCore & buffer,
+    NodeT && node,
+    bool spin_thread = true,
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : TransformListener(
+      buffer,
+      node,
+      spin_thread,
+      rclcpp::QoS(1),
+      static_qos,
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>(),
+      static_options,
+      true)
+  {
+  }
 
-#endif  // AS2_CORE__UTILS__FILTERED_TRANSFORM_LISTENER_HPP_
+  /** \brief Node interface constructor */
+  template<class AllocatorT = std::allocator<void>>
+  StaticTransformListener(
+    tf2::BufferCore & buffer,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    bool spin_thread = true,
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : TransformListener(
+      buffer,
+      node_base,
+      node_logging,
+      node_parameters,
+      node_topics,
+      spin_thread,
+      rclcpp::QoS(1),
+      static_qos,
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>(),
+      static_options,
+      true)
+  {
+  }
+
+  TF2_ROS_PUBLIC
+  virtual ~StaticTransformListener()
+  {
+  }
+};
+
+}  // namespace tf2_ros
+
+#endif  // TF2_ROS__TRANSFORM_LISTENER_HPP_

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -71,7 +71,9 @@ using namespace std::chrono_literals; // NOLINT
  * @brief Prefix a TF frame name with a namespace, following aerostack2 conventions.
  *
  * Rules applied:
- *  - If `_frame_name` is empty, throws `std::runtime_error`.
+ *  - If `_frame_name` is empty, the frame is the namespace itself, e.g. namespace
+ *    "drone0" yields "drone0". Throws `std::runtime_error` if `_namespace` is also
+ *    empty, since that leaves no name to build.
  *  - If `_frame_name` starts with '/', it is treated as absolute and returned
  *    without the leading '/' (no namespace prefix is added).
  *  - If `_frame_name` already starts with `<_namespace>/`, it is returned as is.
@@ -83,7 +85,7 @@ using namespace std::chrono_literals; // NOLINT
  * @param _namespace  Robot/node namespace. May be empty or start with '/'.
  * @param _frame_name Frame name, possibly absolute (leading '/') or already prefixed.
  * @return Fully-qualified TF frame id.
- * @throw std::runtime_error if `_frame_name` is empty.
+ * @throw std::runtime_error if both `_frame_name` and `_namespace` are empty.
  */
 std::string generateTfName(const std::string & _namespace, const std::string & _frame_name);
 
@@ -93,7 +95,7 @@ std::string generateTfName(const std::string & _namespace, const std::string & _
  * @param node        ROS 2 node whose namespace will be used as prefix.
  * @param _frame_name Frame name (see `generateTfName(namespace, frame_name)` for rules).
  * @return Fully-qualified TF frame id.
- * @throw std::runtime_error if `_frame_name` is empty.
+ * @throw std::runtime_error if `_frame_name` is empty and the node namespace is root.
  */
 std::string generateTfName(rclcpp::Node * node, std::string _frame_name);
 /**

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -45,6 +45,7 @@
 #include <string>
 #include <utility>
 #include <memory>
+#include <vector>
 
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -59,6 +60,7 @@
 #include "as2_core/node.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
+#include "as2_core/utils/filtered_transform_listener.hpp"
 
 namespace as2
 {
@@ -122,6 +124,7 @@ geometry_msgs::msg::TransformStamped getTransformation(
   const std::string & _frame_id, const std::string & _child_frame_id, double _translation_x,
   double _translation_y, double _translation_z, double _roll, double _pitch, double _yaw);
 
+
 /**
  * @brief Helper that wraps `tf2_ros::Buffer` and `tf2_ros::TransformListener`
  *        for use inside an `as2::Node`.
@@ -136,19 +139,21 @@ geometry_msgs::msg::TransformStamped getTransformation(
  */
 class TfHandler
 {
-private:
+protected:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_ = nullptr;
+  std::shared_ptr<as2::tf::FilteredTransformListener> filtered_listener_ = nullptr;
   as2::Node * node_;
   std::chrono::nanoseconds tf_timeout_threshold_ = std::chrono::nanoseconds::zero();
 
 public:
+  using FilterRule = std::function<bool (const geometry_msgs::msg::TransformStamped &)>;
   /**
    * @brief Construct a new TfHandler bound to the given `as2::Node`.
    *
    * @param _node Owning node used for clock, parameters and logging.
    */
-  explicit TfHandler(as2::Node * _node);
+  explicit TfHandler(as2::Node * _node, const std::vector<FilterRule> & _filter_rules = {});
 
   /**
    * @brief Set the TF lookup timeout threshold.
@@ -606,6 +611,23 @@ public:
   std::pair<geometry_msgs::msg::PoseStamped, geometry_msgs::msg::TwistStamped> getState(
     const geometry_msgs::msg::TwistStamped & _twist, const std::string & _twist_target_frame,
     const std::string & _pose_target_frame, const std::string & _pose_source_frame);
+
+  /**
+  * @brief add transform to the tf Buffer
+  * @param _transform the transform to Add
+  * @return bool true if the transform was added
+  * @throw tf2::TransformException if the transform is not available
+  */
+  bool addTransform(const geometry_msgs::msg::TransformStamped & _transform)
+  {
+    try {
+      tf_buffer_->setTransform(_transform, node_->get_name());
+      return true;
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_ERROR(node_->get_logger(), "Could not set transform: %s", ex.what());
+      return false;
+    }
+  }
 };  // class TfHandler
 
 }  // namespace tf

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -60,7 +60,6 @@
 #include "as2_core/custom/tf2_geometry_msgs.hpp"
 #include "as2_core/node.hpp"
 #include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
 #include "as2_core/utils/filtered_transform_listener.hpp"
 
 namespace as2
@@ -125,9 +124,8 @@ geometry_msgs::msg::TransformStamped getTransformation(
   const std::string & _frame_id, const std::string & _child_frame_id, double _translation_x,
   double _translation_y, double _translation_z, double _roll, double _pitch, double _yaw);
 
-
 /**
- * @brief Helper that wraps `tf2_ros::Buffer` and `tf2_ros::TransformListener`
+ * @brief Helper that wraps `tf2_ros::Buffer` and `as2::tf::FilteredTransformListener`
  *        for use inside an `as2::Node`.
  *
  * On construction, the handler declares (if not already declared) and reads the
@@ -142,17 +140,18 @@ class TfHandler
 {
 protected:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_ = nullptr;
-  std::shared_ptr<as2::tf::FilteredTransformListener> filtered_listener_ = nullptr;
+  std::shared_ptr<as2::tf::FilteredTransformListener> tf_listener_;
   as2::Node * node_;
   std::chrono::nanoseconds tf_timeout_threshold_ = std::chrono::nanoseconds::zero();
 
 public:
-  using FilterRule = std::function<bool (const geometry_msgs::msg::TransformStamped &)>;
+  using FilterRule = FilteredTransformListener::FilterRule;
   /**
    * @brief Construct a new TfHandler bound to the given `as2::Node`.
    *
    * @param _node Owning node used for clock, parameters and logging.
+   * @param _filter_rules Rules applied to every incoming transform before it reaches the
+   *        buffer. A transform is dropped as soon as one rule returns false.
    */
   explicit TfHandler(as2::Node * _node, const std::vector<FilterRule> & _filter_rules = {});
 
@@ -612,23 +611,6 @@ public:
   std::pair<geometry_msgs::msg::PoseStamped, geometry_msgs::msg::TwistStamped> getState(
     const geometry_msgs::msg::TwistStamped & _twist, const std::string & _twist_target_frame,
     const std::string & _pose_target_frame, const std::string & _pose_source_frame);
-
-  /**
-  * @brief add transform to the tf Buffer
-  * @param _transform the transform to Add
-  * @return bool true if the transform was added
-  * @throw tf2::TransformException if the transform is not available
-  */
-  bool addTransform(const geometry_msgs::msg::TransformStamped & _transform)
-  {
-    try {
-      tf_buffer_->setTransform(_transform, node_->get_name());
-      return true;
-    } catch (const tf2::TransformException & ex) {
-      RCLCPP_ERROR(node_->get_logger(), "Could not set transform: %s", ex.what());
-      return false;
-    }
-  }
 };  // class TfHandler
 
 }  // namespace tf

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -60,6 +60,7 @@
 #include "as2_core/custom/tf2_geometry_msgs.hpp"
 #include "as2_core/node.hpp"
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 #include "as2_core/utils/filtered_transform_listener.hpp"
 
 namespace as2
@@ -125,8 +126,8 @@ geometry_msgs::msg::TransformStamped getTransformation(
   double _translation_y, double _translation_z, double _roll, double _pitch, double _yaw);
 
 /**
- * @brief Helper that wraps `tf2_ros::Buffer` and `as2::tf::FilteredTransformListener`
- *        for use inside an `as2::Node`.
+ * @brief Helper that wraps `tf2_ros::Buffer` and a TF listener for use inside an
+ *        `as2::Node`.
  *
  * On construction, the handler declares (if not already declared) and reads the
  * ROS parameter `tf_timeout_threshold` (in seconds, default 0.05) on the owning
@@ -140,7 +141,8 @@ class TfHandler
 {
 protected:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<as2::tf::FilteredTransformListener> tf_listener_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_ = nullptr;
+  std::shared_ptr<as2::tf::FilteredTransformListener> filtered_listener_ = nullptr;
   as2::Node * node_;
   std::chrono::nanoseconds tf_timeout_threshold_ = std::chrono::nanoseconds::zero();
 
@@ -151,7 +153,9 @@ public:
    *
    * @param _node Owning node used for clock, parameters and logging.
    * @param _filter_rules Rules applied to every incoming transform before it reaches the
-   *        buffer. A transform is dropped as soon as one rule returns false.
+   *        buffer. A transform is dropped as soon as one rule returns false. When empty,
+   *        the handler uses `tf2_ros::TransformListener` so that it tracks its upstream
+   *        fixes, instead of the copy this package carries.
    */
   explicit TfHandler(as2::Node * _node, const std::vector<FilterRule> & _filter_rules = {});
 

--- a/as2_core/include/as2_core/utils/tf_utils.hpp
+++ b/as2_core/include/as2_core/utils/tf_utils.hpp
@@ -32,6 +32,7 @@
  *  \authors    David Perez Saura
  *              Miguel Fernandez Cortizas
  *              Rafael Perez Segui
+ *              Rodrigo Da Silva Gómez
  ********************************************************************************/
 
 #ifndef AS2_CORE__UTILS__TF_UTILS_HPP_

--- a/as2_core/src/node.cpp
+++ b/as2_core/src/node.cpp
@@ -35,6 +35,11 @@
  *              Rafael Pérez Seguí
  ********************************************************************************/
 
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
 #include "as2_core/node.hpp"
 
 std::string as2::Node::generate_global_name(const std::string & name)
@@ -62,19 +67,58 @@ namespace tf
 std::string generateTfName(const std::string & _namespace, const std::string & _frame_name);
 }  // namespace tf
 
+void Node::warnIfNotStandardFrame(
+  const std::string & param_name, const std::string & value, const std::string & standard)
+{
+  // An empty name is the documented way to ask for the bare namespace, e.g. Gazebo
+  if (value == standard || value.empty()) {
+    return;
+  }
+  RCLCPP_WARN(
+    this->get_logger(),
+    "[%s] is '%s', not the REP-105 name '%s'.", param_name.c_str(), value.c_str(),
+    standard.c_str());
+}
+
 void Node::initializeCanonicalFrames()
 {
   // A leading '/' marks a frame as global: generateTfName() strips it and does
   // not namespace it. earth defaults to it, since every robot shares that frame
   const std::string ns = this->get_namespace();
-  earth_frame_id_ =
-    tf::generateTfName(ns, getParameter<std::string>("earth_frame_id", "/earth"));
-  map_frame_id_ =
-    tf::generateTfName(ns, getParameter<std::string>("map_frame_id", "map"));
-  odom_frame_id_ =
-    tf::generateTfName(ns, getParameter<std::string>("odom_frame_id", "odom"));
-  base_frame_id_ =
-    tf::generateTfName(ns, getParameter<std::string>("base_frame_id", "base_link"));
+
+  const std::string earth = getParameter<std::string>("earth_frame_id", "/earth");
+  const std::string map = getParameter<std::string>("map_frame_id", "map");
+  const std::string odom = getParameter<std::string>("odom_frame_id", "odom");
+  const std::string base = getParameter<std::string>("base_frame_id", "base_link");
+
+  warnIfNotStandardFrame("earth_frame_id", earth, "/earth");
+  warnIfNotStandardFrame("map_frame_id", map, "map");
+  warnIfNotStandardFrame("odom_frame_id", odom, "odom");
+  warnIfNotStandardFrame("base_frame_id", base, "base_link");
+
+  earth_frame_id_ = tf::generateTfName(ns, earth);
+  map_frame_id_ = tf::generateTfName(ns, map);
+  odom_frame_id_ = tf::generateTfName(ns, odom);
+  base_frame_id_ = tf::generateTfName(ns, base);
+
+  // An empty name resolves to the namespace, so two frames left empty collapse into the same
+  // id and yield a self transform. Fail here rather than at the first lookup
+  const std::vector<std::string> frames =
+  {earth_frame_id_, map_frame_id_, odom_frame_id_, base_frame_id_};
+  if (std::set<std::string>(frames.begin(), frames.end()).size() != frames.size()) {
+    throw std::runtime_error(
+            "Canonical TF frames must be distinct, got earth='" + earth_frame_id_ +
+            "' map='" + map_frame_id_ + "' odom='" + odom_frame_id_ +
+            "' base='" + base_frame_id_ + "'");
+  }
+
+  // The namespaced result is what the rest of the stack actually uses, and it is not
+  // recoverable from the parameter values alone
+  RCLCPP_INFO(this->get_logger(), "Frame names:");
+  RCLCPP_INFO(this->get_logger(), "\tEarth frame: %s", earth_frame_id_.c_str());
+  RCLCPP_INFO(this->get_logger(), "\tMap frame: %s", map_frame_id_.c_str());
+  RCLCPP_INFO(this->get_logger(), "\tOdom frame: %s", odom_frame_id_.c_str());
+  RCLCPP_INFO(this->get_logger(), "\tBase frame: %s", base_frame_id_.c_str());
 }
 
 }  // namespace as2

--- a/as2_core/src/utils/filtered_transform_listener.cpp
+++ b/as2_core/src/utils/filtered_transform_listener.cpp
@@ -1,0 +1,128 @@
+// Copyright 2023 Universidad Politécnica de Madrid
+// Copyright (c) 2008, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*!*******************************************************************************************
+ *  \file       filtered_transform_listener.cpp
+ *  \brief      filtered_transform_listener implementation file.
+ *  \authors    Tully Foote
+ *              Miguel Fernandez Cortizas
+ *              Rafael Perez Segui
+ ********************************************************************************/
+
+
+#include "as2_core/utils/filtered_transform_listener.hpp"
+#include <memory>
+#include <string>
+#include <thread>
+
+
+namespace as2
+{
+
+namespace tf
+{
+
+
+FilteredTransformListener::FilteredTransformListener(
+  tf2::BufferCore & buffer, bool spin_thread,
+  bool static_only)
+: buffer_(buffer)
+{
+  rclcpp::NodeOptions options;
+  // create a unique name for the node
+  // but specify its name in .arguments to override any __node passed on the command line.
+  // avoiding sstream because it's behavior can be overridden by external libraries.
+  // See this issue: https://github.com/ros2/geometry2/issues/540
+  char node_name[42];
+  snprintf(
+    node_name, sizeof(node_name), "transform_listener_impl_%zx",
+    reinterpret_cast<size_t>(this)
+  );
+  options.arguments({"--ros-args", "-r", "__node:=" + std::string(node_name)});
+  options.start_parameter_event_publisher(false);
+  options.start_parameter_services(false);
+  optional_default_node_ = rclcpp::Node::make_shared("_", options);
+  init(
+    optional_default_node_->get_node_base_interface(),
+    optional_default_node_->get_node_logging_interface(),
+    optional_default_node_->get_node_parameters_interface(),
+    optional_default_node_->get_node_topics_interface(),
+    spin_thread, tf2_ros::DynamicListenerQoS(), tf2_ros::StaticListenerQoS(),
+    tf2_ros::detail::get_default_transform_listener_sub_options(),
+    tf2_ros::detail::get_default_transform_listener_static_sub_options(),
+    static_only);
+}
+
+FilteredTransformListener::~FilteredTransformListener()
+{
+  if (spin_thread_) {
+    executor_->cancel();
+    dedicated_listener_thread_->join();
+  }
+}
+
+void FilteredTransformListener::subscription_callback(
+  const tf2_msgs::msg::TFMessage::ConstSharedPtr msg,
+  bool is_static)
+{
+  const tf2_msgs::msg::TFMessage & msg_in = *msg;
+  // TODO(tfoote) find a way to get the authority
+  std::string authority = "Authority undetectable";
+  for (size_t i = 0u; i < msg_in.transforms.size(); i++) {
+    // check the filter_rules_
+    // if any of the filter rules return false, skip this Transform
+    bool skip = false;
+    for (auto filter_rule : filter_rules_) {
+      if (!filter_rule(msg_in.transforms[i])) {
+        skip = true;
+        break;
+      }
+    }
+    if (skip) {
+      continue;
+    }
+
+    try {
+      buffer_.setTransform(msg_in.transforms[i], authority, is_static);
+    } catch (const tf2::TransformException & ex) {
+      // /\todo Use error reporting
+      std::string temp = ex.what();
+      RCLCPP_ERROR(
+        node_logging_interface_->get_logger(),
+        "Failure to set received transform from %s to %s with error: %s\n",
+        msg_in.transforms[i].child_frame_id.c_str(),
+        msg_in.transforms[i].header.frame_id.c_str(), temp.c_str());
+    }
+  }
+}
+
+
+}  // namespace tf
+
+}  // namespace as2

--- a/as2_core/src/utils/filtered_transform_listener.cpp
+++ b/as2_core/src/utils/filtered_transform_listener.cpp
@@ -33,6 +33,7 @@
  *  \authors    Tully Foote
  *              Miguel Fernandez Cortizas
  *              Rafael Perez Segui
+ *              Rodrigo Da Silva Gómez
  ********************************************************************************/
 
 

--- a/as2_core/src/utils/filtered_transform_listener.cpp
+++ b/as2_core/src/utils/filtered_transform_listener.cpp
@@ -1,58 +1,45 @@
-// Copyright 2023 Universidad Politécnica de Madrid
-// Copyright (c) 2008, Willow Garage, Inc.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//    * Redistributions of source code must retain the above copyright
-//      notice, this list of conditions and the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
-//      contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-/*!*******************************************************************************************
- *  \file       filtered_transform_listener.cpp
- *  \brief      filtered_transform_listener implementation file.
- *  \authors    Tully Foote
- *              Miguel Fernandez Cortizas
- *              Rafael Perez Segui
- *              Rodrigo Da Silva Gómez
- ********************************************************************************/
+/** \author Tully Foote */
 
-
-#include "as2_core/utils/filtered_transform_listener.hpp"
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
+#include "tf2_ros/transform_listener.hpp"
 
-namespace as2
+namespace tf2_ros
 {
 
-namespace tf
-{
-
-
-FilteredTransformListener::FilteredTransformListener(
-  tf2::BufferCore & buffer, bool spin_thread,
-  bool static_only)
+TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 : buffer_(buffer)
 {
   rclcpp::NodeOptions options;
@@ -74,13 +61,40 @@ FilteredTransformListener::FilteredTransformListener(
     optional_default_node_->get_node_logging_interface(),
     optional_default_node_->get_node_parameters_interface(),
     optional_default_node_->get_node_topics_interface(),
-    spin_thread, tf2_ros::DynamicListenerQoS(), tf2_ros::StaticListenerQoS(),
-    tf2_ros::detail::get_default_transform_listener_sub_options(),
-    tf2_ros::detail::get_default_transform_listener_static_sub_options(),
+    spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
+    detail::get_default_transform_listener_sub_options(),
+    detail::get_default_transform_listener_static_sub_options());
+}
+
+TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread, bool static_only)
+: buffer_(buffer)
+{
+  rclcpp::NodeOptions options;
+  // create a unique name for the node
+  // but specify its name in .arguments to override any __node passed on the command line.
+  // avoiding sstream because it's behavior can be overridden by external libraries.
+  // See this issue: https://github.com/ros2/geometry2/issues/540
+  char node_name[42];
+  snprintf(
+    node_name, sizeof(node_name), "transform_listener_impl_%zx",
+    reinterpret_cast<size_t>(this)
+  );
+  options.arguments({"--ros-args", "-r", "__node:=" + std::string(node_name)});
+  options.start_parameter_event_publisher(false);
+  options.start_parameter_services(false);
+  optional_default_node_ = rclcpp::Node::make_shared("_", options);
+  init(
+    optional_default_node_->get_node_base_interface(),
+    optional_default_node_->get_node_logging_interface(),
+    optional_default_node_->get_node_parameters_interface(),
+    optional_default_node_->get_node_topics_interface(),
+    spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
+    detail::get_default_transform_listener_sub_options(),
+    detail::get_default_transform_listener_static_sub_options(),
     static_only);
 }
 
-FilteredTransformListener::~FilteredTransformListener()
+TransformListener::~TransformListener()
 {
   if (spin_thread_) {
     executor_->cancel();
@@ -88,7 +102,7 @@ FilteredTransformListener::~FilteredTransformListener()
   }
 }
 
-void FilteredTransformListener::subscription_callback(
+void TransformListener::subscription_callback(
   const tf2_msgs::msg::TFMessage::ConstSharedPtr msg,
   bool is_static)
 {
@@ -96,19 +110,6 @@ void FilteredTransformListener::subscription_callback(
   // TODO(tfoote) find a way to get the authority
   std::string authority = "Authority undetectable";
   for (size_t i = 0u; i < msg_in.transforms.size(); i++) {
-    // check the filter_rules_
-    // if any of the filter rules return false, skip this Transform
-    bool skip = false;
-    for (auto filter_rule : filter_rules_) {
-      if (!filter_rule(msg_in.transforms[i])) {
-        skip = true;
-        break;
-      }
-    }
-    if (skip) {
-      continue;
-    }
-
     try {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);
     } catch (const tf2::TransformException & ex) {
@@ -123,7 +124,4 @@ void FilteredTransformListener::subscription_callback(
   }
 }
 
-
-}  // namespace tf
-
-}  // namespace as2
+}  // namespace tf2_ros

--- a/as2_core/src/utils/filtered_transform_listener.cpp
+++ b/as2_core/src/utils/filtered_transform_listener.cpp
@@ -31,9 +31,10 @@
  *  \file       filtered_transform_listener.cpp
  *  \brief      filtered_transform_listener implementation file.
  *
- *  Copy of tf2_ros/src/transform_listener.cpp from ROS 2 (jazzy), Copyright (c) 2008 Willow
- *  Garage, Inc., released under the 3-clause BSD licence reproduced above. Kept line by line
- *  identical to the original except for the filter rules.
+ *  Copy of tf2_ros/src/transform_listener.cpp, from ros2/geometry2 at b950c7ea204d
+ *  (2026-05-29, jazzy). Copyright (c) 2008 Willow Garage, Inc., released under the 3-clause
+ *  BSD licence reproduced above. Kept line by line identical to that revision except for the
+ *  filter rules.
  *
  *  \authors    Tully Foote
  *              Miguel Fernandez Cortizas

--- a/as2_core/src/utils/filtered_transform_listener.cpp
+++ b/as2_core/src/utils/filtered_transform_listener.cpp
@@ -1,46 +1,63 @@
-/*
- * Copyright (c) 2008, Willow Garage, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Willow Garage, Inc. nor the names of its
- *       contributors may be used to endorse or promote products derived from
- *       this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright 2026 Universidad Politécnica de Madrid
+// Copyright (c) 2008, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-/** \author Tully Foote */
+/*!*******************************************************************************************
+ *  \file       filtered_transform_listener.cpp
+ *  \brief      filtered_transform_listener implementation file.
+ *
+ *  Copy of tf2_ros/src/transform_listener.cpp from ROS 2 (jazzy), Copyright (c) 2008 Willow
+ *  Garage, Inc., released under the 3-clause BSD licence reproduced above. Kept line by line
+ *  identical to the original except for the filter rules.
+ *
+ *  \authors    Tully Foote
+ *              Miguel Fernandez Cortizas
+ *              Rafael Perez Segui
+ *              Rodrigo Da Silva Gómez
+ ********************************************************************************/
 
 #include <memory>
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
-#include "tf2_ros/transform_listener.hpp"
+#include "as2_core/utils/filtered_transform_listener.hpp"
 
-namespace tf2_ros
+namespace as2
 {
 
-TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
-: buffer_(buffer)
+namespace tf
+{
+
+FilteredTransformListener::FilteredTransformListener(
+  tf2::BufferCore & buffer, std::vector<FilterRule> filter_rules, bool spin_thread)
+: buffer_(buffer), filter_rules_(std::move(filter_rules))
 {
   rclcpp::NodeOptions options;
   // create a unique name for the node
@@ -61,13 +78,15 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
     optional_default_node_->get_node_logging_interface(),
     optional_default_node_->get_node_parameters_interface(),
     optional_default_node_->get_node_topics_interface(),
-    spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
-    detail::get_default_transform_listener_sub_options(),
-    detail::get_default_transform_listener_static_sub_options());
+    spin_thread, tf2_ros::DynamicListenerQoS(), tf2_ros::StaticListenerQoS(),
+    tf2_ros::detail::get_default_transform_listener_sub_options(),
+    tf2_ros::detail::get_default_transform_listener_static_sub_options());
 }
 
-TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread, bool static_only)
-: buffer_(buffer)
+FilteredTransformListener::FilteredTransformListener(
+  tf2::BufferCore & buffer, std::vector<FilterRule> filter_rules, bool spin_thread,
+  bool static_only)
+: buffer_(buffer), filter_rules_(std::move(filter_rules))
 {
   rclcpp::NodeOptions options;
   // create a unique name for the node
@@ -88,13 +107,13 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread,
     optional_default_node_->get_node_logging_interface(),
     optional_default_node_->get_node_parameters_interface(),
     optional_default_node_->get_node_topics_interface(),
-    spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
-    detail::get_default_transform_listener_sub_options(),
-    detail::get_default_transform_listener_static_sub_options(),
+    spin_thread, tf2_ros::DynamicListenerQoS(), tf2_ros::StaticListenerQoS(),
+    tf2_ros::detail::get_default_transform_listener_sub_options(),
+    tf2_ros::detail::get_default_transform_listener_static_sub_options(),
     static_only);
 }
 
-TransformListener::~TransformListener()
+FilteredTransformListener::~FilteredTransformListener()
 {
   if (spin_thread_) {
     executor_->cancel();
@@ -102,7 +121,7 @@ TransformListener::~TransformListener()
   }
 }
 
-void TransformListener::subscription_callback(
+void FilteredTransformListener::subscription_callback(
   const tf2_msgs::msg::TFMessage::ConstSharedPtr msg,
   bool is_static)
 {
@@ -110,6 +129,18 @@ void TransformListener::subscription_callback(
   // TODO(tfoote) find a way to get the authority
   std::string authority = "Authority undetectable";
   for (size_t i = 0u; i < msg_in.transforms.size(); i++) {
+    // A single rule returning false is enough to keep the transform out of the buffer
+    bool accepted = true;
+    for (const auto & filter_rule : filter_rules_) {
+      if (!filter_rule(msg_in.transforms[i])) {
+        accepted = false;
+        break;
+      }
+    }
+    if (!accepted) {
+      continue;
+    }
+
     try {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);
     } catch (const tf2::TransformException & ex) {
@@ -124,4 +155,6 @@ void TransformListener::subscription_callback(
   }
 }
 
-}  // namespace tf2_ros
+}  // namespace tf
+
+}  // namespace as2

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -30,6 +30,7 @@
  *  \file       tf_utils.cpp
  *  \brief      Tranform utilities library implementation file.
  *  \authors    David Perez Saura
+ *              Rodrigo Da Silva Gómez
  ********************************************************************************/
 
 #include "as2_core/utils/tf_utils.hpp"

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -49,7 +49,15 @@ std::string generateTfName(rclcpp::Node * node, std::string _frame_name)
 std::string generateTfName(const std::string & _namespace, const std::string & _frame_name)
 {
   if (!_frame_name.size()) {
-    throw std::runtime_error("Empty frame name");
+    // An empty frame name means the frame is the namespace itself, e.g. "drone0"
+    std::string base_ns = _namespace;
+    if (base_ns.size() && base_ns[0] == '/') {
+      base_ns = base_ns.substr(1);
+    }
+    if (base_ns.empty()) {
+      throw std::runtime_error("Empty frame name and empty namespace");
+    }
+    return base_ns;
   }
   if (_frame_name[0] == '/') {
     return _frame_name.substr(1);

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -119,13 +119,18 @@ TfHandler::TfHandler(as2::Node * _node, const std::vector<FilterRule> & _filter_
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
     _node->get_node_base_interface(), _node->get_node_timers_interface());
   tf_buffer_->setCreateTimerInterface(timer_interface);
-  tf_listener_ = std::make_shared<as2::tf::FilteredTransformListener>(
-    *tf_buffer_,
-    _filter_rules,
-    _node->get_node_base_interface(),
-    _node->get_node_logging_interface(),
-    _node->get_node_parameters_interface(),
-    _node->get_node_topics_interface());
+  // Without rules there is nothing to filter
+  if (_filter_rules.empty()) {
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, _node);
+  } else {
+    filtered_listener_ = std::make_shared<as2::tf::FilteredTransformListener>(
+      *tf_buffer_,
+      _filter_rules,
+      _node->get_node_base_interface(),
+      _node->get_node_logging_interface(),
+      _node->get_node_parameters_interface(),
+      _node->get_node_topics_interface());
+  }
 
   // Read tf_timeout_threshold from the parameter server
   setTfTimeoutThreshold(_node->getParameter<double>("tf_timeout_threshold", 0.05));

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -33,6 +33,7 @@
  ********************************************************************************/
 
 #include "as2_core/utils/tf_utils.hpp"
+#include <vector>
 
 namespace as2
 {
@@ -110,14 +111,21 @@ geometry_msgs::msg::TransformStamped getTransformation(
   return transformation;
 }
 
-TfHandler::TfHandler(as2::Node * _node)
+TfHandler::TfHandler(as2::Node * _node, const std::vector<FilterRule> & _filter_rules)
 : node_(_node)
 {
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(_node->get_clock());
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
     _node->get_node_base_interface(), _node->get_node_timers_interface());
   tf_buffer_->setCreateTimerInterface(timer_interface);
-  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  if (_filter_rules.size() > 0) {
+    filtered_listener_ = std::make_shared<as2::tf::FilteredTransformListener>(*tf_buffer_);
+    for (auto filter_rule : _filter_rules) {
+      filtered_listener_->add_filter_rule(filter_rule);
+    }
+  } else {
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  }
 
   // Read tf_timeout_threshold from the parameter server
   setTfTimeoutThreshold(_node->getParameter<double>("tf_timeout_threshold", 0.05));

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -119,14 +119,13 @@ TfHandler::TfHandler(as2::Node * _node, const std::vector<FilterRule> & _filter_
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
     _node->get_node_base_interface(), _node->get_node_timers_interface());
   tf_buffer_->setCreateTimerInterface(timer_interface);
-  if (_filter_rules.size() > 0) {
-    filtered_listener_ = std::make_shared<as2::tf::FilteredTransformListener>(*tf_buffer_);
-    for (auto filter_rule : _filter_rules) {
-      filtered_listener_->add_filter_rule(filter_rule);
-    }
-  } else {
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-  }
+  tf_listener_ = std::make_shared<as2::tf::FilteredTransformListener>(
+    *tf_buffer_,
+    _filter_rules,
+    _node->get_node_base_interface(),
+    _node->get_node_logging_interface(),
+    _node->get_node_parameters_interface(),
+    _node->get_node_topics_interface());
 
   // Read tf_timeout_threshold from the parameter server
   setTfTimeoutThreshold(_node->getParameter<double>("tf_timeout_threshold", 0.05));

--- a/as2_core/tests/filtered_transform_listener_gtest.cpp
+++ b/as2_core/tests/filtered_transform_listener_gtest.cpp
@@ -1,0 +1,142 @@
+// Copyright 2026 Universidad Politécnica de Madrid
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universidad Politécnica de Madrid nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*!*******************************************************************************************
+ *  \file       filtered_transform_listener_gtest.cpp
+ *  \brief      Test file for the filtered transform listener
+ *  \authors    Rafael Pérez Seguí
+ ********************************************************************************/
+
+#include "as2_core/utils/filtered_transform_listener.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace as2
+{
+namespace tf
+{
+
+// subscription_callback() is public, so the filter can be driven straight from the test
+// thread with a hand made message: no publisher, no spin, no dedicated listener thread.
+class FilteredTransformListenerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {node_ = rclcpp::Node::make_shared("filtered_transform_listener_test");}
+
+  std::shared_ptr<FilteredTransformListener> makeListener(
+    tf2::BufferCore & buffer, std::vector<FilteredTransformListener::FilterRule> rules)
+  {
+    return std::make_shared<FilteredTransformListener>(
+      buffer,
+      rules,
+      node_->get_node_base_interface(),
+      node_->get_node_logging_interface(),
+      node_->get_node_parameters_interface(),
+      node_->get_node_topics_interface(),
+      false);
+  }
+
+  static tf2_msgs::msg::TFMessage::ConstSharedPtr makeMessage(
+    const std::string & frame_id, const std::string & child_frame_id)
+  {
+    auto msg = std::make_shared<tf2_msgs::msg::TFMessage>();
+    geometry_msgs::msg::TransformStamped transform;
+    transform.header.frame_id = frame_id;
+    transform.child_frame_id = child_frame_id;
+    transform.transform.rotation.w = 1.0;
+    msg->transforms.push_back(transform);
+    return msg;
+  }
+
+  rclcpp::Node::SharedPtr node_;
+};
+
+TEST_F(FilteredTransformListenerTest, RuleDropsMatchingTransform) {
+  tf2::BufferCore buffer;
+  // Drop anything published under "odom", accept the rest
+  auto listener = makeListener(
+    buffer,
+    {[](const geometry_msgs::msg::TransformStamped & transform) {
+        return transform.header.frame_id != "odom";
+      }});
+
+  listener->subscription_callback(makeMessage("odom", "base_link"), true);
+  EXPECT_FALSE(buffer.canTransform("odom", "base_link", tf2::TimePointZero));
+
+  listener->subscription_callback(makeMessage("map", "odom"), true);
+  EXPECT_TRUE(buffer.canTransform("map", "odom", tf2::TimePointZero));
+}
+
+TEST_F(FilteredTransformListenerTest, NoRulesAcceptsEverything) {
+  tf2::BufferCore buffer;
+  auto listener = makeListener(buffer, {});
+
+  listener->subscription_callback(makeMessage("odom", "base_link"), true);
+  EXPECT_TRUE(buffer.canTransform("odom", "base_link", tf2::TimePointZero));
+}
+
+TEST_F(FilteredTransformListenerTest, TransformIsDroppedWhenAnyRuleRejectsIt) {
+  tf2::BufferCore buffer;
+  auto listener = makeListener(
+    buffer,
+    {[](const geometry_msgs::msg::TransformStamped &) {return true;},
+      [](const geometry_msgs::msg::TransformStamped & transform) {
+        return transform.child_frame_id != "base_link";
+      }});
+
+  listener->subscription_callback(makeMessage("odom", "base_link"), true);
+  EXPECT_FALSE(buffer.canTransform("odom", "base_link", tf2::TimePointZero));
+}
+
+// Several handlers on one node is the state estimator's case: one TfHandler per plugin
+TEST_F(FilteredTransformListenerTest, SeveralListenersShareTheNode) {
+  tf2::BufferCore first_buffer;
+  tf2::BufferCore second_buffer;
+  auto first = makeListener(first_buffer, {});
+  auto second = makeListener(second_buffer, {});
+
+  first->subscription_callback(makeMessage("odom", "base_link"), true);
+  EXPECT_TRUE(first_buffer.canTransform("odom", "base_link", tf2::TimePointZero));
+  EXPECT_FALSE(second_buffer.canTransform("odom", "base_link", tf2::TimePointZero));
+}
+
+}  // namespace tf
+}  // namespace as2
+
+int main(int argc, char * argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  auto result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/as2_core/tests/tf2_namespace_test.cpp
+++ b/as2_core/tests/tf2_namespace_test.cpp
@@ -36,7 +36,10 @@ TEST(TF2NamespacesTest, empty_empty) {
   EXPECT_THROW(as2::tf::generateTfName("", ""), std::runtime_error);
 }
 TEST(TF2NamespacesTest, ns_empty) {
-  EXPECT_THROW(as2::tf::generateTfName("ns", ""), std::runtime_error);
+  EXPECT_EQ(as2::tf::generateTfName("ns", ""), "ns");
+}
+TEST(TF2NamespacesTest, global_ns_empty) {
+  EXPECT_EQ(as2::tf::generateTfName("/ns", ""), "ns");
 }
 
 TEST(TF2NamespacesTest, ns_foo) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

# `as2_core`: Empty TF frame names resolve to the namespace, and a filterable TF listener

> **Prerequisite PR.** These two `as2_core` changes were split out of the
> `as2_state_estimator` rework so that the shared-library change can be reviewed on its own,
> independently of the estimator redesign that consumes it. The state estimator PR is
> stacked on this branch and should merge after it.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | n/a: `as2_core` library change with no platform-specific code paths. Verified by the `as2_core` test suite (284 tests, 0 failures) |

---

## Summary

Three self-contained changes to `as2_core`. None of them changes the source compatibility of
any existing caller: the frame name change only affects an input that previously threw, the
listener change is behind a defaulted constructor argument, and the frame validation only
rejects configurations that were already broken.

1. **`generateTfName()` accepts an empty frame name** and resolves it to the node namespace,
   so a frame can *be* the namespace (`drone0`) rather than a child of it
   (`drone0/base_link`).
2. **`FilteredTransformListener`**, a TF listener that drops incoming transforms matching
   caller-supplied rules before they reach the buffer, so a node that both publishes and
   consumes TF can keep its own output out of its input. It is a vendored copy of
   `tf2_ros::TransformListener`, pinned to `ros2/geometry2` at `b950c7ea204d` (2026-05-29,
   jazzy), plus the filter hook.
3. **`as2::Node` logs and validates the canonical frames.** It logs the four resolved frame
   ids, warns when one is configured away from its REP-105 name, and refuses a configuration
   where two of them collapse into the same id.

```mermaid
graph LR
  subgraph plain["tf2_ros::TransformListener"]
    A1["/tf, /tf_static"] --> B1[subscription_callback] --> C1[(Buffer)]
  end
  subgraph filtered["as2::tf::FilteredTransformListener"]
    A2["/tf, /tf_static"] --> B2[subscription_callback] --> F{"every filter rule<br/>returns true?"}
    F -->|yes| C2[(Buffer)]
    F -->|no| D2[dropped]
  end
```

**7 commits · 9 files · +799/−21 · package: `as2_core`**

---

## Description of contribution in a few bullet points

* **Empty frame name → namespace.** `generateTfName(ns, "")` previously threw
  `std::runtime_error("Empty frame name")`. It now returns the namespace with any leading
  `/` stripped, and throws only when the namespace is *also* empty, since that leaves no
  name to build from. The motivating case: Gazebo roots a model's TF tree at the bare model
  name (`drone0`), not at `drone0/base_link`. Expressing that used to need a dedicated
  boolean flag; `base_frame: ""` now says it directly.

* **This reaches `as2::Node`.** `node.cpp` resolves `earth_frame_id`, `map_frame_id`,
  `odom_frame_id` and `base_frame_id` through `generateTfName()`, so setting any of those to
  `""` now yields the namespace instead of aborting node construction. That is the mechanism
  the state estimator PR uses to replace its `use_gazebo_tf` flag.

* **`as2::Node` hardens the canonical frames.** On construction it logs the four namespaced
  frame ids, since the namespaced result is what the stack actually uses and it is not
  recoverable from the parameter values alone; warns when a frame is configured away from
  its REP-105 name; and throws when two of the four resolve to the same id. An empty name
  resolving to the namespace makes that collision easy to write (two frames left empty), and
  it would otherwise surface as a confusing self-transform at the first lookup.

* **`FilteredTransformListener`** (new, 384 + 161 lines). A vendored copy of
  `tf2_ros::TransformListener`, taken byte for byte from `ros2/geometry2` at `b950c7ea204d`
  in its own commit (`c1a579ff`), so the provenance can be checked with a single command:

  ```bash
  curl -sL https://raw.githubusercontent.com/ros2/geometry2/b950c7ea204d/tf2_ros/include/tf2_ros/transform_listener.hpp \
    | cmp - <(git show c1a579ff:as2_core/include/as2_core/utils/filtered_transform_listener.hpp)
  ```

  The commits on top are what aerostack2 adds, so porting an upstream fix stays mechanical.
  The one functional addition sits in `subscription_callback`: each transform in an incoming
  `TFMessage` is tested against the filter rules and skipped before `buffer_.setTransform()`
  if any rule returns `false`. Rules are
  `std::function<bool(const geometry_msgs::msg::TransformStamped &)>`, and they are **fixed
  at construction**: the listener starts its dedicated thread inside the constructor, so
  rules mutable after that would race with the callback thread reading them. It is a copy
  rather than a subclass because Humble's `subscription_callback()` is private and
  non-virtual; from Jazzy on it is public and virtual, and this file can become a subclass.
  Two blocks of the original are not copied: the `detail` helpers, used from the original
  header instead, and the `StaticTransformListener` convenience class, which has no caller
  here.

* **`static_only` construction flag.** When set, the listener subscribes to `/tf_static`
  only and never creates the `/tf` subscription. Useful for consumers that only care about
  the fixed part of the tree.

* **Subscriptions live on the caller's node.** Both listener paths attach `/tf` and
  `/tf_static` to the owning node, in their own callback group spun by the listener's
  dedicated thread, instead of creating a hidden node per handler: a blocked executor on the
  drone node does not delay TF reception, and several handlers on one node coexist without
  colliding, which is the state estimator's case, one `TfHandler` per plugin. Upstream's
  `qos_overriding_options` are kept, so `qos_overrides./tf.subscription.depth` and friends
  are now reachable from the node's YAML, since they are declared on a node with a stable
  name instead of a hidden one named after a memory address.

* **`TfHandler` opts in via a defaulted argument.**
  `TfHandler(as2::Node *, const std::vector<FilterRule> & = {})`. With an empty vector it
  builds a plain `tf2_ros::TransformListener`, so every node without rules keeps tracking
  upstream's fixes instead of aging on the copy; with rules it builds a
  `FilteredTransformListener`. Every existing call site compiles unchanged.

* **`TfHandler` members `private` → `protected`**, so the handler can be subclassed. A
  widening of access, not a change to any existing behaviour.

---

## :warning: Breaking changes

**None at the source level.** `TfHandler`'s new constructor parameter is defaulted, so all
existing call sites are source-compatible, and no existing function signature changes.

Three behavioural notes worth a reviewer's attention:

* **An empty frame name is no longer an error.** A config that sets a frame id to `""`,
  whether deliberately or by accident (an unset variable, an empty YAML value), used to
  fail loudly with `std::runtime_error` at construction. It now silently resolves to the
  node namespace. This is the entire point of the change, but it does convert one class of
  configuration mistake from a hard failure into a working node with an unexpected frame
  name. `generateTfName("", "")` still throws, so the fully-empty case is unchanged. The
  distinctness check below catches the worst variant of this mistake.

* **Two canonical frames resolving to the same id is now a construction error.** A config
  that collapses, say, `map` and `odom` onto one id used to construct a node and misbehave
  at the first lookup; it now throws in the `as2::Node` constructor with a message naming
  all four resolved ids. Deliberate hardening, but a downstream config relying on the old
  laxness will stop starting.

* **On Humble, `tf2` 0.25.16 or newer is required.** The vendored file uses the `.hpp`
  header spellings and the `tf2_ros::detail` subscription-option helpers, which entered the
  Humble release line at `0.25.16`. Any Humble install updated since then is fine, as is
  Jazzy and newer natively; a Humble install frozen on an older patch fails to compile with
  a missing-header error pointing at the vendored file.

---

## Testing

`as2_core`: **284 tests, 0 failures, 0 errors, 46 skipped.** Run on this branch with:

```bash
ROS_DOMAIN_ID=77 colcon test --packages-select as2_core
```

| Group | Tests | Notes |
| --- | --- | --- |
| `tf2_namespace_test` | 7 | directly covers this PR's frame-name change |
| `filtered_transform_listener_gtest` | 4 | a rule drops the transform it matches, an empty rule set accepts everything, one rejecting rule out of several is enough to drop, two listeners on one node keep separate buffers |
| `tf_utils_gtest` | 4 | `TfHandler` and the transform helpers |
| `aerial_platform_gtest` | 16 | |
| `control_mode_utils_gtest` | 13 | |
| `sensor_test` | 9 | |
| `frame_test` | 6 | |
| `platform_state_machine_test` | 4 | |
| Lint / style | 205 | copyright, cpplint, uncrustify, flake8, pep257, lint_cmake, xmllint, cppcheck |
| **Total** | **284** | 0 failures |

The 46 skipped are the whole `cppcheck` suite, which skips when `cppcheck` is not installed
on the machine. It is unrelated to this branch. `colcon test-result` reports 284 rather
than the 268 individual tests because it also counts the CTest roll-up entry for each of
the 16 test suites.

`tf2_namespace_test` was updated to match the new contract:

| Case | `main` | This PR |
| --- | --- | --- |
| `generateTfName("", "")` | throws | throws (unchanged) |
| `generateTfName("ns", "")` | throws | `"ns"` |
| `generateTfName("/ns", "")` | throws | `"ns"` (new test `global_ns_empty`) |

Because the no-hidden-node change affects every `TfHandler` in the stack, the four other
packages that construct one were built and tested against this branch: `as2_motion_controller`
(125), `as2_behaviors_motion` (164), `as2_behaviors_payload` (84) and
`as2_behaviors_trajectory_generation` (180), all 0 failures. Merged with the stacked
`new_state_estimator` branch: `as2_core` + `as2_state_estimator`, 437 tests, 0 failures.

Every commit in this PR builds on its own, with one deliberate exception: `c1a579ff` is the
verbatim upstream copy before adaptation and does not build alone, which its commit message
states.

### Gaps, stated plainly

* **Nothing in this branch passes filter rules to a `TfHandler`.** The filter itself is
  unit-tested here, but the rules parameter has no caller in this branch; its first consumer
  is the state estimator PR stacked on top. That is the cost of splitting the PRs.

---

## Description of documentation updates required from the changes

* **`generateTfName()`'s doxygen contract** is updated in place in `tf_utils.hpp`: the rules
  list, the `@throw` clause on both overloads, and the note that an empty name means the
  frame is the namespace itself.
* **`FilteredTransformListener`** carries a class-level comment pinning the upstream
  revision it was copied from, and explaining why it is a copy rather than a subclass and
  when it can stop being one.
* On the documentation site, the `as2_core` TF utilities page should mention that an empty
  frame name is a valid, meaningful input, since it is the supported way to express a
  Gazebo-style tree rooted at the model name.