### PR TITLE
[as2_motion_controller] Yaw reference, PID library name and debug topics

### DIFF
--- a/as2_core/src/utils/control_mode_utils.cpp
+++ b/as2_core/src/utils/control_mode_utils.cpp
@@ -100,8 +100,7 @@ CommandFrameUsage getCommandFrameUsage(const as2_msgs::msg::ControlMode & mode)
       // TrajectorySetpoints carries both the pose and the twist of the setpoints
       return {true, true};
     case as2_msgs::msg::ControlMode::ATTITUDE:
-      // The yaw is part of the commanded orientation
-      return {true, false};
+      return {true, !yaw_in_pose};
     case as2_msgs::msg::ControlMode::SPEED:
       // The linear velocity is in the twist, and the yaw in whichever carries it
       return {yaw_in_pose, true};

--- a/as2_motion_controller/CMakeLists.txt
+++ b/as2_motion_controller/CMakeLists.txt
@@ -30,6 +30,29 @@ foreach(DEPENDENCY ${PROJECT_DEPENDENCIES})
   find_package(${DEPENDENCY} REQUIRED)
 endforeach()
 
+# PID Controller library
+set(AS2_MC_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
+file(MAKE_DIRECTORY ${AS2_MC_THIRDPARTIES_DIR})
+file(WRITE ${AS2_MC_THIRDPARTIES_DIR}/AMENT_IGNORE "")
+set(LOCAL_PID_SRC ${AS2_MC_THIRDPARTIES_DIR}/pid_controller)
+if(EXISTS ${LOCAL_PID_SRC}/CMakeLists.txt)
+  message(STATUS "pid_controller: using local clone at ${LOCAL_PID_SRC}")
+  add_subdirectory(${LOCAL_PID_SRC} ${CMAKE_BINARY_DIR}/pid_controller_build)
+else()
+  message(STATUS "pid_controller: cloning into ${LOCAL_PID_SRC}")
+  include(FetchContent)
+  fetchcontent_declare(
+    pid_controller
+    GIT_REPOSITORY https://github.com/RPS98/pid_controller.git
+    GIT_TAG v1.0
+    SOURCE_DIR ${LOCAL_PID_SRC}
+  )
+  fetchcontent_makeavailable(pid_controller)
+endif()
+set(PID_CONTROLLER_INCLUDE_DIR ${AS2_MC_THIRDPARTIES_DIR}/pid_controller/include)
+# Rename library to avoid name collision with other packages that may use the same library name
+set_target_properties(pid_controller PROPERTIES OUTPUT_NAME as2_pid_controller)
+
 include_directories(
   include
 )

--- a/as2_motion_controller/config/motion_controller_default.yaml
+++ b/as2_motion_controller/config/motion_controller_default.yaml
@@ -16,10 +16,9 @@
     # disables the corresponding publisher. Plugin-specific debug topics
     # live under <plugin_name>.debug.* in each plugin's controller_default.yaml.
     debug:
-      state_pose_topic: "debug/controller/state/pose"
-      state_twist_topic: "debug/controller/state/twist"
-      reference_pose_topic: "debug/controller/reference/pose"
-      reference_twist_topic: "debug/controller/reference/twist"
-      reference_trajectory_topic: "debug/controller/reference/trajectory"
-      reference_thrust_topic: "debug/controller/reference/thrust"
-      compute_output_time_topic: "debug/controller/compute_output_time"
+      state_pose_topic: "state/pose"
+      state_twist_topic: "state/twist"
+      reference_pose_topic: "reference/pose"
+      reference_twist_topic: "reference/twist"
+      reference_trajectory_topic: "reference/trajectory"
+      compute_output_time_topic: "compute_output_time"

--- a/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
@@ -181,7 +181,6 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr debug_reference_pose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr debug_reference_twist_pub_;
   rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr debug_reference_trajectory_pub_;
-  rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr debug_reference_thrust_pub_;
   rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr debug_compute_output_time_pub_;
 
   // Services servers

--- a/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
@@ -139,6 +139,21 @@ inline Eigen::Vector3d readVector3(as2::Node * node, const std::string & name)
  */
 bool isNanSentinel(const std::vector<double> & values);
 
+/**
+ * @brief Prefix a configured debug topic with the controller debug namespace.
+ *
+ * Rules applied:
+ *  - An empty name disables the topic, and is returned empty.
+ *  - A name starting with '/' is global and is returned as is, so a topic can
+ *    be placed outside the namespace of the drone.
+ *  - Any other name hangs from `debug/controller/`, which keeps the debug
+ *    output of every controller plugin under one relative branch.
+ *
+ * @param topic_name Topic name as the configuration file provides it.
+ * @return Topic name to create the publisher with, empty when disabled.
+ */
+std::string debugTopicName(const std::string & topic_name);
+
 }  // namespace as2_motion_controller_param_utils
 
 #endif  // AS2_MOTION_CONTROLLER__PARAM_UTILS_HPP_

