### PR TITLE
fix(pixi): pin macOS compilers to clang 22

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -13,6 +13,12 @@ version = "1.1.3"
 [system-requirements]
 libc = { family = "glibc", version = "2.34" }
 
+# pin: libcxx 23 removed std::wstring_convert, still used by rosidl_runtime_cpp
+# headers. Drop when ROS or conda-forge ships a fix.
+[workspace.target.osx-arm64.build-variants]
+c_compiler_version = ["22"]
+cxx_compiler_version = ["22"]
+
 [tasks]
 clean = "rm -rf build/ install/ log/"
 test-pkg = "sh -c 'colcon test --packages-up-to \"$0\" --event-handlers console_direct+'"


### PR DESCRIPTION
I've detected that in pixi builds `libcxx` was not pinned and could roll from one version to the other without notice. This caused the main jobs to fail unexpectedly.

What happened was that libcxx jumped from 22 to 23 and some API was removed. Then, `rosidl_runtime_cpp` broke as it was using removed functions.

```
rosidl_runtime_cpp/traits.hpp:131:8:
error: no member named 'wstring_convert' in namespace 'std'
```