### PR TITLE
ci: cancel in-flight PR runs when a new push arrives

### DIFF
--- a/.github/workflows/build-humble.yaml
+++ b/.github/workflows/build-humble.yaml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
 
+# Cancel in-flight runs when a PR receives a new push; never cancel main builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-jazzy.yaml
+++ b/.github/workflows/build-jazzy.yaml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
 
+# Cancel in-flight runs when a PR receives a new push; never cancel main builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -7,6 +7,11 @@ on:
       - main
   workflow_dispatch:
 
+# Cancel in-flight runs when a PR receives a new push; never cancel main builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pixi-build.yaml
+++ b/.github/workflows/pixi-build.yaml
@@ -10,6 +10,11 @@ on:
       - main
   workflow_dispatch:
 
+# Cancel in-flight runs when a PR receives a new push; never cancel main builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: build-${{ matrix.env }}-${{ matrix.platform }}


### PR DESCRIPTION
Adds a concurrency group keyed by PR number to the four workflows that run on pull requests. Pushes to main are keyed by ref and never cancelled.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | (add issues here #1) |
| ROS2 version tested on | (Humble, Other) |
| Aerial platform tested on | (Gazebo, Crazyflie, Tello, PX4, DJI, Multirotor Simulator, Other) |

## Description of contribution in a few bullet points

<!--
* Added this neat new feature
* Also fixed a typo in a parameter name in as2_motion_controller_manager
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* Added some capabilities, need to document them
-->

## Future work that may be required in bullet points

<!--
* There might be some optimizations to be made in ...
* A lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
-->