--- a/as2_motion_controller/plugins/pid_speed_controller/CMakeLists.txt
+++ b/as2_motion_controller/plugins/pid_speed_controller/CMakeLists.txt
@@ -30,43 +30,11 @@ foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
   find_package(${DEPENDENCY} REQUIRED)
 endforeach()
 
-# pid_controller: prefer system → local clone → FetchContent.
-# The local clone lives in plugins/pid_speed_controller/thirdparties/pid_controller/
-# so it is fetched only the first time and reused on subsequent builds. The
-# thirdparties/ directory carries an AMENT_IGNORE so colcon never indexes it
-# as a ROS package and the ament file-walking linters skip the vendored sources.
-set(_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
-file(MAKE_DIRECTORY ${_THIRDPARTIES_DIR})
-file(WRITE ${_THIRDPARTIES_DIR}/AMENT_IGNORE "")
-
-find_package(pid_controller QUIET)
-if(${pid_controller_FOUND})
-  message(STATUS "pid_controller found system-wide")
-else()
-  set(LOCAL_PID_SRC ${_THIRDPARTIES_DIR}/pid_controller)
-  if(EXISTS ${LOCAL_PID_SRC}/CMakeLists.txt)
-    message(STATUS "pid_controller: using local clone at ${LOCAL_PID_SRC}")
-    add_subdirectory(${LOCAL_PID_SRC} ${CMAKE_BINARY_DIR}/pid_controller_build)
-  else()
-    message(STATUS "pid_controller: cloning into ${LOCAL_PID_SRC}")
-    include(FetchContent)
-    fetchcontent_declare(
-      pid_controller
-      GIT_REPOSITORY https://github.com/RPS98/pid_controller.git
-      GIT_TAG v1.0
-      SOURCE_DIR ${LOCAL_PID_SRC}
-    )
-    fetchcontent_makeavailable(pid_controller)
-  endif()
-endif()
-
 include_directories(
   include
   include/${PLUGIN_NAME}
   ${EIGEN3_INCLUDE_DIRS}
-
-  # pid_controller headers (vendored under thirdparties/)
-  ${_THIRDPARTIES_DIR}/pid_controller/include
+  ${PID_CONTROLLER_INCLUDE_DIR}
 )
 
 set(SOURCE_CPP_FILES

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -34,6 +34,7 @@
  ********************************************************************************************/
 
 #include "as2_motion_controller/controller_handler.hpp"
+#include "as2_motion_controller/param_utils.hpp"
 
 #include <as2_core/utils/tf_utils.hpp>
 
@@ -756,7 +757,8 @@ void ControllerHandler::publishCommand()
 void ControllerHandler::initializeDebugPublishers()
 {
   auto topic = [this](const std::string & name) {
-      return node_ptr_->getParameter<std::string>(name, "");
+      return as2_motion_controller_param_utils::debugTopicName(
+        node_ptr_->getParameter<std::string>(name, ""));
     };
 
   const std::string state_pose_topic = topic("debug.state_pose_topic");
@@ -764,7 +766,6 @@ void ControllerHandler::initializeDebugPublishers()
   const std::string ref_pose_topic = topic("debug.reference_pose_topic");
   const std::string ref_twist_topic = topic("debug.reference_twist_topic");
   const std::string ref_traj_topic = topic("debug.reference_trajectory_topic");
-  const std::string ref_thrust_topic = topic("debug.reference_thrust_topic");
   const std::string compute_output_time_topic = topic("debug.compute_output_time_topic");
 
   const auto qos = rclcpp::SensorDataQoS();
@@ -787,10 +788,6 @@ void ControllerHandler::initializeDebugPublishers()
   if (!ref_traj_topic.empty()) {
     debug_reference_trajectory_pub_ =
       node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(ref_traj_topic, qos);
-  }
-  if (!ref_thrust_topic.empty()) {
-    debug_reference_thrust_pub_ =
-      node_ptr_->create_publisher<as2_msgs::msg::Thrust>(ref_thrust_topic, qos);
   }
   if (!compute_output_time_topic.empty()) {
     debug_compute_output_time_pub_ =
@@ -828,11 +825,6 @@ void ControllerHandler::publishDebug(const rclcpp::Time & tick)
     auto msg = ref_traj_;
     msg.header.stamp = tick;
     debug_reference_trajectory_pub_->publish(msg);
-  }
-  if (debug_reference_thrust_pub_ && ref_thrust_acquired_) {
-    auto msg = ref_thrust_;
-    msg.header.stamp = tick;
-    debug_reference_thrust_pub_->publish(msg);
   }
 }
 

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -730,6 +730,9 @@ void ControllerHandler::publishCommand()
       twist_pub_->publish(command_twist_);  // For twist limits
       break;
     case as2_msgs::msg::ControlMode::SPEED:
+      if (control_mode_out_.yaw_mode == as2_msgs::msg::ControlMode::YAW_ANGLE) {
+        pose_pub_->publish(command_pose_);  // Carries the yaw angle
+      }
       twist_pub_->publish(command_twist_);
       break;
     case as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE:
@@ -737,12 +740,13 @@ void ControllerHandler::publishCommand()
       twist_pub_->publish(command_twist_);
       break;
     case as2_msgs::msg::ControlMode::ATTITUDE:
-      command_thrust_.header = command_pose_.header;
       pose_pub_->publish(command_pose_);
+      if (control_mode_out_.yaw_mode == as2_msgs::msg::ControlMode::YAW_SPEED) {
+        twist_pub_->publish(command_twist_);  // Carries the yaw rate
+      }
       thrust_pub_->publish(command_thrust_);
       break;
     case as2_msgs::msg::ControlMode::BODY_RATES:
-      command_thrust_.header = command_pose_.header;
       twist_pub_->publish(command_twist_);
       thrust_pub_->publish(command_thrust_);
       break;

--- a/as2_motion_controller/src/param_utils.cpp
+++ b/as2_motion_controller/src/param_utils.cpp
@@ -69,4 +69,13 @@ bool isNanSentinel(const std::vector<double> & values)
   return true;
 }
 
+std::string debugTopicName(const std::string & topic_name)
+{
+  if (topic_name.empty() || topic_name.front() == '/') {
+    return topic_name;
+  }
+  // Relative namespace every debug topic of the controller hangs from.
+  return "debug/controller/" + topic_name;
+}
+
 }  // namespace as2_motion_controller_param_utils


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* ATTITUDE with a yaw rate reference now declares that it needs the twist message, and
  the controller publishes the message that carries the yaw reference in the SPEED and
  ATTITUDE output modes. Until now the yaw reference did not reach the platform in
  either case.
* Stamping the thrust header with the pose header is dropped: the plugin already stamps
  the thrust with the frame its command belongs to.
* The vendored PID library installs as `as2_pid_controller`, so it no longer collides
  with the `pid_controller` package of `ros2_controllers`. It is also resolved once for
  the package instead of once per plugin, and the system-wide lookup is dropped, since
  the vendored project installs no CMake package configuration and `find_package` could
  only ever match an unrelated library.
* Debug topic names are prefixed in one place: a relative name hangs from
  `debug/controller/`, and a name starting with a slash is left alone so a topic can be
  published outside the namespace of the drone, as TF does. The configuration files no
  longer repeat the namespace.
* The reference thrust debug topic is removed: it republished the reference exactly as
  received, with no frame change and no computation, on a topic the platform already
  publishes.
