### PR TITLE
fix: upgrade pixi-build-ros / pin ros2 distro mutex (temporarily)

### DIFF
--- a/.github/workflows/pixi-build.yaml
+++ b/.github/workflows/pixi-build.yaml
@@ -32,9 +32,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.8
+        uses: prefix-dev/setup-pixi@v0.10.2
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.79.0
           run-install: false
 
       - name: Build workspace

--- a/aerostack2/pixi.toml
+++ b/aerostack2/pixi.toml
@@ -3,7 +3,7 @@ name = "aerostack2"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_aerial_platforms/as2_platform_gazebo/pixi.toml
+++ b/as2_aerial_platforms/as2_platform_gazebo/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_platform_gazebo"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_aerial_platforms/as2_platform_multirotor_simulator/pixi.toml
+++ b/as2_aerial_platforms/as2_platform_multirotor_simulator/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_platform_multirotor_simulator"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behavior_tree/pixi.toml
+++ b/as2_behavior_tree/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behavior_tree"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behavior/pixi.toml
+++ b/as2_behaviors/as2_behavior/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behavior"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_motion/pixi.toml
+++ b/as2_behaviors/as2_behaviors_motion/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_motion"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_object_perception/pixi.toml
+++ b/as2_behaviors/as2_behaviors_object_perception/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_object_perception"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_param_estimation/pixi.toml
+++ b/as2_behaviors/as2_behaviors_param_estimation/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_param_estimation"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_path_planning/pixi.toml
+++ b/as2_behaviors/as2_behaviors_path_planning/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_path_planning"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_payload/pixi.toml
+++ b/as2_behaviors/as2_behaviors_payload/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_payload"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_platform/pixi.toml
+++ b/as2_behaviors/as2_behaviors_platform/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_platform"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_swarm_flocking/pixi.toml
+++ b/as2_behaviors/as2_behaviors_swarm_flocking/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_swarm_flocking"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_behaviors/as2_behaviors_trajectory_generation/pixi.toml
+++ b/as2_behaviors/as2_behaviors_trajectory_generation/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_behaviors_trajectory_generation"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_cli/pixi.toml
+++ b/as2_cli/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_cli"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{ "python3-click" = { conda = ["click"] } }]

--- a/as2_core/pixi.toml
+++ b/as2_core/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_core"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{ as2_msgs = { conda = [] } }]

--- a/as2_hardware_drivers/as2_realsense_interface/pixi.toml
+++ b/as2_hardware_drivers/as2_realsense_interface/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_realsense_interface"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_hardware_drivers/as2_usb_camera_interface/pixi.toml
+++ b/as2_hardware_drivers/as2_usb_camera_interface/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_usb_camera_interface"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_map_server/pixi.toml
+++ b/as2_map_server/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_map_server"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_motion_controller/pixi.toml
+++ b/as2_motion_controller/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_motion_controller"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_motion_reference_handlers/pixi.toml
+++ b/as2_motion_reference_handlers/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_motion_reference_handlers"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_msgs/pixi.toml
+++ b/as2_msgs/pixi.toml
@@ -3,4 +3,4 @@ name = "as2_msgs"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }

--- a/as2_python_api/pixi.toml
+++ b/as2_python_api/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_python_api"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_simulation_assets/as2_gazebo_assets/pixi.toml
+++ b/as2_simulation_assets/as2_gazebo_assets/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_gazebo_assets"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_state_estimator/pixi.toml
+++ b/as2_state_estimator/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_state_estimator"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_user_interfaces/as2_alphanumeric_viewer/pixi.toml
+++ b/as2_user_interfaces/as2_alphanumeric_viewer/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_alphanumeric_viewer"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_user_interfaces/as2_keyboard_teleoperation/pixi.toml
+++ b/as2_user_interfaces/as2_keyboard_teleoperation/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_keyboard_teleoperation"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_user_interfaces/as2_visualization/as2_rviz_plugins/pixi.toml
+++ b/as2_user_interfaces/as2_visualization/as2_rviz_plugins/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_rviz_plugins"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_user_interfaces/as2_visualization/as2_visualization/pixi.toml
+++ b/as2_user_interfaces/as2_visualization/as2_visualization/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_visualization"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_utilities/as2_external_object_to_tf/pixi.toml
+++ b/as2_utilities/as2_external_object_to_tf/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_external_object_to_tf"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/as2_utilities/as2_geozones/pixi.toml
+++ b/as2_utilities/as2_geozones/pixi.toml
@@ -3,7 +3,7 @@ name = "as2_geozones"
 version = "0.0.0"
 
 [package.build]
-backend = { name = "pixi-build-ros", version = "==0.4.1" }
+backend = { name = "pixi-build-ros", version = "0.7.*" }
 
 [package.build.config]
 extra-package-mappings = [{

--- a/pixi.toml
+++ b/pixi.toml
@@ -39,7 +39,6 @@ aerostack2 = { path = "./aerostack2" }
 channels = ["robostack-jazzy"]
 
 [feature.jazzy.dependencies]
-ros2-distro-mutex = "0.15.*"
 ros-jazzy-ros2cli = ">=0.32.8,<0.33"
 ros-jazzy-ros2pkg = ">=0.32.8,<0.33"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -39,6 +39,7 @@ aerostack2 = { path = "./aerostack2" }
 channels = ["robostack-jazzy"]
 
 [feature.jazzy.dependencies]
+ros2-distro-mutex = "0.15.*"
 ros-jazzy-ros2cli = ">=0.32.8,<0.33"
 ros-jazzy-ros2pkg = ">=0.32.8,<0.33"
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble, Jazzy |
| Aerial platform tested on | - |

## Description of contribution in a few bullet points

* Bump the `pixi-build-ros` backend from `==0.4.1` to `0.7.*` in every package `pixi.toml`.
* Update CI to `setup-pixi@v0.10.2` and pixi `v0.79.0` so the workflow can use the new backend.

## Description of documentation updates required from your changes

* None.

## Future work that may be required in bullet points

* Revisit the `ros2-distro-mutex` pin once the upstream recipes settle.
