### PR TITLE
[as2_core] Fix getting lastest transform with fixed frames

### DIFF
--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -279,9 +279,7 @@ geometry_msgs::msg::PoseStamped TfHandler::getPoseStamped(
         node_->get_clock()->now()), source_frame, time, node_->getEarthFrameId(),
       timeout);
   } else {
-    transform = tf_buffer_->lookupTransform(
-      target_frame, tf2::TimePointZero, source_frame, tf2::TimePointZero, node_->getEarthFrameId(),
-      timeout);
+    transform = tf_buffer_->lookupTransform(target_frame, source_frame, tf2::TimePointZero);
   }
 
   geometry_msgs::msg::PoseStamped pose;
@@ -329,9 +327,7 @@ geometry_msgs::msg::QuaternionStamped TfHandler::getQuaternionStamped(
         node_->get_clock()->now()), source_frame, time, node_->getEarthFrameId(),
       timeout);
   } else {
-    transform = tf_buffer_->lookupTransform(
-      target_frame, tf2::TimePointZero, source_frame, tf2::TimePointZero, node_->getEarthFrameId(),
-      timeout);
+    transform = tf_buffer_->lookupTransform(target_frame, source_frame, tf2::TimePointZero);
   }
 
   geometry_msgs::msg::QuaternionStamped quaternion;

--- a/as2_core/src/utils/tf_utils.cpp
+++ b/as2_core/src/utils/tf_utils.cpp
@@ -274,10 +274,7 @@ geometry_msgs::msg::PoseStamped TfHandler::getPoseStamped(
   // if-else needed for galactic
   geometry_msgs::msg::TransformStamped transform;
   if (timeout != std::chrono::nanoseconds::zero()) {
-    transform = tf_buffer_->lookupTransform(
-      target_frame, tf2_ros::fromMsg(
-        node_->get_clock()->now()), source_frame, time, node_->getEarthFrameId(),
-      timeout);
+    transform = tf_buffer_->lookupTransform(target_frame, source_frame, time, timeout);
   } else {
     transform = tf_buffer_->lookupTransform(target_frame, source_frame, tf2::TimePointZero);
   }
@@ -322,10 +319,7 @@ geometry_msgs::msg::QuaternionStamped TfHandler::getQuaternionStamped(
 {
   geometry_msgs::msg::TransformStamped transform;
   if (timeout != std::chrono::nanoseconds::zero()) {
-    transform = tf_buffer_->lookupTransform(
-      target_frame, tf2_ros::fromMsg(
-        node_->get_clock()->now()), source_frame, time, node_->getEarthFrameId(),
-      timeout);
+    transform = tf_buffer_->lookupTransform(target_frame, source_frame, time, timeout);
   } else {
     transform = tf_buffer_->lookupTransform(target_frame, source_frame, tf2::TimePointZero);
   }

--- a/as2_core/tests/tf_utils_gtest.cpp
+++ b/as2_core/tests/tf_utils_gtest.cpp
@@ -321,6 +321,10 @@ TEST(TFHandlerTest, getPoseStampedKeepsTheTransformStamp) {
   }
 
   EXPECT_EQ(rclcpp::Time(pose.header.stamp), rclcpp::Time(map_to_base.header.stamp));
+  const geometry_msgs::msg::PoseStamped at_instant = tf_handler->getPoseStamped(
+    "earth", "stamp_base", tf2_ros::fromMsg(map_to_base.header.stamp),
+    std::chrono::milliseconds(50));
+  EXPECT_EQ(rclcpp::Time(at_instant.header.stamp), rclcpp::Time(map_to_base.header.stamp));
 }
 
 TEST(TFHandlerTest, generateTfName) {

--- a/as2_core/tests/tf_utils_gtest.cpp
+++ b/as2_core/tests/tf_utils_gtest.cpp
@@ -37,6 +37,7 @@
 #include "as2_core/utils/tf_utils.hpp"
 
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 #include <chrono>
 #include <cmath>
@@ -281,6 +282,45 @@ TEST(TFHandlerTest, convertTrajectorySetpointsPureYawRotation) {
   EXPECT_NEAR(out.setpoints[0].acceleration.z, 0.0, kTol);
   // Yaw is shifted by +pi/2.
   EXPECT_NEAR(out.setpoints[0].yaw_angle, static_cast<float>(M_PI_2), 1e-5);
+}
+
+TEST(TFHandlerTest, getPoseStampedKeepsTheTransformStamp) {
+  auto node = std::make_shared<as2::Node>("test_tf_stamp_node");
+  auto tf_handler = std::make_shared<TfHandler>(node.get());
+
+  // earth is the root of the tree and its link to the map frame is static, so
+  // neither of the two carries a time of its own. The stamp of the answer can
+  // only come from the moving link below them.
+  geometry_msgs::msg::TransformStamped earth_to_map;
+  earth_to_map.header.frame_id = "earth";
+  earth_to_map.child_frame_id = "stamp_map";
+  earth_to_map.transform.rotation.w = 1.0;
+  publicStaticTransformBroadcaster(node.get(), earth_to_map);
+
+  tf2_ros::TransformBroadcaster broadcaster(node.get());
+  geometry_msgs::msg::TransformStamped map_to_base;
+  map_to_base.header.frame_id = "stamp_map";
+  map_to_base.child_frame_id = "stamp_base";
+  map_to_base.header.stamp = node->now();
+  map_to_base.transform.rotation.w = 1.0;
+
+  // The listener spins on a thread of its own, so the transform is resent until
+  // it lands rather than after a fixed wait.
+  geometry_msgs::msg::PoseStamped pose;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    broadcaster.sendTransform(map_to_base);
+    rclcpp::spin_some(node);
+    try {
+      pose = tf_handler->getPoseStamped(
+        "earth", "stamp_base", tf2::TimePointZero, std::chrono::nanoseconds::zero());
+      break;
+    } catch (const tf2::TransformException &) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+  }
+
+  EXPECT_EQ(rclcpp::Time(pose.header.stamp), rclcpp::Time(map_to_base.header.stamp));
 }
 
 TEST(TFHandlerTest, generateTfName) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | - |

---

## Description of contribution in a few bullet points

* TfHandler::getPoseStamped() and getQuaternionStamped() asked tf2 for the transform through a fixed frame, always the node's earth frame, with the same instant on both sides. That variant of lookupTransform exists to bridge two different instants; with a single one it adds nothing.