### PR TITLE
[as2_motion_controller] Plugin parameter contract and hover as a frozen reference

### DIFF
--- a/as2_core/src/utils/control_mode_utils.cpp
+++ b/as2_core/src/utils/control_mode_utils.cpp
@@ -100,8 +100,7 @@ CommandFrameUsage getCommandFrameUsage(const as2_msgs::msg::ControlMode & mode)
       // TrajectorySetpoints carries both the pose and the twist of the setpoints
       return {true, true};
     case as2_msgs::msg::ControlMode::ATTITUDE:
-      // The yaw is part of the commanded orientation
-      return {true, false};
+      return {true, !yaw_in_pose};
     case as2_msgs::msg::ControlMode::SPEED:
       // The linear velocity is in the twist, and the yaw in whichever carries it
       return {yaw_in_pose, true};

--- a/as2_motion_controller/CMakeLists.txt
+++ b/as2_motion_controller/CMakeLists.txt
@@ -30,6 +30,29 @@ foreach(DEPENDENCY ${PROJECT_DEPENDENCIES})
   find_package(${DEPENDENCY} REQUIRED)
 endforeach()
 
+# PID Controller library
+set(AS2_MC_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
+file(MAKE_DIRECTORY ${AS2_MC_THIRDPARTIES_DIR})
+file(WRITE ${AS2_MC_THIRDPARTIES_DIR}/AMENT_IGNORE "")
+set(LOCAL_PID_SRC ${AS2_MC_THIRDPARTIES_DIR}/pid_controller)
+if(EXISTS ${LOCAL_PID_SRC}/CMakeLists.txt)
+  message(STATUS "pid_controller: using local clone at ${LOCAL_PID_SRC}")
+  add_subdirectory(${LOCAL_PID_SRC} ${CMAKE_BINARY_DIR}/pid_controller_build)
+else()
+  message(STATUS "pid_controller: cloning into ${LOCAL_PID_SRC}")
+  include(FetchContent)
+  fetchcontent_declare(
+    pid_controller
+    GIT_REPOSITORY https://github.com/RPS98/pid_controller.git
+    GIT_TAG v1.0
+    SOURCE_DIR ${LOCAL_PID_SRC}
+  )
+  fetchcontent_makeavailable(pid_controller)
+endif()
+set(PID_CONTROLLER_INCLUDE_DIR ${AS2_MC_THIRDPARTIES_DIR}/pid_controller/include)
+# Rename library to avoid name collision with other packages that may use the same library name
+set_target_properties(pid_controller PROPERTIES OUTPUT_NAME as2_pid_controller)
+
 include_directories(
   include
 )

--- a/as2_motion_controller/config/motion_controller_default.yaml
+++ b/as2_motion_controller/config/motion_controller_default.yaml
@@ -16,10 +16,9 @@
     # disables the corresponding publisher. Plugin-specific debug topics
     # live under <plugin_name>.debug.* in each plugin's controller_default.yaml.
     debug:
-      state_pose_topic: "debug/controller/state/pose"
-      state_twist_topic: "debug/controller/state/twist"
-      reference_pose_topic: "debug/controller/reference/pose"
-      reference_twist_topic: "debug/controller/reference/twist"
-      reference_trajectory_topic: "debug/controller/reference/trajectory"
-      reference_thrust_topic: "debug/controller/reference/thrust"
-      compute_output_time_topic: "debug/controller/compute_output_time"
+      state_pose_topic: "state/pose"
+      state_twist_topic: "state/twist"
+      reference_pose_topic: "reference/pose"
+      reference_twist_topic: "reference/twist"
+      reference_trajectory_topic: "reference/trajectory"
+      compute_output_time_topic: "compute_output_time"

--- a/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
@@ -58,9 +58,7 @@ namespace as2_motion_controller_plugin_base
 /**
  * @brief Base class for controller plugins loaded by ControllerManager.
  *
- * Plugins inherit from this class and implement the pure-virtual hooks. The
- * base owns the per-tick state cache, hover latch and essential-parameter
- * tracking so plugins only deal with controller-specific logic.
+ * Plugins inherit from this class and implement the pure-virtual hooks.
  */
 class ControllerBase
 {
@@ -124,13 +122,6 @@ public:
   void setPluginParamNamespace(const std::string & ns) {plugin_param_namespace_ = ns;}
 
   /**
-   * @brief Request that the next state update synthesizes a hover reference.
-   *
-   * Called by ControllerHandler after a successful setMode(HOVER).
-   */
-  void requestHoverLatch() {hover_pending_ = true;}
-
-  /**
    * @brief Override the pose frame id used by the controller for state and references.
    *
    * Typically called from setMode() to react to the active control mode.
@@ -169,49 +160,39 @@ public:
   std::string getDesiredTwistFrameId() const {return desired_twist_frame_id_;}
 
   /**
-   * @brief Whether all essential parameters have been received and applied.
-   *
-   * Consulted by ControllerHandler before accepting setMode.
-   */
-  bool essentialParamsReady() const {return essential_params_ready_;}
-
-  /**
-   * @brief Filter a parameter batch by the plugin namespace and dispatch each match to updateParameter().
-   *
-   * Tracks the essential names still pending and, the first time the set
-   * empties, flips essential_params_ready_ and calls onAllParametersRead()
-   * exactly once. Invoked by ControllerManager with the initial bulk and by
-   * ControllerHandler::parametersCallback for runtime changes. The pending
-   * set is populated at the end of initialize() from getEssentialParameters()
-   * so plugins do not need to manage this state themselves.
+   * @brief Deliver every parameter of the plugin namespace to updateParameter().
    *
    * @param batch Parameter batch from rclcpp.
    */
   void dispatchParameters(const std::vector<rclcpp::Parameter> & batch)
   {
     const std::string prefix = plugin_param_namespace_ + ".";
-    const bool latch_was_false = !essential_params_ready_;
     for (const auto & p : batch) {
       const std::string & name = p.get_name();
       if (name.compare(0, prefix.size(), prefix) != 0) {continue;}
+      const std::string tail = name.substr(prefix.size());
+      if (base_claimed_parameters_.count(tail) != 0) {continue;}
+      if (init_parameters_.count(tail) != 0) {
+        // The initial bulk repeats what deliverInitParameters() already applied.
+        if (initial_dispatch_done_) {
+          RCLCPP_WARN(
+            node_ptr_->get_logger(),
+            "Parameter '%s' is applied when the plugin is built, the change has no effect",
+            tail.c_str());
+        }
+        continue;
+      }
       RCLCPP_INFO(
         node_ptr_->get_logger(), "Parameter %s := %s",
-        p.get_name().c_str(), p.value_to_string().c_str());
-      updateParameter(p);
-      pending_essentials_.erase(name);
+        name.c_str(), p.value_to_string().c_str());
+      updateParameter(tail, p);
+      missing_parameters_.erase(tail);
     }
-    if (latch_was_false && pending_essentials_.empty()) {
-      essential_params_ready_ = true;
-      onAllParametersRead();
-    }
+    initial_dispatch_done_ = true;
   }
 
   /**
    * @brief Update the latest state (pose + twist) seen by the controller.
-   *
-   * Validates that the incoming frames match the desired ones, caches the
-   * state, consumes a pending hover latch (if any) and forwards the state
-   * to onUpdateState().
    *
    * @param pose_msg Latest pose message received by the controller node.
    * @param twist_msg Latest twist message received by the controller node.
@@ -236,11 +217,6 @@ public:
     state_pose_ = pose_msg;
     state_twist_ = twist_msg;
     state_received_ = true;
-
-    if (hover_pending_) {
-      latchHoverReference(state_pose_, state_twist_);
-      hover_pending_ = false;
-    }
 
     onUpdateState(pose_msg, twist_msg);
   }
@@ -297,7 +273,36 @@ public:
   virtual void ownInitialize() {}
 
   /**
-   * @brief Plugin hook called by the base after frame validation and hover latch.
+   * @brief Apply one parameter of the plugin to the controller.
+   *
+   * @param name Parameter name, without the plugin namespace.
+   * @param param Parameter as delivered.
+   */
+  virtual void updateParameter(
+    const std::string & name,
+    const rclcpp::Parameter & param) = 0;
+
+  /**
+   * @brief Names of the parameters the plugin needs before it can control.
+   *
+   * @return Parameter names, or an empty list when the plugin needs none.
+   */
+  virtual std::vector<std::string> requiredParameters() const {return {};}
+
+  /**
+   * @brief Names of the parameters the plugin consumes when it builds itself.
+   *
+   * Delivered through updateParameter() before ownInitialize(), so whatever
+   * depends on them is built with their value. They are not applied again: a
+   * later change is reported and ignored, since the object that read them is
+   * not rebuilt.
+   *
+   * @return Parameter names, without the plugin namespace.
+   */
+  virtual std::vector<std::string> initParameters() const {return {};}
+
+  /**
+   * @brief Plugin hook called by the base after frame validation.
    *
    * The plugin updates its internal state/integrators here.
    *
@@ -358,113 +363,74 @@ public:
    * @param mode_out Output control mode requested.
    * @return true if the in-out control mode configuration is valid.
    */
-  virtual bool setMode(
+  bool setMode(
     const as2_msgs::msg::ControlMode & mode_in,
-    const as2_msgs::msg::ControlMode & mode_out) = 0;
+    const as2_msgs::msg::ControlMode & mode_out)
+  {
+    if (!missing_parameters_.empty()) {
+      for (const auto & name : missing_parameters_) {
+        RCLCPP_ERROR(
+          node_ptr_->get_logger(),
+          "Parameter '%s' is not provided by any configuration file", name.c_str());
+      }
+      return false;
+    }
+
+    if (!onSetMode(mode_in, mode_out)) {
+      return false;
+    }
+
+    control_mode_in_ = mode_in;
+    control_mode_out_ = mode_out;
+    return true;
+  }
 
   /**
-   * @brief Names of the parameters whose presence is required before the plugin can accept setMode.
+   * @brief Mark whether the mode just set serves a hover request.
    *
-   * Names must be already namespaced with `<plugin_name>.`. The manager
-   * tracks reception of these names and invokes onAllParametersRead() once
-   * the last one arrives.
-   *
-   * @return Vector of fully-qualified essential parameter names.
+   * @param enabled true when the accepted mode serves a hover request.
    */
-  virtual std::vector<std::string> getEssentialParameters() const = 0;
+  void setHoverEnabled(bool enabled) {hover_enabled_ = enabled;}
 
   /**
-   * @brief Apply a single parameter to the plugin.
+   * @brief Control mode the plugin runs to perform a hover request.
    *
-   * Called by the manager for every parameter (essential or not) with a name
-   * starting with `<plugin_name>.`, both at startup and on runtime changes.
-   * The plugin can read essentialParamsReady() to decide whether to apply at
-   * runtime or defer the configuration to onAllParametersRead().
-   *
-   * @param parameter Parameter to apply.
+   * @return Control mode the plugin does the hover with, UNSET when it cannot hover.
    */
-  virtual void updateParameter(const rclcpp::Parameter & parameter) = 0;
+  virtual as2_msgs::msg::ControlMode hoverMode() const
+  {
+    as2_msgs::msg::ControlMode mode;
+    mode.control_mode = as2_msgs::msg::ControlMode::UNSET;
+    return mode;
+  }
 
   /**
-   * @brief Hook fired once when every essential parameter has been delivered.
+   * @brief Plugin hook to accept or refuse a control mode pair.
    *
-   * The latch essentialParamsReady() is already true on entry. Plugins use
-   * this hook to perform first-time configuration of the underlying
-   * solver/controller from the now-fully-populated parameter set.
+   * @param mode_in Input control mode requested.
+   * @param mode_out Output control mode requested.
+   * @return true if the plugin accepts the pair.
    */
-  virtual void onAllParametersRead() {}
+  virtual bool onSetMode(
+    const as2_msgs::msg::ControlMode & mode_in,
+    const as2_msgs::msg::ControlMode & mode_out)
+  {
+    (void)mode_in;
+    (void)mode_out;
+    return true;
+  }
 
   /**
    * @brief Reset the controller.
    *
    * Default implementation clears the per-mode flags maintained by the base.
    * Plugins should override and call ControllerBase::reset() so the base
-   * state is also cleared. essential_params_ready_ is intentionally NOT
-   * cleared here; it is a monotonic latch — parameters are read once at
-   * startup via the rclcpp parameter callback, and reset() runs on every
-   * successful setMode and would otherwise leave the latch permanently
-   * false, rejecting all subsequent mode transitions.
+   * state is also cleared.
    */
   virtual void reset()
   {
-    hover_pending_ = false;
     state_received_ = false;
     reference_received_ = false;
-  }
-
-  /**
-   * @brief Default hover latch: synthesize a single-point trajectory at the cached state.
-   *
-   * Override in plugins that do not consume trajectory references; in that
-   * case feed the hover via updateReference(pose) / updateReference(twist)
-   * with twist set to zero.
-   *
-   * @param pose Cached state pose used as the hover anchor.
-   * @param twist Cached state twist (unused by the default).
-   */
-  virtual void latchHoverReference(
-    const geometry_msgs::msg::PoseStamped & pose,
-    const geometry_msgs::msg::TwistStamped & /*twist*/)
-  {
-    // Hover pose reference
-    updateReference(pose);
-
-    // Hover speed reference
-    geometry_msgs::msg::TwistStamped zero_twist;
-    zero_twist.header = pose.header;
-    zero_twist.twist.linear.x = 0.0;
-    zero_twist.twist.linear.y = 0.0;
-    zero_twist.twist.linear.z = 0.0;
-    zero_twist.twist.angular.x = 0.0;
-    zero_twist.twist.angular.y = 0.0;
-    zero_twist.twist.angular.z = 0.0;
-    updateReference(zero_twist);
-
-    // Hover trajectory reference
-    as2_msgs::msg::TrajectorySetpoints traj;
-    traj.header = pose.header;
-    as2_msgs::msg::TrajectoryPoint point;
-    point.position.x = pose.pose.position.x;
-    point.position.y = pose.pose.position.y;
-    point.position.z = pose.pose.position.z;
-    point.twist.x = 0.0;
-    point.twist.y = 0.0;
-    point.twist.z = 0.0;
-    point.acceleration.x = 0.0;
-    point.acceleration.y = 0.0;
-    point.acceleration.z = 0.0;
-    point.yaw_angle = as2::frame::getYawFromQuaternion(pose.pose.orientation);
-    traj.setpoints.push_back(point);
-    updateReference(traj);
-
-    // Hover thrust reference
-    as2_msgs::msg::Thrust thrust;
-    thrust.header = pose.header;
-    thrust.thrust = 9.81;  // Default to gravity for hover (needs mass)
-    thrust.thrust_normalized = 0.5;
-    updateReference(thrust);
-
-    reference_received_ = true;
   }
 
   /**
@@ -563,12 +529,35 @@ protected:
   bool isStateReceived() const {return state_received_;}
 
   /**
-   * @brief Whether a hover latch is pending consumption on the next state update.
+   * @brief Whether the active mode is serving a hover request.
    */
-  bool isHoverPending() const {return hover_pending_;}
+  bool isHoverEnabled() const {return hover_enabled_;}
 
 private:
   // Implementation details
+
+  /**
+   * @brief Deliver the parameters the plugin consumes when it builds itself.
+   */
+  void deliverInitParameters()
+  {
+    const auto names = initParameters();
+    init_parameters_ = std::set<std::string>(names.begin(), names.end());
+    for (const auto & tail : init_parameters_) {
+      const std::string name = param(tail);
+      if (!node_ptr_->has_parameter(name)) {
+        RCLCPP_ERROR(
+          node_ptr_->get_logger(),
+          "Parameter '%s' is not provided by any configuration file", tail.c_str());
+        continue;
+      }
+      const rclcpp::Parameter parameter = node_ptr_->get_parameter(name);
+      RCLCPP_INFO(
+        node_ptr_->get_logger(), "Parameter %s := %s",
+        name.c_str(), parameter.value_to_string().c_str());
+      updateParameter(tail, parameter);
+    }
+  }
 
   /**
    * @brief Declare and read the desired_pose_frame_id / desired_twist_frame_id parameters.
@@ -600,23 +589,28 @@ private:
   std::string desired_pose_frame_id_;
   std::string desired_twist_frame_id_;
 
-  // Last validated state cached by updateState() for hover latch and
-  // diagnostics.
+  // Last validated state cached by updateState()
   geometry_msgs::msg::PoseStamped state_pose_;
   geometry_msgs::msg::TwistStamped state_twist_;
 
   // Plugin-side flags owned by the base.
   bool state_received_ = false;
   bool reference_received_ = false;
-  bool hover_pending_ = false;
-  bool essential_params_ready_ = false;
+  bool hover_enabled_ = false;
 
-  // Set of essential parameter names not yet received by the plugin.
-  // Populated at the end of initialize() from getEssentialParameters() and
-  // decremented inside dispatchParameters() as parameters arrive. Once
-  // emptied for the first time, the latch above is flipped and
-  // onAllParametersRead() fires.
-  std::set<std::string> pending_essentials_;
+  // Parameter to be read
+  std::set<std::string> base_claimed_parameters_;
+
+  // Parameter tails delivered once, before the plugin is built.
+  std::set<std::string> init_parameters_;
+  bool initial_dispatch_done_ = false;
+
+  // Required parameter tails not delivered yet.
+  std::set<std::string> missing_parameters_;
+
+  // Control modes in use
+  as2_msgs::msg::ControlMode control_mode_in_;
+  as2_msgs::msg::ControlMode control_mode_out_;
 };   // class ControllerBase
 
 }  // namespace as2_motion_controller_plugin_base

--- a/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_base.hpp
@@ -38,12 +38,14 @@
 
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 
 #include "as2_core/node.hpp"
+#include "as2_motion_controller/param_utils.hpp"
 #include "as2_core/utils/frame_utils.hpp"
 #include "as2_core/utils/tf_utils.hpp"
 #include "as2_msgs/msg/control_mode.hpp"
@@ -90,8 +92,7 @@ public:
    * @brief Initialize the plugin.
    *
    * Called by ControllerManager after the per-plugin setters have been
-   * configured. Declares frame parameters, runs ownInitialize() and seeds
-   * the pending-essentials set from getEssentialParameters().
+   * configured. Declares the frame parameters and runs ownInitialize().
    *
    * @param node_ptr Non-owning pointer to the controller node.
    */
@@ -99,11 +100,10 @@ public:
   {
     node_ptr_ = node_ptr;
     declareFrameParameters();
+    deliverInitParameters();
     ownInitialize();
-    if (!essential_params_ready_) {
-      const auto essentials = getEssentialParameters();
-      pending_essentials_ = std::set<std::string>(essentials.begin(), essentials.end());
-    }
+    const auto required = requiredParameters();
+    missing_parameters_ = std::set<std::string>(required.begin(), required.end());
   }
 
   /**
@@ -509,6 +509,43 @@ protected:
   {
     return plugin_param_namespace_.empty() ? tail : plugin_param_namespace_ + "." + tail;
   }
+
+  /**
+   * @brief Create a publisher for an optional debug topic.
+   *
+   * Debug topics are opt-in: the plugin declares a `debug.<name>_topic`
+   * parameter and the publisher only exists when it is set to a non-empty
+   * topic name. The name is resolved by debugTopicName(), so the
+   * configuration file carries the leaf name and not the debug namespace.
+   *
+   * @tparam MsgT Message type of the topic.
+   * @param topic_param_tail Parameter name without the plugin namespace.
+   * @param qos Quality of service of the publisher.
+   * @return The publisher, or nullptr when the parameter is empty.
+   */
+  template<typename MsgT>
+  typename rclcpp::Publisher<MsgT>::SharedPtr createDebugPublisher(
+    const std::string & topic_param_tail,
+    const rclcpp::QoS & qos = rclcpp::SensorDataQoS())
+  {
+    base_claimed_parameters_.insert(topic_param_tail);
+    const auto topic = as2_motion_controller_param_utils::debugTopicName(
+      node_ptr_->template getParameter<std::string>(param(topic_param_tail), ""));
+    if (topic.empty()) {
+      return nullptr;
+    }
+    return node_ptr_->template create_publisher<MsgT>(topic, qos);
+  }
+
+  /**
+   * @brief Input control mode currently active.
+   */
+  const as2_msgs::msg::ControlMode & getControlModeIn() const {return control_mode_in_;}
+
+  /**
+   * @brief Output control mode negotiated with the platform.
+   */
+  const as2_msgs::msg::ControlMode & getControlModeOut() const {return control_mode_out_;}
 
   /**
    * @brief Last validated state pose cached by the base.

--- a/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <utility>
 #include <vector>
 #include <string>
 #include <rclcpp/clock.hpp>
@@ -196,10 +197,9 @@ private:
 
   // Internal variables
   bool control_mode_established_ = false;
-  // Aggregated reference gate for control flow (set whenever any of the four
-  // specific reference types arrives). Per-type flags below drive debug
-  // publishing so we don't emit default-constructed messages on topics for
-  // reference types the active mode never produced.
+  bool hover_pending_ = false;
+
+  // References and state acquired flags.
   bool ref_pose_acquired_ = false;
   bool ref_twist_acquired_ = false;
   bool ref_traj_acquired_ = false;
@@ -286,9 +286,10 @@ private:
   /**
    * @brief Service handler for `controller/set_control_mode`.
    *
-   * Negotiates the input/output mode pair with the platform, applies the
-   * negotiated mode to the plugin, and arms the hover latch when the
-   * requested mode is HOVER.
+   * Negotiates the input/output mode pair with the platform and applies it to
+   * the plugin. A HOVER request is served by the platform when it offers that
+   * mode, and otherwise by the mode the plugin holds position with, which then
+   * receives a reference frozen at the current state.
    *
    * @param request Mode requested by the upstream client.
    * @param response Service response with the success flag.

--- a/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
@@ -181,7 +181,6 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr debug_reference_pose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr debug_reference_twist_pub_;
   rclcpp::Publisher<as2_msgs::msg::TrajectorySetpoints>::SharedPtr debug_reference_trajectory_pub_;
-  rclcpp::Publisher<as2_msgs::msg::Thrust>::SharedPtr debug_reference_thrust_pub_;
   rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr debug_compute_output_time_pub_;
 
   // Services servers

--- a/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/controller_handler.hpp
@@ -79,6 +79,59 @@ namespace controller_handler
 using namespace std::chrono_literals; // NOLINT
 
 /**
+ * @brief Control mode matching between the plugin and the platform.
+ *
+ * Free functions so the negotiation can be exercised without a ROS graph.
+ */
+namespace mode_negotiation
+{
+
+/**
+ * @brief Collect every platform input mode the controller can feed, in preference order.
+ *
+ * @param preferred_output_mode Output mode to try first, or 0 when there is none.
+ * @param controller_modes_out Output modes the plugin declares.
+ * @param platform_modes_in Input modes the platform declares.
+ * @return Matching platform modes, without duplicates.
+ */
+std::vector<uint8_t> findOutputModes(
+  const uint8_t preferred_output_mode,
+  const std::vector<uint8_t> & controller_modes_out,
+  const std::vector<uint8_t> & platform_modes_in);
+
+/**
+ * @brief Check whether a controller input mode is compatible with a given output mode.
+ *
+ * @param input_mode In/out: input mode under evaluation; refined on success.
+ * @param output_mode Output mode the input must feed.
+ * @param controller_modes_in Input modes the plugin declares.
+ * @return true if the combination is supported.
+ */
+bool checkSuitabilityInputMode(
+  uint8_t & input_mode,
+  const uint8_t output_mode,
+  const std::vector<uint8_t> & controller_modes_in);
+
+/**
+ * @brief Build every self-consistent input/output mode pair, in preference order.
+ *
+ * @param input_mode Input mode the upstream client asked for.
+ * @param preferred_output_mode Output mode to try first, or 0 when there is none.
+ * @param controller_modes_in Input modes the plugin declares.
+ * @param controller_modes_out Output modes the plugin declares.
+ * @param platform_modes_in Input modes the platform declares.
+ * @return Pairs to try in order, empty when none is viable.
+ */
+std::vector<std::pair<uint8_t, uint8_t>> findModePairs(
+  const uint8_t input_mode,
+  const uint8_t preferred_output_mode,
+  const std::vector<uint8_t> & controller_modes_in,
+  const std::vector<uint8_t> & controller_modes_out,
+  const std::vector<uint8_t> & platform_modes_in);
+
+}  // namespace mode_negotiation
+
+/**
  * @brief Orchestrates the controller plugin life cycle inside the ControllerManager.
  *
  * Owns the subscriptions for state and motion references, the publishers for
@@ -315,41 +368,12 @@ private:
   // Internal methods
 
   /**
-   * @brief Find a controller output mode that matches the platform's input mode.
-   *
-   * @param output_mode Output: matching output mode bitmask, if any.
-   * @param input_mode Platform input mode the output must feed.
-   * @return true if a match was found.
-   */
-  bool findSuitableOutputControlModeForPlatformInputMode(
-    uint8_t & output_mode,
-    const uint8_t input_mode);
-
-  /**
-   * @brief Check whether a controller input mode is compatible with a given output mode.
-   *
-   * @param input_mode In/out: input mode under evaluation; refined on success.
-   * @param output_mode Output mode the input must feed.
-   * @return true if the combination is supported.
-   */
-  bool checkSuitabilityInputMode(uint8_t & input_mode, const uint8_t output_mode);
-
-  /**
    * @brief Send a `set_platform_control_mode` request to the platform.
    *
    * @param mode Control mode the platform should enter.
    * @return true if the platform accepted the new mode.
    */
   bool setPlatformControlMode(const as2_msgs::msg::ControlMode & mode);
-
-  /**
-   * @brief Find a self-consistent input/output mode pair given the active modes.
-   *
-   * @param input_mode In/out: candidate input mode; refined on success.
-   * @param output_mode In/out: candidate output mode; refined on success.
-   * @return true if a compatible pair was found.
-   */
-  bool findSuitableControlModes(uint8_t & input_mode, uint8_t & output_mode);
 
   /**
    * @brief Drive the platform into HOVER directly, bypassing the plugin.

--- a/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
@@ -139,6 +139,21 @@ inline Eigen::Vector3d readVector3(as2::Node * node, const std::string & name)
  */
 bool isNanSentinel(const std::vector<double> & values);
 
+/**
+ * @brief Prefix a configured debug topic with the controller debug namespace.
+ *
+ * Rules applied:
+ *  - An empty name disables the topic, and is returned empty.
+ *  - A name starting with '/' is global and is returned as is, so a topic can
+ *    be placed outside the namespace of the drone.
+ *  - Any other name hangs from `debug/controller/`, which keeps the debug
+ *    output of every controller plugin under one relative branch.
+ *
+ * @param topic_name Topic name as the configuration file provides it.
+ * @return Topic name to create the publisher with, empty when disabled.
+ */
+std::string debugTopicName(const std::string & topic_name);
+
 }  // namespace as2_motion_controller_param_utils
 
 #endif  // AS2_MOTION_CONTROLLER__PARAM_UTILS_HPP_

--- a/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
+++ b/as2_motion_controller/include/as2_motion_controller/param_utils.hpp
@@ -115,17 +115,59 @@ std::vector<double> readDoubleArray(
   std::size_t expected_size = 0);
 
 /**
+ * @brief Read a double array from a delivered parameter, optionally checking its size.
+ *
+ * The parameter callback runs before the node commits the new value, so a
+ * plugin reacting to a change has to read the delivered parameter and not the
+ * node.
+ *
+ * @param param Parameter delivered to the plugin.
+ * @param expected_size Expected number of elements, zero to accept any size.
+ * @return Values of the parameter.
+ * @throw rclcpp::exceptions::InvalidParameterValueException if the size does not match.
+ */
+std::vector<double> readDoubleArray(
+  const rclcpp::Parameter & param,
+  std::size_t expected_size = 0);
+
+/**
+ * @brief Read a fixed-size double array from a delivered parameter.
+ *
+ * @tparam N Expected number of elements in the array.
+ * @param param Parameter delivered to the plugin.
+ * @return Fixed-size std::array<double, N> with the values.
+ * @throw rclcpp::exceptions::InvalidParameterValueException if the size is not N.
+ */
+template<std::size_t N>
+std::array<double, N> readArray(const rclcpp::Parameter & param)
+{
+  const auto values = readDoubleArray(param, N);
+  std::array<double, N> out{};
+  std::copy_n(values.begin(), N, out.begin());
+  return out;
+}
+
+/**
  * @brief Read a 3-component double array parameter as Eigen::Vector3d.
  *
  * @param node Pointer to the aerostack2 node.
  * @param name Fully-qualified parameter name.
  * @return Eigen::Vector3d with the values.
  */
-inline Eigen::Vector3d readVector3(as2::Node * node, const std::string & name)
-{
-  const auto a = readArray<3>(node, name);
-  return Eigen::Vector3d(a[0], a[1], a[2]);
-}
+Eigen::Vector3d readVector3(as2::Node * node, const std::string & name);
+
+/**
+ * @brief Read a 3-component double array from a delivered parameter.
+ *
+ * The parameter callback runs before the node commits the new value, so a
+ * plugin reacting to a change has to read the delivered parameter and not the
+ * node.
+ *
+ * @param param Parameter delivered to the plugin.
+ * @return Eigen::Vector3d with the values.
+ * @throw rclcpp::exceptions::InvalidParameterValueException if the size is not 3.
+ */
+Eigen::Vector3d readVector3(const rclcpp::Parameter & param);
 
 /**
  * @brief True if every element of values is NaN.

--- a/as2_motion_controller/plugins/differential_flatness_controller/config/available_modes.yaml
+++ b/as2_motion_controller/plugins/differential_flatness_controller/config/available_modes.yaml
@@ -23,7 +23,6 @@
 #-----------------------------------------------------------------
 
 output_control_modes:
-  - 0b00000000 # UNSET
   - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
@@ -37,7 +36,6 @@ output_control_modes:
   # - 0b01110100 # TRAJECTORY with yaw SPEED
 
 input_control_modes:
-  - 0b00000000 # UNSET
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)

--- a/as2_motion_controller/plugins/differential_flatness_controller/config/available_modes.yaml
+++ b/as2_motion_controller/plugins/differential_flatness_controller/config/available_modes.yaml
@@ -24,7 +24,6 @@
 
 output_control_modes:
   - 0b00000000 # UNSET
-  # - 0b00010000 # HOVER
   - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
@@ -39,7 +38,6 @@ output_control_modes:
 
 input_control_modes:
   - 0b00000000 # UNSET
-  - 0b00010000 # HOVER
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
@@ -50,5 +48,5 @@ input_control_modes:
   # - 0b01100000 # POSITION with yaw ANGLE
   # - 0b01100100 # POSITION with yaw SPEED
   - 0b01110000 # TRAJECTORY with yaw ANGLE
-  - 0b01110100 # TRAJECTORY with yaw SPEED
+  # - 0b01110100 # TRAJECTORY with yaw SPEED
 

--- a/as2_motion_controller/plugins/differential_flatness_controller/config/controller_default.yaml
+++ b/as2_motion_controller/plugins/differential_flatness_controller/config/controller_default.yaml
@@ -4,7 +4,6 @@
       mass: 0.82
       trajectory_control:
         antiwindup_cte: 1.0
-        alpha: 0.1
         kp:
           x: 6.0
           y: 6.0
@@ -23,5 +22,3 @@
           kp: 5.5
         yaw_control:
           kp: 2.0
-      debug:
-        desired_velocity_topic: "debug/controller/desired_velocity"

--- a/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
@@ -100,46 +100,49 @@ public:
   void ownInitialize() override;
 
   /**
-   * @brief Names of the parameters required before the plugin can accept setMode.
+   * @brief Control mode the plugin runs to hold its position.
    *
-   * @return Vector of fully-qualified essential parameter names.
+   * @return TRAJECTORY with yaw angle, the only law this plugin implements.
    */
-  std::vector<std::string> getEssentialParameters() const override;
+  as2_msgs::msg::ControlMode hoverMode() const override;
 
   /**
-   * @brief Apply a single parameter to the plugin.
+   * @brief Apply one parameter of the plugin to the controller.
    *
-   * Routes the value to the differential-flatness gain matrices and the
-   * mass/antiwindup scalars.
-   *
-   * @param parameter Parameter to apply.
+   * @param name Parameter name, without the plugin namespace.
+   * @param param Parameter as delivered.
    */
-  void updateParameter(const rclcpp::Parameter & parameter) override;
+  void updateParameter(
+    const std::string & name,
+    const rclcpp::Parameter & param) override;
 
   /**
-   * @brief Reset the cached state, references and commands.
+   * @brief Names of the parameters the plugin needs before it can control.
    *
-   * Calls ControllerBase::reset() to clear the base flags. The
-   * essentialParamsReady() latch is intentionally preserved.
+   * @return Parameter names, without the plugin namespace.
    */
-  void reset() override;
+  std::vector<std::string> requiredParameters() const override;
 
   /**
-   * @brief Update the control mode to be used by the controller plugin.
+   * @brief Accept a control mode pair.
    *
-   * Only the TRAJECTORY input mode is accepted by the differential-flatness
-   * controller.
-   *
-   * @param mode_in Input control mode requested.
+   * @param mode_in Input control mode, already resolved.
    * @param mode_out Output control mode requested.
-   * @return true if the in-out control mode configuration is valid.
+   * @return true if the plugin can serve the pair.
    */
-  bool setMode(
+  bool onSetMode(
     const as2_msgs::msg::ControlMode & mode_in,
     const as2_msgs::msg::ControlMode & mode_out) override;
 
   /**
-   * @brief Plugin hook called by the base after frame validation and hover latch.
+   * @brief Reset the cached state, references and commands.
+   *
+   * Calls ControllerBase::reset() to clear the base flags.
+   */
+  void reset() override;
+
+  /**
+   * @brief Plugin hook called by the base after frame validation.
    *
    * Caches the position, velocity and attitude used by the controller.
    *

--- a/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/include/differential_flatness_controller/differential_flatness_controller.hpp
@@ -177,14 +177,6 @@ public:
 
 private:
   /**
-   * @brief Apply a parameter change to the differential-flatness gains.
-   *
-   * @param _parameter_name Tail name of the parameter (without plugin namespace).
-   * @param _param New parameter value.
-   */
-  void updateDFParameter(const std::string & _parameter_name, const rclcpp::Parameter & _param);
-
-  /**
    * @brief Reset the cached UAV state.
    */
   void resetState();
@@ -255,8 +247,6 @@ private:
   UAV_reference control_ref_;
   BodyRates_command control_command_;
 
-  as2_msgs::msg::ControlMode control_mode_in_;
-  as2_msgs::msg::ControlMode control_mode_out_;
 
   // Controller gains and parameters
   Eigen::Matrix3d Kp_{Eigen::Matrix3d::Zero()};
@@ -270,29 +260,6 @@ private:
   double antiwindup_cte_ = 0.0;
 
   const Eigen::Vector3d gravitational_accel_ = Eigen::Vector3d(0, 0, -9.81);
-
-  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr
-    debug_desired_velocity_pub_;
-
-  // Tail names of the parameters tracked by the plugin. Resolved against the
-  // plugin namespace at runtime via ControllerBase::param().
-  const std::vector<std::string> parameters_tail_ = {
-    "mass",
-    "trajectory_control.antiwindup_cte",
-    "trajectory_control.alpha",
-    "trajectory_control.kp.x",
-    "trajectory_control.kp.y",
-    "trajectory_control.kp.z",
-    "trajectory_control.ki.x",
-    "trajectory_control.ki.y",
-    "trajectory_control.ki.z",
-    "trajectory_control.kd.x",
-    "trajectory_control.kd.y",
-    "trajectory_control.kd.z",
-    "trajectory_control.roll_control.kp",
-    "trajectory_control.pitch_control.kp",
-    "trajectory_control.yaw_control.kp",
-  };
 };  // class Plugin
 
 }  // namespace differential_flatness_controller

--- a/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
@@ -145,7 +145,7 @@ bool Plugin::computeOutput(
 
   resetCommands();
 
-  switch (control_mode_in_.yaw_mode) {
+  switch (getControlModeIn().yaw_mode) {
     case as2_msgs::msg::ControlMode::YAW_ANGLE:
       break;
     default: {
@@ -171,65 +171,11 @@ bool Plugin::computeOutput(
       }
   }
 
-  if (debug_desired_velocity_pub_) {
-    geometry_msgs::msg::TwistStamped msg;
-    msg.header.stamp = getNodePtr()->now();
-    msg.header.frame_id = getDesiredTwistFrameId();
-    msg.twist.linear.x = control_ref_.velocity.x();
-    msg.twist.linear.y = control_ref_.velocity.y();
-    msg.twist.linear.z = control_ref_.velocity.z();
-    debug_desired_velocity_pub_->publish(msg);
-  }
-
   return getOutput(twist, thrust);
 }
 
 // ===== Internal helpers =====================================================
 
-void Plugin::updateDFParameter(
-  const std::string & _parameter_name,
-  const rclcpp::Parameter & _param)
-{
-  // For trajectory_control.* gains the plugin code historically uses the
-  // post-dot subname (e.g. "kp.x"), so strip the leading "trajectory_control."
-  // when present to keep the existing dispatch.
-  const std::string controller = _parameter_name.substr(0, _parameter_name.find('.'));
-  const std::string subname = _parameter_name.find('.') == std::string::npos ?
-    _parameter_name :
-    _parameter_name.substr(_parameter_name.find('.') + 1);
-  const std::string dispatch_name = (controller == "trajectory_control") ?
-    subname : _parameter_name;
-
-  if (dispatch_name == "mass") {
-    mass_ = _param.get_value<double>();
-  } else if (dispatch_name == "antiwindup_cte") {
-    antiwindup_cte_ = _param.get_value<double>();
-  } else if (dispatch_name == "kp.x") {
-    Kp_(0, 0) = _param.get_value<double>();
-  } else if (dispatch_name == "kp.y") {
-    Kp_(1, 1) = _param.get_value<double>();
-  } else if (dispatch_name == "kp.z") {
-    Kp_(2, 2) = _param.get_value<double>();
-  } else if (dispatch_name == "ki.x") {
-    Ki_(0, 0) = _param.get_value<double>();
-  } else if (dispatch_name == "ki.y") {
-    Ki_(1, 1) = _param.get_value<double>();
-  } else if (dispatch_name == "ki.z") {
-    Ki_(2, 2) = _param.get_value<double>();
-  } else if (dispatch_name == "kd.x") {
-    Kd_(0, 0) = _param.get_value<double>();
-  } else if (dispatch_name == "kd.y") {
-    Kd_(1, 1) = _param.get_value<double>();
-  } else if (dispatch_name == "kd.z") {
-    Kd_(2, 2) = _param.get_value<double>();
-  } else if (dispatch_name == "roll_control.kp") {
-    Kp_ang_mat_(0, 0) = _param.get_value<double>();
-  } else if (dispatch_name == "pitch_control.kp") {
-    Kp_ang_mat_(1, 1) = _param.get_value<double>();
-  } else if (dispatch_name == "yaw_control.kp") {
-    Kp_ang_mat_(2, 2) = _param.get_value<double>();
-  }
-}
 
 inline void Plugin::resetState() {uav_state_ = UAV_state();}
 

--- a/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/src/differential_flatness_controller.cpp
@@ -43,36 +43,71 @@ void Plugin::ownInitialize()
   // TrajectorySetpoints encodes pose and twist in the same frame.
   setDesiredTwistFrameId(getDesiredPoseFrameId());
 
-  const std::string desired_velocity_topic =
-    getNodePtr()->getParameter<std::string>(param("debug.desired_velocity_topic"), "");
-  if (!desired_velocity_topic.empty()) {
-    debug_desired_velocity_pub_ =
-      getNodePtr()->create_publisher<geometry_msgs::msg::TwistStamped>(
-      desired_velocity_topic, rclcpp::SensorDataQoS());
-  }
-
   reset();
 }
 
-std::vector<std::string> Plugin::getEssentialParameters() const
+std::vector<std::string> Plugin::requiredParameters() const
 {
-  std::vector<std::string> out;
-  out.reserve(parameters_tail_.size());
-  for (const auto & tail : parameters_tail_) {
-    out.push_back(param(tail));
-  }
-  return out;
+  return {
+    "mass",
+    "trajectory_control.antiwindup_cte",
+    "trajectory_control.kp.x",
+    "trajectory_control.kp.y",
+    "trajectory_control.kp.z",
+    "trajectory_control.ki.x",
+    "trajectory_control.ki.y",
+    "trajectory_control.ki.z",
+    "trajectory_control.kd.x",
+    "trajectory_control.kd.y",
+    "trajectory_control.kd.z",
+    "trajectory_control.roll_control.kp",
+    "trajectory_control.pitch_control.kp",
+    "trajectory_control.yaw_control.kp",
+  };
 }
 
-void Plugin::updateParameter(const rclcpp::Parameter & p)
+as2_msgs::msg::ControlMode Plugin::hoverMode() const
 {
-  const std::string ns_prefix = getPluginParamNamespace().empty() ?
-    std::string() :
-    getPluginParamNamespace() + ".";
-  const std::string & full_name = p.get_name();
-  const std::string tail = ns_prefix.empty() ? full_name :
-    full_name.substr(ns_prefix.size());
-  updateDFParameter(tail, p);
+  as2_msgs::msg::ControlMode mode;
+  mode.control_mode = as2_msgs::msg::ControlMode::TRAJECTORY;
+  mode.yaw_mode = as2_msgs::msg::ControlMode::YAW_ANGLE;
+  return mode;
+}
+
+void Plugin::updateParameter(const std::string & name, const rclcpp::Parameter & param)
+{
+  if (name == "mass") {
+    mass_ = param.as_double();
+  } else if (name == "trajectory_control.antiwindup_cte") {
+    antiwindup_cte_ = param.as_double();
+  } else if (name == "trajectory_control.kp.x") {
+    Kp_(0, 0) = param.as_double();
+  } else if (name == "trajectory_control.kp.y") {
+    Kp_(1, 1) = param.as_double();
+  } else if (name == "trajectory_control.kp.z") {
+    Kp_(2, 2) = param.as_double();
+  } else if (name == "trajectory_control.ki.x") {
+    Ki_(0, 0) = param.as_double();
+  } else if (name == "trajectory_control.ki.y") {
+    Ki_(1, 1) = param.as_double();
+  } else if (name == "trajectory_control.ki.z") {
+    Ki_(2, 2) = param.as_double();
+  } else if (name == "trajectory_control.kd.x") {
+    Kd_(0, 0) = param.as_double();
+  } else if (name == "trajectory_control.kd.y") {
+    Kd_(1, 1) = param.as_double();
+  } else if (name == "trajectory_control.kd.z") {
+    Kd_(2, 2) = param.as_double();
+  } else if (name == "trajectory_control.roll_control.kp") {
+    Kp_ang_mat_(0, 0) = param.as_double();
+  } else if (name == "trajectory_control.pitch_control.kp") {
+    Kp_ang_mat_(1, 1) = param.as_double();
+  } else if (name == "trajectory_control.yaw_control.kp") {
+    Kp_ang_mat_(2, 2) = param.as_double();
+  } else {
+    RCLCPP_ERROR(
+      getNodePtr()->get_logger(), "Unknown parameter '%s'", name.c_str());
+  }
 }
 
 void Plugin::reset()
@@ -83,23 +118,32 @@ void Plugin::reset()
   resetCommands();
 }
 
-bool Plugin::setMode(
-  const as2_msgs::msg::ControlMode & in_mode,
-  const as2_msgs::msg::ControlMode & out_mode)
+bool Plugin::onSetMode(
+  const as2_msgs::msg::ControlMode & mode_in,
+  const as2_msgs::msg::ControlMode & mode_out)
 {
-  if (!essentialParamsReady()) {
-    RCLCPP_WARN(getNodePtr()->get_logger(), "Plugin parameters not read yet, can not set mode");
+  (void)mode_in;
+  (void)mode_out;
+
+  // A zero gain block produces no command, so the mode is refused instead of
+  // flying an inert controller.
+  if (Kp_.isZero() && Kd_.isZero() && Ki_.isZero()) {
+    RCLCPP_ERROR(
+      getNodePtr()->get_logger(),
+      "The position loop has all its gains at zero, the mode cannot be served");
     return false;
   }
-
-  if (in_mode.control_mode == as2_msgs::msg::ControlMode::HOVER) {
-    control_mode_in_.control_mode = in_mode.control_mode;
-    control_mode_in_.yaw_mode = as2_msgs::msg::ControlMode::YAW_ANGLE;
-  } else {
-    control_mode_in_ = in_mode;
+  if (Kp_ang_mat_.isZero()) {
+    RCLCPP_ERROR(
+      getNodePtr()->get_logger(),
+      "The attitude loop has all its gains at zero, the mode cannot be served");
+    return false;
   }
-
-  control_mode_out_ = out_mode;
+  if (mass_ <= 0.0) {
+    RCLCPP_ERROR(
+      getNodePtr()->get_logger(), "The mass must be positive, the mode cannot be served");
+    return false;
+  }
   return true;
 }
 
@@ -119,9 +163,7 @@ void Plugin::onUpdateState(
 
 void Plugin::onUpdateReference(const as2_msgs::msg::TrajectorySetpoints & trajectory_setpoints_msg)
 {
-  if (control_mode_in_.control_mode != as2_msgs::msg::ControlMode::TRAJECTORY &&
-    control_mode_in_.control_mode != as2_msgs::msg::ControlMode::HOVER)
-  {
+  if (getControlModeIn().control_mode != as2_msgs::msg::ControlMode::TRAJECTORY) {
     return;
   }
 
@@ -155,8 +197,7 @@ bool Plugin::computeOutput(
       }
   }
 
-  switch (control_mode_in_.control_mode) {
-    case as2_msgs::msg::ControlMode::HOVER:
+  switch (getControlModeIn().control_mode) {
     case as2_msgs::msg::ControlMode::TRAJECTORY:
       control_command_ = computeTrajectoryControl(
         dt, uav_state_.position, uav_state_.velocity,

--- a/as2_motion_controller/plugins/differential_flatness_controller/tests/differential_flatness_controller_gtest.cpp
+++ b/as2_motion_controller/plugins/differential_flatness_controller/tests/differential_flatness_controller_gtest.cpp
@@ -119,6 +119,7 @@ getControllerManagerNode()
   };
   rclcpp::NodeOptions opts;
   opts.arguments(node_args);
+  opts.automatically_declare_parameters_from_overrides(true);
   return std::make_shared<controller_manager::ControllerManager>(opts);
 }
 
@@ -224,26 +225,18 @@ TEST_F(PluginFixture, DesiredFrameIds) {
   EXPECT_FALSE(plugin_.getDesiredTwistFrameId().empty());
 }
 
-TEST_F(PluginFixture, SetModeRejectedBeforeParameters) {
-  EXPECT_FALSE(plugin_.setMode(test_config::modeIn(), test_config::modeOut()));
-}
-
 TEST_F(PluginFixture, UpdateParamsApplyAll) {
   ASSERT_FALSE(nodeParametersAsVector(node_.get()).empty());
-  applyAllParams(plugin_, node_.get());
-  EXPECT_TRUE(plugin_.essentialParamsReady());
+  EXPECT_NO_THROW(applyAllParams(plugin_, node_.get()));
 }
 
 TEST_F(PluginFixture, UpdateParamsRejectsBadDim) {
   if (std::string(test_config::kBadDimParamName).empty()) {
     GTEST_SKIP() << "Plugin does not validate vector parameter dimensions";
   }
-  // Configure once with the YAML defaults so the latch is set.
   applyAllParams(plugin_, node_.get());
-  ASSERT_TRUE(plugin_.essentialParamsReady());
 
-  // Overwrite the parameter with a wrong-size vector and re-dispatch; the
-  // plugin re-reads from the node inside setParameters() and throws there.
+  // Overwrite the parameter with a wrong-size vector and re-dispatch.
   rclcpp::Parameter bad(test_config::kBadDimParamName, test_config::badDimValue());
   node_->set_parameter(bad);
   EXPECT_THROW(
@@ -253,19 +246,12 @@ TEST_F(PluginFixture, UpdateParamsRejectsBadDim) {
 
 TEST_F(PluginFixture, SetModeValidCombo) {
   applyAllParams(plugin_, node_.get());
-  ASSERT_TRUE(plugin_.essentialParamsReady());
   EXPECT_TRUE(plugin_.setMode(test_config::modeIn(), test_config::modeOut()));
 }
 
-TEST_F(PluginFixture, ResetPreservesEssentialParamsLatch) {
+TEST_F(PluginFixture, ResetKeepsModeSettable) {
   applyAllParams(plugin_, node_.get());
-  ASSERT_TRUE(plugin_.essentialParamsReady());
-
   plugin_.reset();
-
-  // essential_params_ready_ is a monotonic latch: once parameters have been
-  // received, reset() must keep it true so subsequent setMode calls are
-  // accepted (parameters are read once at startup, not re-fed after reset).
   EXPECT_TRUE(plugin_.setMode(test_config::modeIn(), test_config::modeOut()));
 }
 

--- a/as2_motion_controller/plugins/pid_speed_controller/CMakeLists.txt
+++ b/as2_motion_controller/plugins/pid_speed_controller/CMakeLists.txt
@@ -30,43 +30,11 @@ foreach(DEPENDENCY ${PLUGIN_DEPENDENCIES})
   find_package(${DEPENDENCY} REQUIRED)
 endforeach()
 
-# pid_controller: prefer system → local clone → FetchContent.
-# The local clone lives in plugins/pid_speed_controller/thirdparties/pid_controller/
-# so it is fetched only the first time and reused on subsequent builds. The
-# thirdparties/ directory carries an AMENT_IGNORE so colcon never indexes it
-# as a ROS package and the ament file-walking linters skip the vendored sources.
-set(_THIRDPARTIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties)
-file(MAKE_DIRECTORY ${_THIRDPARTIES_DIR})
-file(WRITE ${_THIRDPARTIES_DIR}/AMENT_IGNORE "")
-
-find_package(pid_controller QUIET)
-if(${pid_controller_FOUND})
-  message(STATUS "pid_controller found system-wide")
-else()
-  set(LOCAL_PID_SRC ${_THIRDPARTIES_DIR}/pid_controller)
-  if(EXISTS ${LOCAL_PID_SRC}/CMakeLists.txt)
-    message(STATUS "pid_controller: using local clone at ${LOCAL_PID_SRC}")
-    add_subdirectory(${LOCAL_PID_SRC} ${CMAKE_BINARY_DIR}/pid_controller_build)
-  else()
-    message(STATUS "pid_controller: cloning into ${LOCAL_PID_SRC}")
-    include(FetchContent)
-    fetchcontent_declare(
-      pid_controller
-      GIT_REPOSITORY https://github.com/RPS98/pid_controller.git
-      GIT_TAG v1.0
-      SOURCE_DIR ${LOCAL_PID_SRC}
-    )
-    fetchcontent_makeavailable(pid_controller)
-  endif()
-endif()
-
 include_directories(
   include
   include/${PLUGIN_NAME}
   ${EIGEN3_INCLUDE_DIRS}
-
-  # pid_controller headers (vendored under thirdparties/)
-  ${_THIRDPARTIES_DIR}/pid_controller/include
+  ${PID_CONTROLLER_INCLUDE_DIR}
 )
 
 set(SOURCE_CPP_FILES

--- a/as2_motion_controller/plugins/pid_speed_controller/config/available_modes.yaml
+++ b/as2_motion_controller/plugins/pid_speed_controller/config/available_modes.yaml
@@ -23,7 +23,6 @@
 #-----------------------------------------------------------------
 
 input_control_modes:
-  - 0b00000000 # UNSET
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
@@ -37,7 +36,6 @@ input_control_modes:
   - 0b01110100 # TRAJECTORY with yaw SPEED
 
 output_control_modes:
-  - 0b00000000 # UNSET
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)

--- a/as2_motion_controller/plugins/pid_speed_controller/config/available_modes.yaml
+++ b/as2_motion_controller/plugins/pid_speed_controller/config/available_modes.yaml
@@ -24,7 +24,6 @@
 
 input_control_modes:
   - 0b00000000 # UNSET
-  - 0b00010000 # HOVER
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
@@ -39,7 +38,6 @@ input_control_modes:
 
 output_control_modes:
   - 0b00000000 # UNSET
-  # - 0b00010000 # HOVER
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
   # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)

--- a/as2_motion_controller/plugins/pid_speed_controller/config/controller_default.yaml
+++ b/as2_motion_controller/plugins/pid_speed_controller/config/controller_default.yaml
@@ -82,4 +82,4 @@
         kd: 0.0
         ki: 0.0
       debug:
-        desired_velocity_topic: "debug/controller/desired_velocity"
+        desired_velocity_topic: "desired_velocity"

--- a/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
@@ -78,22 +78,6 @@ struct UAV_command
 };
 
 /**
- * @brief Per-mode readiness for the optional gain groups.
- *
- * The base already gates the essential groups (plugin / position_control /
- * yaw_control) via essentialParamsReady(); these flags add the per-mode
- * gating that the base does not know about (TRAJECTORY needs
- * trajectory_control gains; SPEED / SPEED_IN_A_PLANE need speed_control
- * gains when !use_bypass_).
- */
-struct ModeParametersRead
-{
-  bool velocity = false;
-  bool speed_in_a_plane = false;
-  bool trajectory = false;
-};
-
-/**
  * @brief PID-based speed controller plugin.
  */
 class Plugin : public as2_motion_controller_plugin_base::ControllerBase
@@ -222,11 +206,6 @@ public:
     as2_msgs::msg::Thrust & thrust) override;
 
 private:
-  as2_msgs::msg::ControlMode control_mode_in_;
-  as2_msgs::msg::ControlMode control_mode_out_;
-
-  ModeParametersRead params_read_;
-
   PID_1D pid_yaw_handler_;
   PID pid_3D_position_handler_;
   PID pid_3D_velocity_handler_;
@@ -276,14 +255,6 @@ private:
     "yaw_control.ki",
     "yaw_control.kd"};
 
-  // Mutable copies of the optional-group tails. Decremented as parameters
-  // arrive in updateParameter(); when a list empties, the corresponding
-  // params_read_ flag flips and gates setMode for that mode. The essential
-  // groups (plugin / position / yaw) are tracked by the base.
-  std::vector<std::string> velocity_control_parameters_to_read_;
-  std::vector<std::string> speed_in_a_plane_control_parameters_to_read_;
-  std::vector<std::string> trajectory_control_parameters_to_read_;
-
   UAV_state uav_state_;
   UAV_state control_ref_;
   UAV_command control_command_;
@@ -305,25 +276,13 @@ private:
 
 private:
   /**
-   * @brief Mark a parameter as read inside an optional-group tail list.
-   *
-   * @param param Parameter name (already namespaced) to remove.
-   * @param _params_list In/out tail list still pending; entries are erased on hit.
-   * @param _all_params_read Out: flipped to true once `_params_list` is empty.
-   */
-  void checkParamList(
-    const std::string & param,
-    std::vector<std::string> & _params_list,
-    bool & _all_params_read);
-
-  /**
    * @brief Apply a parameter change to a 1-D PID handler.
    *
    * @param _pid_handler PID handler to configure.
    * @param _parameter_name Tail name of the parameter (without plugin namespace).
    * @param _param New parameter value.
    */
-  void updateControllerParameter(
+  bool updateControllerParameter(
     PID_1D & _pid_handler,
     const std::string & _parameter_name,
     const rclcpp::Parameter & _param);
@@ -335,7 +294,7 @@ private:
    * @param _parameter_name Tail name of the parameter (without plugin namespace).
    * @param _param New parameter value.
    */
-  void updateController3DParameter(
+  bool updateController3DParameter(
     PID & _pid_handler,
     const std::string & _parameter_name,
     const rclcpp::Parameter & _param);
@@ -348,7 +307,7 @@ private:
    * @param _parameter_name Tail name of the parameter (without plugin namespace).
    * @param _param New parameter value.
    */
-  void updateSpeedInAPlaneParameter(
+  bool updateSpeedInAPlaneParameter(
     PID_1D & _pid_1d_handler,
     PID & _pid_3d_handler,
     const std::string & _parameter_name,

--- a/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/include/pid_speed_controller/pid_speed_controller.hpp
@@ -95,53 +95,50 @@ public:
   void ownInitialize() override;
 
   /**
-   * @brief Names of the parameters required before the plugin can accept setMode.
+   * @brief Control mode the plugin runs to hold its position.
    *
-   * Returns the fully-namespaced names of the essential PID gain groups
-   * (plugin / position_control / yaw_control). Optional groups are tracked
-   * separately via params_read_.
-   *
-   * @return Vector of fully-qualified essential parameter names.
+   * @return POSITION when the position loop is usable, SPEED when only the
+   *         speed loop is, UNSET when neither can hold.
    */
-  std::vector<std::string> getEssentialParameters() const override;
+  as2_msgs::msg::ControlMode hoverMode() const override;
 
   /**
-   * @brief Apply a single parameter to the plugin.
+   * @brief Apply one parameter of the plugin to the controller.
    *
-   * Routes the value to the corresponding PID handler and toggles the
-   * plugin-side flags (use_bypass_, proportional_limitation_). Tracks the
-   * optional gain groups in params_read_ so setMode can refuse modes whose
-   * gains have not been delivered yet.
-   *
-   * @param parameter Parameter to apply.
+   * @param name Parameter name, without the plugin namespace.
+   * @param param Parameter as delivered.
    */
-  void updateParameter(const rclcpp::Parameter & parameter) override;
+  void updateParameter(
+    const std::string & name,
+    const rclcpp::Parameter & param) override;
+
+  /**
+   * @brief Names of the parameters the plugin needs before it can control.
+   *
+   * @return Parameter names, without the plugin namespace.
+   */
+  std::vector<std::string> requiredParameters() const override;
 
   /**
    * @brief Reset the cached state, references and commands.
    *
-   * Calls ControllerBase::reset() to clear the base flags. The
-   * essentialParamsReady() latch is intentionally preserved.
+   * Calls ControllerBase::reset() to clear the base flags.
    */
   void reset() override;
 
   /**
-   * @brief Update the control mode to be used by the controller plugin.
+   * @brief Accept a control mode pair and pick the output frame.
    *
-   * Validates that the requested mode is supported by the active gain
-   * groups, configures the output twist frame id, and resets the integrators
-   * of the affected PID handlers.
-   *
-   * @param mode_in Input control mode requested.
+   * @param mode_in Input control mode, already resolved.
    * @param mode_out Output control mode requested.
-   * @return true if the in-out control mode configuration is valid.
+   * @return true if the plugin can serve the pair.
    */
-  bool setMode(
+  bool onSetMode(
     const as2_msgs::msg::ControlMode & mode_in,
     const as2_msgs::msg::ControlMode & mode_out) override;
 
   /**
-   * @brief Plugin hook called by the base after frame validation and hover latch.
+   * @brief Plugin hook called by the base after frame validation.
    *
    * Caches the position, velocity and yaw used by the PID handlers.
    *
@@ -172,20 +169,6 @@ public:
    * @param ref Latest trajectory reference message.
    */
   void onUpdateReference(const as2_msgs::msg::TrajectorySetpoints & ref) override;
-
-  /**
-   * @brief Hover latch override.
-   *
-   * Synthesizes the reference directly into control_ref_ (zero velocity at
-   * the cached pose) because onUpdateReference(TrajectorySetpoints) is gated
-   * to TRAJECTORY mode and would reject the default base-class latch.
-   *
-   * @param pose Cached state pose used as the hover anchor.
-   * @param twist Cached state twist (unused).
-   */
-  void latchHoverReference(
-    const geometry_msgs::msg::PoseStamped & pose,
-    const geometry_msgs::msg::TwistStamped & twist) override;
 
   /**
    * @brief Compute the output signal of the controller plugin.

--- a/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
@@ -60,90 +60,76 @@ void Plugin::ownInitialize()
   // picks something else for body frame velocity modes.
   output_twist_frame_id_ = getDesiredPoseFrameId();
 
-  // Mutable copies of the optional-group parameter tail lists. The essential
-  // groups (plugin / position / yaw) are tracked by the base via
-  // pending_essentials_.
-  velocity_control_parameters_to_read_ = velocity_control_parameters_tail_;
-  speed_in_a_plane_control_parameters_to_read_ = speed_in_a_plane_control_parameters_tail_;
-  trajectory_control_parameters_to_read_ = trajectory_control_parameters_tail_;
-
-  const std::string desired_velocity_topic =
-    getNodePtr()->getParameter<std::string>(param("debug.desired_velocity_topic"), "");
-  if (!desired_velocity_topic.empty()) {
-    debug_desired_velocity_pub_ =
-      getNodePtr()->create_publisher<geometry_msgs::msg::TwistStamped>(
-      desired_velocity_topic, rclcpp::SensorDataQoS());
-  }
+  debug_desired_velocity_pub_ =
+    createDebugPublisher<geometry_msgs::msg::TwistStamped>("debug.desired_velocity_topic");
 
   reset();
 }
 
-std::vector<std::string> Plugin::getEssentialParameters() const
+std::vector<std::string> Plugin::requiredParameters() const
 {
-  // Only the always-active controllers (plugin globals, position and yaw) are
-  // returned as essential. Mode-specific groups (trajectory / velocity /
-  // speed_in_a_plane) are gated separately at setMode time using their own
-  // params_read_ flags.
-  std::vector<std::string> out;
-  out.reserve(
-    plugin_parameters_tail_.size() +
-    position_control_parameters_tail_.size() +
-    yaw_control_parameters_tail_.size());
-  for (const auto & tail : plugin_parameters_tail_) {
-    out.push_back(param(tail));
+  std::vector<std::string> required = plugin_parameters_tail_;
+  for (const auto * group : {&position_control_parameters_tail_,
+      &velocity_control_parameters_tail_,
+      &speed_in_a_plane_control_parameters_tail_,
+      &trajectory_control_parameters_tail_,
+      &yaw_control_parameters_tail_})
+  {
+    required.insert(required.end(), group->begin(), group->end());
   }
-  for (const auto & tail : position_control_parameters_tail_) {
-    out.push_back(param(tail));
-  }
-  for (const auto & tail : yaw_control_parameters_tail_) {
-    out.push_back(param(tail));
-  }
-  return out;
+  return required;
 }
 
-void Plugin::updateParameter(const rclcpp::Parameter & parameter)
+as2_msgs::msg::ControlMode Plugin::hoverMode() const
 {
-  const std::string ns_prefix = getPluginParamNamespace().empty() ?
-    std::string() :
-    getPluginParamNamespace() + ".";
-  const std::string & full_name = parameter.get_name();
-  const std::string tail = ns_prefix.empty() ? full_name :
-    full_name.substr(ns_prefix.size());
+  as2_msgs::msg::ControlMode mode;
+  mode.yaw_mode = as2_msgs::msg::ControlMode::YAW_ANGLE;
+  mode.control_mode = as2_msgs::msg::ControlMode::UNSET;
 
-  RCLCPP_DEBUG(getNodePtr()->get_logger(), "Updating parameter %s", full_name.c_str());
+  if (!usableGains(pid_yaw_handler_)) {
+    return mode;
+  }
+  if (usableGains(pid_3D_position_handler_)) {
+    mode.control_mode = as2_msgs::msg::ControlMode::POSITION;
+  } else if (use_bypass_ || usableGains(pid_3D_velocity_handler_)) {
+    // Without a position loop the hold only drives the speed to zero, so the
+    // drift is not corrected.
+    mode.control_mode = as2_msgs::msg::ControlMode::SPEED;
+  }
+  return mode;
+}
 
-  if (tail == "proportional_limitation") {
-    proportional_limitation_ = parameter.get_value<bool>();
-  } else if (tail == "use_bypass") {
-    use_bypass_ = parameter.get_value<bool>();
-  } else {
-    const auto dot = tail.find('.');
-    if (dot == std::string::npos) {return;}
-    const std::string controller = tail.substr(0, dot);
-    const std::string param_subname = tail.substr(dot + 1);
-    if (controller == "position_control") {
-      updateController3DParameter(pid_3D_position_handler_, param_subname, parameter);
-    } else if (controller == "speed_control") {
-      updateController3DParameter(pid_3D_velocity_handler_, param_subname, parameter);
-      if (!params_read_.velocity) {
-        checkParamList(tail, velocity_control_parameters_to_read_, params_read_.velocity);
-      }
-    } else if (controller == "speed_in_a_plane_control") {
-      updateSpeedInAPlaneParameter(
-        pid_1D_speed_in_a_plane_handler_,
-        pid_3D_speed_in_a_plane_handler_, param_subname, parameter);
-      if (!params_read_.speed_in_a_plane) {
-        checkParamList(
-          tail, speed_in_a_plane_control_parameters_to_read_, params_read_.speed_in_a_plane);
-      }
-    } else if (controller == "trajectory_control") {
-      updateController3DParameter(pid_3D_trajectory_handler_, param_subname, parameter);
-      if (!params_read_.trajectory) {
-        checkParamList(tail, trajectory_control_parameters_to_read_, params_read_.trajectory);
-      }
-    } else if (controller == "yaw_control") {
-      updateControllerParameter(pid_yaw_handler_, param_subname, parameter);
-    }
+void Plugin::updateParameter(const std::string & name, const rclcpp::Parameter & param)
+{
+  if (name == "proportional_limitation") {
+    proportional_limitation_ = param.as_bool();
+    return;
+  }
+  if (name == "use_bypass") {
+    use_bypass_ = param.as_bool();
+    return;
+  }
+
+  const auto dot = name.find('.');
+  const std::string controller = name.substr(0, dot);
+  const std::string subname = dot == std::string::npos ? std::string() : name.substr(dot + 1);
+
+  bool known = false;
+  if (controller == "position_control") {
+    known = updateController3DParameter(pid_3D_position_handler_, subname, param);
+  } else if (controller == "speed_control") {
+    known = updateController3DParameter(pid_3D_velocity_handler_, subname, param);
+  } else if (controller == "speed_in_a_plane_control") {
+    known = updateSpeedInAPlaneParameter(
+      pid_1D_speed_in_a_plane_handler_, pid_3D_speed_in_a_plane_handler_, subname, param);
+  } else if (controller == "trajectory_control") {
+    known = updateController3DParameter(pid_3D_trajectory_handler_, subname, param);
+  } else if (controller == "yaw_control") {
+    known = updateControllerParameter(pid_yaw_handler_, subname, param);
+  }
+
+  if (!known) {
+    RCLCPP_ERROR(getNodePtr()->get_logger(), "Unknown parameter '%s'", name.c_str());
   }
 }
 
@@ -159,43 +145,40 @@ void Plugin::reset()
   pid_3D_trajectory_handler_.reset_controller();
 }
 
-bool Plugin::setMode(
-  const as2_msgs::msg::ControlMode & in_mode,
-  const as2_msgs::msg::ControlMode & out_mode)
+bool Plugin::onSetMode(
+  const as2_msgs::msg::ControlMode & mode_in,
+  const as2_msgs::msg::ControlMode & mode_out)
 {
-  if (!essentialParamsReady()) {
-    RCLCPP_WARN(
-      getNodePtr()->get_logger(),
-      "Essential parameters not read yet, can not set mode");
-    return false;
-  }
+  (void)mode_out;
 
-  if (in_mode.control_mode == as2_msgs::msg::ControlMode::TRAJECTORY &&
-    !params_read_.trajectory)
-  {
-    RCLCPP_WARN(
-      getNodePtr()->get_logger(),
-      "Trajectory controller parameters not read yet, can not set mode to TRAJECTORY");
-    return false;
-  } else if ((in_mode.control_mode == as2_msgs::msg::ControlMode::SPEED ||  // NOLINT
-    in_mode.control_mode == as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE) &&
-    (!params_read_.velocity && !use_bypass_))
-  {
-    RCLCPP_WARN(
-      getNodePtr()->get_logger(),
-      "Velocity controller parameters not read yet and bypass is not used, can not set "
-      "mode to SPEED or SPEED_IN_A_PLANE");
-    return false;
-  }
+  auto refuse = [this](const char * loop) {
+      RCLCPP_ERROR(
+        getNodePtr()->get_logger(),
+        "The %s loop has all its gains at zero, the mode cannot be served", loop);
+      return false;
+    };
 
-  if (in_mode.control_mode == as2_msgs::msg::ControlMode::HOVER) {
-    control_mode_in_.control_mode = in_mode.control_mode;
-    control_mode_in_.yaw_mode = as2_msgs::msg::ControlMode::YAW_ANGLE;
-  } else {
-    control_mode_in_ = in_mode;
-  }
+  if (!usableGains(pid_yaw_handler_)) {return refuse("yaw");}
 
-  control_mode_out_ = out_mode;
+  switch (mode_in.control_mode) {
+    case as2_msgs::msg::ControlMode::POSITION:
+      if (!usableGains(pid_3D_position_handler_)) {return refuse("position");}
+      break;
+    case as2_msgs::msg::ControlMode::SPEED:
+      if (!use_bypass_ && !usableGains(pid_3D_velocity_handler_)) {return refuse("speed");}
+      break;
+    case as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE:
+      if (!usableGains(pid_1D_speed_in_a_plane_handler_)) {
+        return refuse("speed in a plane height");
+      }
+      if (!usableGains(pid_3D_speed_in_a_plane_handler_)) {return refuse("speed in a plane");}
+      break;
+    case as2_msgs::msg::ControlMode::TRAJECTORY:
+      if (!usableGains(pid_3D_trajectory_handler_)) {return refuse("trajectory");}
+      break;
+    default:
+      break;
+  }
 
   // The plugin works, and commands, in the frame the parameter
   // `desired_pose_frame` configures. The platform converts from there.
@@ -282,17 +265,6 @@ void Plugin::onUpdateReference(const as2_msgs::msg::TrajectorySetpoints & traj_s
   control_ref_.yaw.x() = traj_msg.yaw_angle;
 }
 
-void Plugin::latchHoverReference(
-  const geometry_msgs::msg::PoseStamped & pose,
-  const geometry_msgs::msg::TwistStamped & /*twist*/)
-{
-  // PID mode in HOVER expects control_ref_ pre-populated since
-  // onUpdateReference() ignores incoming messages while in HOVER.
-  control_ref_.position = Eigen::Vector3d(
-    pose.pose.position.x, pose.pose.position.y, pose.pose.position.z);
-  control_ref_.velocity = Eigen::Vector3d::Zero();
-  control_ref_.yaw.x() = as2::frame::getYawFromQuaternion(pose.pose.orientation);
-}
 
 bool Plugin::computeOutput(
   double dt,
@@ -307,8 +279,7 @@ bool Plugin::computeOutput(
 
   resetCommands();
 
-  switch (control_mode_in_.control_mode) {
-    case as2_msgs::msg::ControlMode::HOVER:
+  switch (getControlModeIn().control_mode) {
     case as2_msgs::msg::ControlMode::POSITION: {
         Eigen::Vector3d position_error =
           pid_3D_position_handler_.get_error(uav_state_.position, control_ref_.position);
@@ -379,8 +350,7 @@ bool Plugin::computeOutput(
   if (debug_desired_velocity_pub_) {
     geometry_msgs::msg::TwistStamped msg;
     msg.header.stamp = getNodePtr()->now();
-    switch (control_mode_in_.control_mode) {
-      case as2_msgs::msg::ControlMode::HOVER:
+    switch (getControlModeIn().control_mode) {
       case as2_msgs::msg::ControlMode::POSITION: {
           msg.header.frame_id = getDesiredPoseFrameId();
           msg.twist.linear.x = control_command_.velocity.x();

--- a/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/src/pid_speed_controller.cpp
@@ -38,6 +38,20 @@
 namespace pid_speed_controller
 {
 
+// A loop with every gain at zero produces no command, whatever its structure.
+static bool usableGains(const pid_controller::PID<double> & pid)
+{
+  return !(pid.get_gains_kp().isZero() && pid.get_gains_ki().isZero() &&
+         pid.get_gains_kd().isZero());
+}
+
+static bool usableGains(const pid_1d_controller::PID<double> & pid)
+{
+  double kp, ki, kd;
+  pid.get_gains(kp, ki, kd);
+  return kp != 0.0 || ki != 0.0 || kd != 0.0;
+}
+
 void Plugin::ownInitialize()
 {
   speed_limits_ = Eigen::Vector3d::Zero();
@@ -205,18 +219,18 @@ void Plugin::onUpdateState(
 
 void Plugin::onUpdateReference(const geometry_msgs::msg::PoseStamped & pose_msg)
 {
-  if (control_mode_in_.control_mode == as2_msgs::msg::ControlMode::POSITION ||
-    control_mode_in_.control_mode == as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE)
+  if (getControlModeIn().control_mode == as2_msgs::msg::ControlMode::POSITION ||
+    getControlModeIn().control_mode == as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE)
   {
     control_ref_.position = Eigen::Vector3d(
       pose_msg.pose.position.x, pose_msg.pose.position.y,
       pose_msg.pose.position.z);
   }
 
-  if ((control_mode_in_.control_mode == as2_msgs::msg::ControlMode::SPEED ||
-    control_mode_in_.control_mode == as2_msgs::msg::ControlMode::POSITION ||
-    control_mode_in_.control_mode == as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE) &&
-    control_mode_in_.yaw_mode == as2_msgs::msg::ControlMode::YAW_ANGLE)
+  if ((getControlModeIn().control_mode == as2_msgs::msg::ControlMode::SPEED ||
+    getControlModeIn().control_mode == as2_msgs::msg::ControlMode::POSITION ||
+    getControlModeIn().control_mode == as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE) &&
+    getControlModeIn().yaw_mode == as2_msgs::msg::ControlMode::YAW_ANGLE)
   {
     control_ref_.yaw.x() = as2::frame::getYawFromQuaternion(pose_msg.pose.orientation);
   }
@@ -224,7 +238,7 @@ void Plugin::onUpdateReference(const geometry_msgs::msg::PoseStamped & pose_msg)
 
 void Plugin::onUpdateReference(const geometry_msgs::msg::TwistStamped & twist_msg)
 {
-  if (control_mode_in_.control_mode == as2_msgs::msg::ControlMode::POSITION) {
+  if (getControlModeIn().control_mode == as2_msgs::msg::ControlMode::POSITION) {
     speed_limits_ = Eigen::Vector3d(
       twist_msg.twist.linear.x, twist_msg.twist.linear.y,
       twist_msg.twist.linear.z);
@@ -240,8 +254,8 @@ void Plugin::onUpdateReference(const geometry_msgs::msg::TwistStamped & twist_ms
     return;
   }
 
-  if (control_mode_in_.control_mode != as2_msgs::msg::ControlMode::SPEED &&
-    control_mode_in_.control_mode != as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE)
+  if (getControlModeIn().control_mode != as2_msgs::msg::ControlMode::SPEED &&
+    getControlModeIn().control_mode != as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE)
   {
     return;
   }
@@ -249,14 +263,14 @@ void Plugin::onUpdateReference(const geometry_msgs::msg::TwistStamped & twist_ms
   control_ref_.velocity =
     Eigen::Vector3d(twist_msg.twist.linear.x, twist_msg.twist.linear.y, twist_msg.twist.linear.z);
 
-  if (control_mode_in_.yaw_mode == as2_msgs::msg::ControlMode::YAW_SPEED) {
+  if (getControlModeIn().yaw_mode == as2_msgs::msg::ControlMode::YAW_SPEED) {
     control_ref_.yaw.y() = twist_msg.twist.angular.z;
   }
 }
 
 void Plugin::onUpdateReference(const as2_msgs::msg::TrajectorySetpoints & traj_setpoints_msg)
 {
-  if (control_mode_in_.control_mode != as2_msgs::msg::ControlMode::TRAJECTORY) {
+  if (getControlModeIn().control_mode != as2_msgs::msg::ControlMode::TRAJECTORY) {
     return;
   }
 
@@ -345,7 +359,7 @@ bool Plugin::computeOutput(
       }
   }
 
-  switch (control_mode_in_.yaw_mode) {
+  switch (getControlModeIn().yaw_mode) {
     case as2_msgs::msg::ControlMode::YAW_ANGLE: {
         double yaw_error = as2::frame::angleMinError(control_ref_.yaw.x(), uav_state_.yaw.x());
         control_command_.yaw_speed = pid_yaw_handler_.compute_control(dt, yaw_error);
@@ -401,21 +415,8 @@ bool Plugin::computeOutput(
 
 // ===== Internal helpers =====================================================
 
-void Plugin::checkParamList(
-  const std::string & param_name,
-  std::vector<std::string> & params_list,
-  bool & all_params_read)
-{
-  auto it = std::find(params_list.begin(), params_list.end(), param_name);
-  if (it != params_list.end()) {
-    params_list.erase(it);
-  }
-  if (params_list.empty()) {
-    all_params_read = true;
-  }
-}
 
-void Plugin::updateControllerParameter(
+bool Plugin::updateControllerParameter(
   PID_1D & _pid_handler,
   const std::string & _parameter_name,
   const rclcpp::Parameter & _param)
@@ -438,10 +439,13 @@ void Plugin::updateControllerParameter(
     double kp, ki, kd;
     _pid_handler.get_gains(kp, ki, kd);
     _pid_handler.set_gains(kp, ki, _param.get_value<double>());
+  } else {
+    return false;
   }
+  return true;
 }
 
-void Plugin::updateController3DParameter(
+bool Plugin::updateController3DParameter(
   PID & _pid_handler,
   const std::string & _parameter_name,
   const rclcpp::Parameter & _param)
@@ -490,10 +494,13 @@ void Plugin::updateController3DParameter(
     Eigen::Vector3d current_gains = _pid_handler.get_gains_kd();
     current_gains.z() = _param.get_value<double>();
     _pid_handler.set_gains_kd(current_gains);
+  } else {
+    return false;
   }
+  return true;
 }
 
-void Plugin::updateSpeedInAPlaneParameter(
+bool Plugin::updateSpeedInAPlaneParameter(
   PID_1D & _pid_1d_handler,
   PID & _pid_3d_handler,
   const std::string & _parameter_name,
@@ -546,7 +553,10 @@ void Plugin::updateSpeedInAPlaneParameter(
     Eigen::Vector3d current_gains = _pid_3d_handler.get_gains_kd();
     current_gains.y() = _param.get_value<double>();
     _pid_3d_handler.set_gains_kd(current_gains);
+  } else {
+    return false;
   }
+  return true;
 }
 
 void Plugin::resetState() {uav_state_ = UAV_state();}

--- a/as2_motion_controller/plugins/pid_speed_controller/tests/pid_speed_controller_gtest.cpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/tests/pid_speed_controller_gtest.cpp
@@ -119,6 +119,8 @@ getControllerManagerNode()
   };
   rclcpp::NodeOptions opts;
   opts.arguments(node_args);
+  // Same as ControllerManager: the configuration files define the parameter set.
+  opts.automatically_declare_parameters_from_overrides(true);
   return std::make_shared<controller_manager::ControllerManager>(opts);
 }
 
@@ -132,6 +134,7 @@ buildPluginHostNode()
   };
   rclcpp::NodeOptions opts;
   opts.arguments(node_args);
+  // Same as ControllerManager: the configuration files define the parameter set.
   opts.automatically_declare_parameters_from_overrides(true);
   return std::make_shared<as2::Node>(test_config::kFixtureNodeName, opts);
 }
@@ -154,6 +157,23 @@ void applyAllParams(
   rclcpp::Node * node)
 {
   plugin.dispatchParameters(nodeParametersAsVector(node));
+}
+
+// The shipped defaults declare every gain as zero, so a test that needs the
+// plugin to accept a mode gives the loops it uses a usable gain first.
+void applyUsableGains(
+  as2_motion_controller_plugin_base::ControllerBase & plugin,
+  const std::string & ns)
+{
+  const std::vector<std::string> gains = {
+    "yaw_control.kp",
+    "position_control.kp.x", "position_control.kp.y", "position_control.kp.z"};
+  std::vector<rclcpp::Parameter> params;
+  params.reserve(gains.size());
+  for (const auto & gain : gains) {
+    params.emplace_back(ns + "." + gain, 1.0);
+  }
+  plugin.dispatchParameters(params);
 }
 
 geometry_msgs::msg::PoseStamped makePose(
@@ -226,7 +246,7 @@ TEST_F(PluginFixture, DesiredFrameIds) {
 
 TEST_F(PluginFixture, DesiredTwistFrameMatchesThePoseFrame) {
   applyAllParams(plugin_, node_.get());
-  ASSERT_TRUE(plugin_.essentialParamsReady());
+  applyUsableGains(plugin_, test_config::kPluginNamespace);
 
   // The plugin always works in its own frame, whatever the output mode is:
   // it is the platform that converts the commands to the frame it wants
@@ -234,26 +254,18 @@ TEST_F(PluginFixture, DesiredTwistFrameMatchesThePoseFrame) {
   EXPECT_EQ(plugin_.getDesiredTwistFrameId(), plugin_.getDesiredPoseFrameId());
 }
 
-TEST_F(PluginFixture, SetModeRejectedBeforeParameters) {
-  EXPECT_FALSE(plugin_.setMode(test_config::modeIn(), test_config::modeOut()));
-}
-
 TEST_F(PluginFixture, UpdateParamsApplyAll) {
   ASSERT_FALSE(nodeParametersAsVector(node_.get()).empty());
-  applyAllParams(plugin_, node_.get());
-  EXPECT_TRUE(plugin_.essentialParamsReady());
+  EXPECT_NO_THROW(applyAllParams(plugin_, node_.get()));
 }
 
 TEST_F(PluginFixture, UpdateParamsRejectsBadDim) {
   if (std::string(test_config::kBadDimParamName).empty()) {
     GTEST_SKIP() << "Plugin does not validate vector parameter dimensions";
   }
-  // Configure once with the YAML defaults so the latch is set.
   applyAllParams(plugin_, node_.get());
-  ASSERT_TRUE(plugin_.essentialParamsReady());
 
-  // Overwrite the parameter with a wrong-size vector and re-dispatch; the
-  // plugin re-reads from the node inside setParameters() and throws there.
+  // Overwrite the parameter with a wrong-size vector and re-dispatch.
   rclcpp::Parameter bad(test_config::kBadDimParamName, test_config::badDimValue());
   node_->set_parameter(bad);
   EXPECT_THROW(

--- a/as2_motion_controller/plugins/pid_speed_controller/tests/pid_speed_controller_gtest.cpp
+++ b/as2_motion_controller/plugins/pid_speed_controller/tests/pid_speed_controller_gtest.cpp
@@ -273,21 +273,52 @@ TEST_F(PluginFixture, UpdateParamsRejectsBadDim) {
     rclcpp::exceptions::InvalidParameterValueException);
 }
 
+TEST_F(PluginFixture, SetModeRefusedWithZeroGains) {
+  applyAllParams(plugin_, node_.get());
+  EXPECT_FALSE(plugin_.setMode(test_config::modeIn(), test_config::modeOut()));
+}
+
 TEST_F(PluginFixture, SetModeValidCombo) {
   applyAllParams(plugin_, node_.get());
-  ASSERT_TRUE(plugin_.essentialParamsReady());
+  applyUsableGains(plugin_, test_config::kPluginNamespace);
   EXPECT_TRUE(plugin_.setMode(test_config::modeIn(), test_config::modeOut()));
 }
 
-TEST_F(PluginFixture, ResetPreservesEssentialParamsLatch) {
+TEST_F(PluginFixture, HoverModeIsUnsetWithoutAnyUsableLoop) {
   applyAllParams(plugin_, node_.get());
-  ASSERT_TRUE(plugin_.essentialParamsReady());
+  EXPECT_EQ(plugin_.hoverMode().control_mode, as2_msgs::msg::ControlMode::UNSET);
+}
 
+TEST_F(PluginFixture, HoverModeUsesThePositionLoopWhenItIsUsable) {
+  applyAllParams(plugin_, node_.get());
+  applyUsableGains(plugin_, test_config::kPluginNamespace);
+
+  const auto mode = plugin_.hoverMode();
+  EXPECT_EQ(mode.control_mode, as2_msgs::msg::ControlMode::POSITION);
+  EXPECT_EQ(mode.yaw_mode, as2_msgs::msg::ControlMode::YAW_ANGLE);
+}
+
+TEST_F(PluginFixture, HoverModeFallsBackToTheSpeedLoop) {
+  applyAllParams(plugin_, node_.get());
+
+  // Without a position loop the plugin still holds by driving the speed to zero
+  const std::string ns = test_config::kPluginNamespace;
+  plugin_.dispatchParameters(
+  {
+    rclcpp::Parameter(ns + ".use_bypass", false),
+    rclcpp::Parameter(ns + ".yaw_control.kp", 1.0),
+    rclcpp::Parameter(ns + ".speed_control.kp.x", 1.0),
+    rclcpp::Parameter(ns + ".speed_control.kp.y", 1.0),
+    rclcpp::Parameter(ns + ".speed_control.kp.z", 1.0),
+  });
+
+  EXPECT_EQ(plugin_.hoverMode().control_mode, as2_msgs::msg::ControlMode::SPEED);
+}
+
+TEST_F(PluginFixture, ResetKeepsModeSettable) {
+  applyAllParams(plugin_, node_.get());
+  applyUsableGains(plugin_, test_config::kPluginNamespace);
   plugin_.reset();
-
-  // essential_params_ready_ is a monotonic latch: once parameters have been
-  // received, reset() must keep it true so subsequent setMode calls are
-  // accepted (parameters are read once at startup, not re-fed after reset).
   EXPECT_TRUE(plugin_.setMode(test_config::modeIn(), test_config::modeOut()));
 }
 

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -66,6 +66,22 @@ static uint8_t findBestMatchWithMask(
   return best_match;
 }
 
+static void warnIfHoverIsDeclared(
+  const std::vector<uint8_t> & modes,
+  const rclcpp::Logger & logger,
+  const char * list)
+{
+  for (const uint8_t mode : modes) {
+    if ((mode & MATCH_MODE) == HOVER_MODE_MASK) {
+      RCLCPP_WARN(
+        logger,
+        "HOVER is declared as a plugin %s control mode and is ignored, remove it from the "
+        "available modes: the plugin names the hover mode with hoverMode() method", list);
+      return;
+    }
+  }
+}
+
 ControllerHandler::ControllerHandler(
   std::shared_ptr<as2_motion_controller_plugin_base::ControllerBase> controller,
   as2::Node * node,
@@ -377,6 +393,7 @@ void ControllerHandler::setControlModeSrvCall(
 
   as2_msgs::msg::ControlMode _control_mode_msg_plugin_in;
   as2_msgs::msg::ControlMode _control_mode_msg_plugin_out;
+  std::vector<std::pair<uint8_t, uint8_t>> mode_pairs;
 
   control_mode_established_ = false;
 
@@ -414,41 +431,72 @@ void ControllerHandler::setControlModeSrvCall(
   if (bypass_controller_) {
     RCLCPP_INFO(node_ptr_->get_logger(), "Bypassing controller");
     _control_mode_plugin_in = UNSET_MODE_MASK;
+    mode_pairs.emplace_back(_control_mode_plugin_in, _control_mode_plugin_out);
   } else {
-    bool success = findSuitableControlModes(_control_mode_plugin_in, _control_mode_plugin_out);
-
-    if (!success) {
+    if (hover_requested) {
+      // The plugin holds position with one of its own modes, so that is what
+      // is negotiated; the hover reference is fed once the mode is set.
+      const as2_msgs::msg::ControlMode hover_mode = controller_ptr_->hoverMode();
+      if (hover_mode.control_mode == as2_msgs::msg::ControlMode::UNSET) {
+        RCLCPP_ERROR(
+          node_ptr_->get_logger(), "The plugin cannot hold position, hover is not available");
+        response->success = false;
+        return;
+      }
+      _control_mode_plugin_in = as2::control_mode::convertAS2ControlModeToUint8t(hover_mode);
+    }
+    mode_pairs = mode_negotiation::findModePairs(
+      _control_mode_plugin_in, preferred_output_mode_, controller_available_modes_in_,
+      controller_available_modes_out_, platform_available_modes_in_);
+    if (mode_pairs.empty()) {
       RCLCPP_ERROR(node_ptr_->get_logger(), "No suitable control mode found");
       response->success = false;
       return;
     }
   }
 
-  // request the out mode to the platform
-  _control_mode_msg_plugin_out =
-    as2::control_mode::convertUint8tToAS2ControlMode(_control_mode_plugin_out);
-  if (!setPlatformControlMode(_control_mode_msg_plugin_out)) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Failed to set platform control mode");
-    response->success = false;
-    return;
-  }
+  // Try every viable pair in preference order: the plugin can refuse one and
+  // still serve the next, so a refusal is only final once all are exhausted.
+  const as2_msgs::msg::ControlMode previous_platform_mode = platform_info_.current_control_mode;
+  bool mode_set = false;
+  bool platform_mode_changed = false;
+  for (const auto & pair : mode_pairs) {
+    _control_mode_plugin_in = pair.first;
+    _control_mode_plugin_out = pair.second;
+    _control_mode_msg_plugin_out =
+      as2::control_mode::convertUint8tToAS2ControlMode(_control_mode_plugin_out);
+    _control_mode_msg_plugin_in =
+      as2::control_mode::convertUint8tToAS2ControlMode(_control_mode_plugin_in);
 
-  // request the input and output modes to the platform
-  _control_mode_msg_plugin_in =
-    as2::control_mode::convertUint8tToAS2ControlMode(_control_mode_plugin_in);
-  if (!controller_ptr_->setMode(_control_mode_msg_plugin_in, _control_mode_msg_plugin_out)) {
+    if (!setPlatformControlMode(_control_mode_msg_plugin_out)) {
+      RCLCPP_ERROR(node_ptr_->get_logger(), "Failed to set platform control mode");
+      continue;
+    }
+    platform_mode_changed = true;
+    if (bypass_controller_ ||
+      controller_ptr_->setMode(_control_mode_msg_plugin_in, _control_mode_msg_plugin_out))
+    {
+      mode_set = true;
+      break;
+    }
     RCLCPP_ERROR(
       node_ptr_->get_logger(), "Failed to set plugin control mode to [%s]",
       as2::control_mode::controlModeToString(_control_mode_msg_plugin_in).c_str());
+  }
 
-    as2_msgs::msg::ControlMode hover_mode =
-      as2::control_mode::convertUint8tToAS2ControlMode(HOVER_MODE_MASK);
+  if (!mode_set) {
+    // No pair worked, so the platform is left as it was before trying.
+    if (platform_mode_changed) {
+      setPlatformControlMode(previous_platform_mode);
+    }
 
-    if (_control_mode_msg_plugin_in.control_mode != hover_mode.control_mode) {
+    // A refused hover has no fallback left, and retrying it would recurse.
+    if (!hover_requested) {
       RCLCPP_WARN(node_ptr_->get_logger(), "Try to set hover mode instead");
 
       auto request_hover = std::make_shared<as2_msgs::srv::SetControlMode::Request>();
-      request_hover->control_mode = hover_mode;
+      request_hover->control_mode =
+        as2::control_mode::convertUint8tToAS2ControlMode(HOVER_MODE_MASK);
 
       setControlModeSrvCall(request_hover, response);
       if (response->success) {
@@ -574,55 +622,48 @@ bool ControllerHandler::setPlatformControlMode(const as2_msgs::msg::ControlMode 
   return false;
 }
 
-bool ControllerHandler::findSuitableOutputControlModeForPlatformInputMode(
-  uint8_t & output_mode,
-  const uint8_t input_mode)
+namespace mode_negotiation
 {
-  //  check if the preferred mode is available
-  if (preferred_output_mode_) {
-    auto match = findBestMatchWithMask(
-      preferred_output_mode_, platform_available_modes_in_,
-      MATCH_MODE_AND_YAW);
-    if (match) {
-      output_mode = match;
-      return true;
-    }
+
+std::vector<uint8_t> findOutputModes(
+  const uint8_t preferred_output_mode,
+  const std::vector<uint8_t> & controller_modes_out,
+  const std::vector<uint8_t> & platform_modes_in)
+{
+  std::vector<uint8_t> output_modes;
+
+  auto append = [&output_modes](const uint8_t mode) {
+      if (mode && std::find(output_modes.begin(), output_modes.end(), mode) == output_modes.end()) {
+        output_modes.push_back(mode);
+      }
+    };
+
+  // The preferred mode is only tried first: the plugin can still refuse it,
+  // and the remaining ones stay available.
+  if (preferred_output_mode) {
+    append(findBestMatchWithMask(preferred_output_mode, platform_modes_in, MATCH_MODE_AND_YAW));
   }
 
-  // if the preferred mode is not available, search for the first common mode
-
-  uint8_t common_mode = 0;
-  bool same_yaw = false;
-
-  for (auto & mode_out : controller_available_modes_out_) {
+  for (const uint8_t mode_out : controller_modes_out) {
     // skip unset modes and hover
     if ((mode_out & MATCH_MODE) == UNSET_MODE_MASK || (mode_out & MATCH_MODE) == HOVER_MODE_MASK) {
       continue;
     }
-    common_mode = findBestMatchWithMask(mode_out, platform_available_modes_in_, MATCH_MODE_AND_YAW);
-    if (common_mode) {
-      break;
-    }
+    append(findBestMatchWithMask(mode_out, platform_modes_in, MATCH_MODE_AND_YAW));
   }
 
-  // check if the common mode exist
-  if (common_mode == 0) {
-    return false;
-  }
-  output_mode = common_mode;
-  return true;
+  return output_modes;
 }
 
-bool ControllerHandler::checkSuitabilityInputMode(uint8_t & input_mode, const uint8_t output_mode)
+bool checkSuitabilityInputMode(
+  uint8_t & input_mode,
+  const uint8_t output_mode,
+  const std::vector<uint8_t> & controller_modes_in)
 {
   // check if input_conversion is in the list of available modes
   bool mode_found = false;
-  for (auto & mode : controller_available_modes_in_) {
-    if ((input_mode & MATCH_MODE) == HOVER_MODE_MASK && (input_mode & MATCH_MODE) == mode) {
-      mode_found = true;
-      return true;
-    } else if (mode == input_mode) {
-      input_mode = mode;
+  for (const uint8_t mode : controller_modes_in) {
+    if (mode == input_mode) {
       mode_found = true;
       break;
     }
@@ -630,7 +671,7 @@ bool ControllerHandler::checkSuitabilityInputMode(uint8_t & input_mode, const ui
 
   // if not match, try to match only control mode and yaw mode
   if (!mode_found) {
-    for (auto & mode : controller_available_modes_in_) {
+    for (const uint8_t mode : controller_modes_in) {
       if (checkMatchWithMask(mode, input_mode, MATCH_MODE_AND_YAW)) {
         input_mode = mode;
         mode_found = true;
@@ -641,32 +682,32 @@ bool ControllerHandler::checkSuitabilityInputMode(uint8_t & input_mode, const ui
 
   // check if the input mode is compatible with the output mode
   if ((input_mode & MATCH_MODE) < (output_mode & MATCH_MODE)) {
-    RCLCPP_ERROR(
-      node_ptr_->get_logger(),
-      "Input control mode has lower level than output control mode");
     return false;
   }
 
   return mode_found;
 }
 
-bool ControllerHandler::findSuitableControlModes(uint8_t & input_mode, uint8_t & output_mode)
+std::vector<std::pair<uint8_t, uint8_t>> findModePairs(
+  const uint8_t input_mode,
+  const uint8_t preferred_output_mode,
+  const std::vector<uint8_t> & controller_modes_in,
+  const std::vector<uint8_t> & controller_modes_out,
+  const std::vector<uint8_t> & platform_modes_in)
 {
-  // check if the input mode is available. Get the best output mode
-  bool success = findSuitableOutputControlModeForPlatformInputMode(output_mode, input_mode);
-  if (!success) {
-    RCLCPP_WARN(node_ptr_->get_logger(), "No suitable output control mode found");
-    return false;
+  std::vector<std::pair<uint8_t, uint8_t>> mode_pairs;
+  for (const uint8_t output_mode :
+    findOutputModes(preferred_output_mode, controller_modes_out, platform_modes_in))
+  {
+    uint8_t candidate_input = input_mode;
+    if (checkSuitabilityInputMode(candidate_input, output_mode, controller_modes_in)) {
+      mode_pairs.emplace_back(candidate_input, output_mode);
+    }
   }
-
-  // Get the best input mode for the output mode
-  success = checkSuitabilityInputMode(input_mode, output_mode);
-  if (!success) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Input control mode is not suitable for this controller");
-    return false;
-  }
-  return success;
+  return mode_pairs;
 }
+
+}  // namespace mode_negotiation
 
 bool ControllerHandler::trySetPlatformHover()
 {

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -34,6 +34,7 @@
  ********************************************************************************************/
 
 #include "as2_motion_controller/controller_handler.hpp"
+#include "as2_motion_controller/param_utils.hpp"
 
 #include <as2_core/utils/tf_utils.hpp>
 
@@ -756,7 +757,8 @@ void ControllerHandler::publishCommand()
 void ControllerHandler::initializeDebugPublishers()
 {
   auto topic = [this](const std::string & name) {
-      return node_ptr_->getParameter<std::string>(name, "");
+      return as2_motion_controller_param_utils::debugTopicName(
+        node_ptr_->getParameter<std::string>(name, ""));
     };
 
   const std::string state_pose_topic = topic("debug.state_pose_topic");
@@ -764,7 +766,6 @@ void ControllerHandler::initializeDebugPublishers()
   const std::string ref_pose_topic = topic("debug.reference_pose_topic");
   const std::string ref_twist_topic = topic("debug.reference_twist_topic");
   const std::string ref_traj_topic = topic("debug.reference_trajectory_topic");
-  const std::string ref_thrust_topic = topic("debug.reference_thrust_topic");
   const std::string compute_output_time_topic = topic("debug.compute_output_time_topic");
 
   const auto qos = rclcpp::SensorDataQoS();
@@ -787,10 +788,6 @@ void ControllerHandler::initializeDebugPublishers()
   if (!ref_traj_topic.empty()) {
     debug_reference_trajectory_pub_ =
       node_ptr_->create_publisher<as2_msgs::msg::TrajectorySetpoints>(ref_traj_topic, qos);
-  }
-  if (!ref_thrust_topic.empty()) {
-    debug_reference_thrust_pub_ =
-      node_ptr_->create_publisher<as2_msgs::msg::Thrust>(ref_thrust_topic, qos);
   }
   if (!compute_output_time_topic.empty()) {
     debug_compute_output_time_pub_ =
@@ -828,11 +825,6 @@ void ControllerHandler::publishDebug(const rclcpp::Time & tick)
     auto msg = ref_traj_;
     msg.header.stamp = tick;
     debug_reference_trajectory_pub_->publish(msg);
-  }
-  if (debug_reference_thrust_pub_ && ref_thrust_acquired_) {
-    auto msg = ref_thrust_;
-    msg.header.stamp = tick;
-    debug_reference_thrust_pub_->publish(msg);
   }
 }
 

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -66,7 +66,7 @@ static uint8_t findBestMatchWithMask(
   return best_match;
 }
 
-static void warnIfHoverIsDeclared(
+static void warnIfIgnoredModeIsDeclared(
   const std::vector<uint8_t> & modes,
   const rclcpp::Logger & logger,
   const char * list)
@@ -77,7 +77,11 @@ static void warnIfHoverIsDeclared(
         logger,
         "HOVER is declared as a plugin %s control mode and is ignored, remove it from the "
         "available modes: the plugin names the hover mode with hoverMode() method", list);
-      return;
+    } else if ((mode & MATCH_MODE) == UNSET_MODE_MASK) {
+      RCLCPP_WARN(
+        logger,
+        "UNSET is declared as a plugin %s control mode and is ignored, remove it from the "
+        "available modes: it names no control law and can feed no platform", list);
     }
   }
 }
@@ -192,7 +196,7 @@ void ControllerHandler::getMode(
 
 void ControllerHandler::setInputControlModesAvailables(const std::vector<uint8_t> & available_modes)
 {
-  warnIfHoverIsDeclared(available_modes, node_ptr_->get_logger(), "input");
+  warnIfIgnoredModeIsDeclared(available_modes, node_ptr_->get_logger(), "input");
   controller_available_modes_in_ = available_modes;
   // sort modes in ascending order
   std::sort(controller_available_modes_in_.begin(), controller_available_modes_in_.end());
@@ -201,7 +205,7 @@ void ControllerHandler::setInputControlModesAvailables(const std::vector<uint8_t
 void ControllerHandler::setOutputControlModesAvailables(
   const std::vector<uint8_t> & available_modes)
 {
-  warnIfHoverIsDeclared(available_modes, node_ptr_->get_logger(), "output");
+  warnIfIgnoredModeIsDeclared(available_modes, node_ptr_->get_logger(), "output");
   controller_available_modes_out_ = available_modes;
   // sort modes in ascending order
   std::sort(controller_available_modes_out_.begin(), controller_available_modes_out_.end());

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -176,6 +176,7 @@ void ControllerHandler::getMode(
 
 void ControllerHandler::setInputControlModesAvailables(const std::vector<uint8_t> & available_modes)
 {
+  warnIfHoverIsDeclared(available_modes, node_ptr_->get_logger(), "input");
   controller_available_modes_in_ = available_modes;
   // sort modes in ascending order
   std::sort(controller_available_modes_in_.begin(), controller_available_modes_in_.end());
@@ -184,6 +185,7 @@ void ControllerHandler::setInputControlModesAvailables(const std::vector<uint8_t
 void ControllerHandler::setOutputControlModesAvailables(
   const std::vector<uint8_t> & available_modes)
 {
+  warnIfHoverIsDeclared(available_modes, node_ptr_->get_logger(), "output");
   controller_available_modes_out_ = available_modes;
   // sort modes in ascending order
   std::sort(controller_available_modes_out_.begin(), controller_available_modes_out_.end());
@@ -218,7 +220,33 @@ void ControllerHandler::stateCallback(
     state_acquired_ = true;
     state_pose_ = pose_msg;
     state_twist_ = twist_msg;
-    if (!bypass_controller_) {controller_ptr_->updateState(state_pose_, state_twist_);}
+    if (!bypass_controller_) {
+      if (hover_pending_) {
+        // A hover is a reference frozen at the current state, fed through the same
+        // hooks as any other so the plugin serves it with its own control law.
+        controller_ptr_->updateReference(state_pose_);
+
+        geometry_msgs::msg::TwistStamped zero_twist;
+        zero_twist.header = state_twist_.header;
+        controller_ptr_->updateReference(zero_twist);
+
+        as2_msgs::msg::TrajectorySetpoints traj;
+        traj.header = state_pose_.header;
+        as2_msgs::msg::TrajectoryPoint point;
+        point.position.x = state_pose_.pose.position.x;
+        point.position.y = state_pose_.pose.position.y;
+        point.position.z = state_pose_.pose.position.z;
+        point.yaw_angle = as2::frame::getYawFromQuaternion(state_pose_.pose.orientation);
+        traj.setpoints.push_back(point);
+        controller_ptr_->updateReference(traj);
+
+        RCLCPP_INFO(
+          node_ptr_->get_logger(), "Hover reference set at [%f, %f, %f]",
+          point.position.x, point.position.y, point.position.z);
+        hover_pending_ = false;
+      }
+      controller_ptr_->updateState(state_pose_, state_twist_);
+    }
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(node_ptr_->get_logger(), "Could not get transform: %s", ex.what());
   }
@@ -360,7 +388,9 @@ void ControllerHandler::setControlModeSrvCall(
 
   // If the input mode is Hover, set desired control mode in to Hover,
   // else, set desired control mode in to the request one
-  if (request->control_mode.control_mode == as2_msgs::msg::ControlMode::HOVER) {
+  const bool hover_requested =
+    request->control_mode.control_mode == as2_msgs::msg::ControlMode::HOVER;
+  if (hover_requested) {
     _control_mode_plugin_in = HOVER_MODE_MASK;
   } else {
     _control_mode_plugin_in =
@@ -459,11 +489,9 @@ void ControllerHandler::setControlModeSrvCall(
 
   reset();
 
-  // After a successful HOVER setup the plugin must produce a hover reference
-  if (!bypass_controller_ &&
-    control_mode_in_.control_mode == as2_msgs::msg::ControlMode::HOVER)
-  {
-    controller_ptr_->requestHoverLatch();
+  if (!bypass_controller_) {
+    controller_ptr_->setHoverEnabled(hover_requested);
+    hover_pending_ = hover_requested;
   }
 
   response->success = true;

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -640,7 +640,7 @@ bool ControllerHandler::checkSuitabilityInputMode(uint8_t & input_mode, const ui
   }
 
   // check if the input mode is compatible with the output mode
-  if ((input_mode & MATCH_MODE) < (output_mode & 0b1111000)) {
+  if ((input_mode & MATCH_MODE) < (output_mode & MATCH_MODE)) {
     RCLCPP_ERROR(
       node_ptr_->get_logger(),
       "Input control mode has lower level than output control mode");

--- a/as2_motion_controller/src/controller_handler.cpp
+++ b/as2_motion_controller/src/controller_handler.cpp
@@ -730,6 +730,9 @@ void ControllerHandler::publishCommand()
       twist_pub_->publish(command_twist_);  // For twist limits
       break;
     case as2_msgs::msg::ControlMode::SPEED:
+      if (control_mode_out_.yaw_mode == as2_msgs::msg::ControlMode::YAW_ANGLE) {
+        pose_pub_->publish(command_pose_);  // Carries the yaw angle
+      }
       twist_pub_->publish(command_twist_);
       break;
     case as2_msgs::msg::ControlMode::SPEED_IN_A_PLANE:
@@ -737,12 +740,13 @@ void ControllerHandler::publishCommand()
       twist_pub_->publish(command_twist_);
       break;
     case as2_msgs::msg::ControlMode::ATTITUDE:
-      command_thrust_.header = command_pose_.header;
       pose_pub_->publish(command_pose_);
+      if (control_mode_out_.yaw_mode == as2_msgs::msg::ControlMode::YAW_SPEED) {
+        twist_pub_->publish(command_twist_);  // Carries the yaw rate
+      }
       thrust_pub_->publish(command_thrust_);
       break;
     case as2_msgs::msg::ControlMode::BODY_RATES:
-      command_thrust_.header = command_pose_.header;
       twist_pub_->publish(command_twist_);
       thrust_pub_->publish(command_thrust_);
       break;

--- a/as2_motion_controller/src/controller_manager.cpp
+++ b/as2_motion_controller/src/controller_manager.cpp
@@ -76,10 +76,7 @@ ControllerManager::ControllerManager(const rclcpp::NodeOptions & options)
     controller_->initialize(this);
     controller_->reset();
 
-    // Dispatch the initial parameter bulk through the plugin. The base owns
-    // the pending-essentials set (populated at the end of initialize()) and
-    // flips the latch + fires onAllParametersRead exactly once when the set
-    // first empties.
+    // Dispatch the initial parameter
     auto parameters = this->list_parameters({}, 0);
     std::vector<rclcpp::Parameter> params;
     params.reserve(parameters.names.size());
@@ -192,7 +189,6 @@ void ControllerManager::modeTimerCallback()
 rclcpp::NodeOptions ControllerManager::get_modified_options(const rclcpp::NodeOptions & options)
 {
   rclcpp::NodeOptions modified_options = options;
-  modified_options.allow_undeclared_parameters(true);
   modified_options.automatically_declare_parameters_from_overrides(true);
   return modified_options;
 }

--- a/as2_motion_controller/src/param_utils.cpp
+++ b/as2_motion_controller/src/param_utils.cpp
@@ -56,6 +56,31 @@ std::vector<double> readDoubleArray(
   return values;
 }
 
+std::vector<double> readDoubleArray(
+  const rclcpp::Parameter & param,
+  std::size_t expected_size)
+{
+  auto values = param.as_double_array();
+  if (expected_size != 0 && values.size() != expected_size) {
+    throw rclcpp::exceptions::InvalidParameterValueException(
+            "Parameter '" + param.get_name() + "' has size " +
+            std::to_string(values.size()) + ", expected " + std::to_string(expected_size));
+  }
+  return values;
+}
+
+Eigen::Vector3d readVector3(as2::Node * node, const std::string & name)
+{
+  const auto a = readArray<3>(node, name);
+  return Eigen::Vector3d(a[0], a[1], a[2]);
+}
+
+Eigen::Vector3d readVector3(const rclcpp::Parameter & param)
+{
+  const auto a = readArray<3>(param);
+  return Eigen::Vector3d(a[0], a[1], a[2]);
+}
+
 bool isNanSentinel(const std::vector<double> & values)
 {
   if (values.empty()) {

--- a/as2_motion_controller/src/param_utils.cpp
+++ b/as2_motion_controller/src/param_utils.cpp
@@ -69,4 +69,13 @@ bool isNanSentinel(const std::vector<double> & values)
   return true;
 }
 
+std::string debugTopicName(const std::string & topic_name)
+{
+  if (topic_name.empty() || topic_name.front() == '/') {
+    return topic_name;
+  }
+  // Relative namespace every debug topic of the controller hangs from.
+  return "debug/controller/" + topic_name;
+}
+
 }  // namespace as2_motion_controller_param_utils

--- a/as2_motion_controller/tests/as2_motion_controller_gtest.cpp
+++ b/as2_motion_controller/tests/as2_motion_controller_gtest.cpp
@@ -133,6 +133,31 @@ TEST(As2MotionControllerGTest, IgnoresUnrelatedYamlNextToAvailableModes) {
   std::filesystem::remove_all(temp_dir);
 }
 
+TEST(As2MotionControllerGTest, WarnsWhenThePluginDeclaresHoverMode) {
+  // Old configuration files list HOVER as a plugin mode; it is ignored now, so
+  // the user has to be told where the hover mode comes from instead.
+  const auto temp_dir = std::filesystem::temp_directory_path() /
+    ("as2_motion_controller_hover_test_" + std::to_string(
+      std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(temp_dir);
+
+  const auto available_modes = temp_dir / "available_modes.yaml";
+  std::ofstream(available_modes) <<
+    "input_control_modes:\n"
+    "  - 0b00010000\n"
+    "  - 0b01100000\n"
+    "output_control_modes:\n"
+    "  - 0b01000100\n";
+
+  testing::internal::CaptureStderr();
+  EXPECT_NO_THROW(getControllerManagerNode("pid_speed_controller", available_modes.string()));
+  const auto logs = testing::internal::GetCapturedStderr();
+
+  EXPECT_NE(logs.find("HOVER is declared as a plugin input control mode"), std::string::npos);
+
+  std::filesystem::remove_all(temp_dir);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/as2_motion_controller/tests/as2_motion_controller_gtest.cpp
+++ b/as2_motion_controller/tests/as2_motion_controller_gtest.cpp
@@ -133,9 +133,9 @@ TEST(As2MotionControllerGTest, IgnoresUnrelatedYamlNextToAvailableModes) {
   std::filesystem::remove_all(temp_dir);
 }
 
-TEST(As2MotionControllerGTest, WarnsWhenThePluginDeclaresHoverMode) {
-  // Old configuration files list HOVER as a plugin mode; it is ignored now, so
-  // the user has to be told where the hover mode comes from instead.
+TEST(As2MotionControllerGTest, WarnsWhenThePluginDeclaresAnIgnoredMode) {
+  // Old configuration files list HOVER and UNSET as plugin modes; neither is
+  // used, so the user has to be told instead of believing they declare one.
   const auto temp_dir = std::filesystem::temp_directory_path() /
     ("as2_motion_controller_hover_test_" + std::to_string(
       std::chrono::steady_clock::now().time_since_epoch().count()));
@@ -144,6 +144,7 @@ TEST(As2MotionControllerGTest, WarnsWhenThePluginDeclaresHoverMode) {
   const auto available_modes = temp_dir / "available_modes.yaml";
   std::ofstream(available_modes) <<
     "input_control_modes:\n"
+    "  - 0b00000000\n"
     "  - 0b00010000\n"
     "  - 0b01100000\n"
     "output_control_modes:\n"
@@ -154,6 +155,7 @@ TEST(As2MotionControllerGTest, WarnsWhenThePluginDeclaresHoverMode) {
   const auto logs = testing::internal::GetCapturedStderr();
 
   EXPECT_NE(logs.find("HOVER is declared as a plugin input control mode"), std::string::npos);
+  EXPECT_NE(logs.find("UNSET is declared as a plugin input control mode"), std::string::npos);
 
   std::filesystem::remove_all(temp_dir);
 }

--- a/as2_motion_controller/tests/find_mode_match_gtest.cpp
+++ b/as2_motion_controller/tests/find_mode_match_gtest.cpp
@@ -33,116 +33,48 @@
  ********************************************************************************************/
 
 #include <gtest/gtest.h>
-#include <iostream>
-#include <stdexcept>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
 
 #include "as2_core/utils/control_mode_utils.hpp"
+#include "as2_motion_controller/controller_handler.hpp"
 #include "as2_msgs/msg/control_mode.hpp"
 
-#define MATCH_ALL 0b11111111
-#define MATCH_MODE 0b11110000
-#define MATCH_MODE_AND_YAW 0b11111100
+namespace
+{
 
-#define UNSET_MODE_MASK 0b00000000
-#define HOVER_MODE_MASK 0b00010000
+using controller_handler::mode_negotiation::checkSuitabilityInputMode;
+using controller_handler::mode_negotiation::findModePairs;
+using controller_handler::mode_negotiation::findOutputModes;
 
-std::vector<uint8_t> controller_available_modes_in_ = {
+// Modes of a plugin that ingests speed, position and trajectory and only
+// commands speed, as the pid_speed_controller does.
+const std::vector<uint8_t> kControllerModesIn = {
   0b00000000, 0b00010000, 0b01000000, 0b01000001, 0b01000100,
   0b01000101, 0b01100001, 0b01100101, 0b01110001, 0b01110101};
 
-// With undefined frame
-std::vector<uint8_t> controller_request_modes_in_ = {0b00000000, 0b00010011, 0b01000011, 0b01000111,
-  0b01100011, 0b01100111, 0b01110111};
+const std::vector<uint8_t> kControllerModesOut = {0b00000000, 0b01000100, 0b01000101};
 
-std::vector<uint8_t> controller_available_modes_out_ = {0b00000000, 0b01000100, 0b01000101};
+// The single output mode this platform ingests.
+const std::vector<uint8_t> kPlatformModesIn = {0b01000100};
 
-std::vector<uint8_t> platform_available_modes_in_ = {0b01000100};
+constexpr uint8_t kNoPreferredMode = 0b00000000;
 
-std::uint8_t preferred_output_mode_ = 0;
-
-bool checkSuitabilityInputMode(uint8_t & input_mode, const uint8_t output_mode)
+std::vector<std::pair<uint8_t, uint8_t>> findModePairsInScenario(const uint8_t input_mode)
 {
-  // check if input_conversion is in the list of available modes
-  bool mode_found = false;
-  // Try to match control mode and yaw mode, the reference frame is settled by
-  // the plugin, not by the requester
-  for (auto & mode : controller_available_modes_in_) {
-    if ((input_mode & MATCH_MODE) == HOVER_MODE_MASK && (input_mode & MATCH_MODE) == mode) {
-      mode_found = true;
-      return true;
-    } else if (as2::control_mode::compareModes(mode, input_mode, MATCH_MODE_AND_YAW)) {
-      input_mode = mode;
-      mode_found = true;
-      break;
-    }
-  }
-
-  // check if the input mode is compatible with the output mode
-  if ((input_mode & MATCH_MODE) < (output_mode & MATCH_MODE)) {
-    return false;
-  }
-
-  return mode_found;
+  return findModePairs(
+    input_mode, kNoPreferredMode, kControllerModesIn, kControllerModesOut, kPlatformModesIn);
 }
 
-bool findSuitableOutputControlModeForPlatformInputMode(
-  uint8_t & output_mode,
-  const uint8_t input_mode)
-{
-  //  check if the preferred mode is available
-  uint8_t match = UNSET_MODE_MASK;
-  if (preferred_output_mode_) {
-    if (as2::control_mode::findBestMatchWithMask(
-        preferred_output_mode_, platform_available_modes_in_, MATCH_MODE_AND_YAW, match))
-    {
-      output_mode = match;
-      return true;
-    }
-  }
-
-  // if the preferred mode is not available, search for the first common mode
-
-  for (auto & mode_out : controller_available_modes_out_) {
-    // skip unset modes and hover
-    if ((mode_out & MATCH_MODE) == UNSET_MODE_MASK || (mode_out & MATCH_MODE) == HOVER_MODE_MASK) {
-      continue;
-    }
-    if (as2::control_mode::findBestMatchWithMask(
-        mode_out, platform_available_modes_in_, MATCH_MODE_AND_YAW, match))
-    {
-      output_mode = match;
-      return true;
-    }
-  }
-
-  // no common mode exists
-  return false;
-}
-
-bool findSuitableControlModes(uint8_t & input_mode, uint8_t & output_mode)
-{
-  // check if the input mode is available. Get the best output mode
-  bool success = findSuitableOutputControlModeForPlatformInputMode(output_mode, input_mode);
-  if (!success) {
-    std::cout << "No suitable output mode found" << std::endl;
-    return false;
-  }
-
-  // Get the best input mode for the output mode
-  success = checkSuitabilityInputMode(input_mode, output_mode);
-  if (!success) {
-    std::cout << "Input control mode is not suitable for this controller" << std::endl;
-    return false;
-  }
-  return success;
-}
+}  // namespace
 
 TEST(FindModeMatchTest, ResolvesRequestsIgnoringTheirFrame)
 {
   // Requests reach the controller with an undefined frame: the mode of the
   // plugin, with its own frame, is the one that must be settled.
   const std::vector<std::pair<uint8_t, uint8_t>> requests_and_modes_in = {
-    {0b00010011, 0b00010011},   // HOVER, kept as requested
     {0b01000011, 0b01000000},   // SPEED yaw ANGLE -> first SPEED yaw ANGLE of the plugin
     {0b01000111, 0b01000100},   // SPEED yaw SPEED
     {0b01100011, 0b01100001},   // POSITION yaw ANGLE
@@ -151,23 +83,20 @@ TEST(FindModeMatchTest, ResolvesRequestsIgnoringTheirFrame)
   };
 
   for (const auto & [request, expected_mode_in] : requests_and_modes_in) {
-    uint8_t input_mode = request;
-    uint8_t output_mode = 0;
-    EXPECT_TRUE(findSuitableControlModes(input_mode, output_mode))
+    const auto mode_pairs = findModePairsInScenario(request);
+    ASSERT_EQ(mode_pairs.size(), 1u)
       << "request " << as2::control_mode::controlModeToString(request);
-    EXPECT_EQ(input_mode, expected_mode_in)
+    EXPECT_EQ(mode_pairs.front().first, expected_mode_in)
       << "request " << as2::control_mode::controlModeToString(request);
     // The only output mode the platform of this scenario supports
-    EXPECT_EQ(output_mode, 0b01000100);
+    EXPECT_EQ(mode_pairs.front().second, 0b01000100);
   }
 }
 
 TEST(FindModeMatchTest, RejectsUnsetInputMode)
 {
   // UNSET is below any output mode, so it cannot feed the platform
-  uint8_t input_mode = 0b00000000;
-  uint8_t output_mode = 0;
-  EXPECT_FALSE(findSuitableControlModes(input_mode, output_mode));
+  EXPECT_TRUE(findModePairsInScenario(0b00000000).empty());
 }
 
 TEST(FindModeMatchTest, RejectsInputModeBelowOutputMode)
@@ -176,7 +105,7 @@ TEST(FindModeMatchTest, RejectsInputModeBelowOutputMode)
   // integrate, not to differentiate
   uint8_t input_mode = 0b00100001;         // BODY_RATES, yaw ANGLE
   const uint8_t output_mode = 0b01000100;  // SPEED, yaw SPEED
-  EXPECT_FALSE(checkSuitabilityInputMode(input_mode, output_mode));
+  EXPECT_FALSE(checkSuitabilityInputMode(input_mode, output_mode, kControllerModesIn));
 }
 
 TEST(FindModeMatchTest, AcceptsSameLevelOutputModeWithoutYaw)
@@ -185,5 +114,65 @@ TEST(FindModeMatchTest, AcceptsSameLevelOutputModeWithoutYaw)
   // that bit into the level comparison and rejected a same level input mode.
   uint8_t input_mode = 0b01000001;         // SPEED, yaw ANGLE
   const uint8_t output_mode = 0b01001000;  // SPEED, yaw NONE
-  EXPECT_TRUE(checkSuitabilityInputMode(input_mode, output_mode));
+  EXPECT_TRUE(checkSuitabilityInputMode(input_mode, output_mode, kControllerModesIn));
+}
+
+TEST(FindModeMatchTest, CollectsEveryCommonOutputModeOnce)
+{
+  // Two plugin output modes resolve to the same platform mode, which must be
+  // offered once: retrying an identical pair cannot change the plugin answer.
+  const std::vector<uint8_t> platform_modes_in = {0b01000100, 0b01100100};
+  const std::vector<uint8_t> controller_modes_out = {0b01000100, 0b01000101, 0b01100100};
+
+  const auto output_modes =
+    findOutputModes(kNoPreferredMode, controller_modes_out, platform_modes_in);
+  EXPECT_EQ(output_modes, std::vector<uint8_t>({0b01000100, 0b01100100}));
+}
+
+TEST(FindModeMatchTest, SkipsUnsetAndHoverOutputModes)
+{
+  // Neither can drive a platform, whatever the platform declares.
+  const std::vector<uint8_t> platform_modes_in = {0b00000000, 0b00010000, 0b01000100};
+  const std::vector<uint8_t> controller_modes_out = {0b00000000, 0b00010000, 0b01000100};
+
+  const auto output_modes =
+    findOutputModes(kNoPreferredMode, controller_modes_out, platform_modes_in);
+  EXPECT_EQ(output_modes, std::vector<uint8_t>({0b01000100}));
+}
+
+TEST(FindModeMatchTest, PreferredOutputModeGoesFirstWithoutHidingTheRest)
+{
+  // The plugin can still refuse the preferred pair, so the others must survive.
+  const std::vector<uint8_t> platform_modes_in = {0b01000100, 0b01100100};
+  const std::vector<uint8_t> controller_modes_out = {0b01000100, 0b01100100};
+
+  const auto output_modes =
+    findOutputModes(0b01100100, controller_modes_out, platform_modes_in);
+  EXPECT_EQ(output_modes, std::vector<uint8_t>({0b01100100, 0b01000100}));
+}
+
+TEST(FindModeMatchTest, PairsEveryCompatibleOutputModeWithItsInputMode)
+{
+  // One pair per output mode, in the order they are to be tried.
+  const std::vector<uint8_t> platform_modes_in = {0b01000100, 0b01100100};
+  const std::vector<uint8_t> controller_modes_out = {0b01000100, 0b01100100};
+
+  const auto mode_pairs = findModePairs(
+    0b01110111, kNoPreferredMode, kControllerModesIn, controller_modes_out, platform_modes_in);
+
+  const std::vector<std::pair<uint8_t, uint8_t>> expected = {
+    {0b01110101, 0b01000100},
+    {0b01110101, 0b01100100},
+  };
+  EXPECT_EQ(mode_pairs, expected);
+}
+
+TEST(FindModeMatchTest, ReturnsNoPairWhenThePlatformSharesNoOutputMode)
+{
+  // An ATTITUDE-only platform cannot be fed by a speed-only plugin.
+  const std::vector<uint8_t> platform_modes_in = {0b00110000};
+
+  const auto mode_pairs = findModePairs(
+    0b01100011, kNoPreferredMode, kControllerModesIn, kControllerModesOut, platform_modes_in);
+  EXPECT_TRUE(mode_pairs.empty());
 }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Multirotor Simulator |

---

## Description of contribution in a few bullet points

* Plugins now implement three parameter hooks. `updateParameter(name, value)` receives
  the name without the plugin namespace and the value as delivered, and applies it;
  reading it back from the node was wrong at runtime, because the parameter callback
  runs before the node commits the new value, so a change was applied against the
  previous one. `requiredParameters()` lists what the plugin needs before it can
  control, and the base refuses a control mode while any of them is missing, naming the
  ones it is waiting for. `initParameters()` lists the ones a plugin can only consume
  while it builds itself: they are delivered before `ownInitialize()`, and a later
  change to one of them is warned about and ignored instead of pretending to apply.
* A parameter name that no plugin claims is reported, so a stale key in a configuration
  file is visible at start-up instead of doing nothing.
* Both in-tree plugins refuse a mode whose loop has every gain at zero. The parameters
  are present, so nothing was missing, but the loop produces no command at all.
* Hover stops being a control mode of the plugin. A plugin only names, in `hoverMode()`,
  the mode it holds position with, and UNSET when it cannot hold at all; the handler
  negotiates that mode and feeds a reference frozen at the current state through the
  usual reference hooks. The base no longer synthesises that reference itself, which
  included a thrust of 9.81 N and a normalised 0.5 that belong to no vehicle. HOVER
  stays a real mode at the platform boundary, where a platform offering it natively
  still bypasses the controller, and declaring it as a plugin mode now warns and is
  ignored so an old configuration file says so.
* The mode negotiation tries every compatible input/output pair instead of resolving a
  single one and giving up when the plugin refuses it. The first pair tried is the one
  it resolved before, so the usual path is unchanged. If none works and the platform was
  moved while trying, it is put back in the mode it had.
* Fixed the level check between input and output modes, which masked the output with
  seven bits instead of the mode mask: the yaw NONE bit leaked into the comparison and a
  platform offering an output mode without yaw had every compatible input mode rejected.
* The three matching functions become free functions taking the mode lists as arguments.
  They used to read them from the handler, so the test carried its own copy of the
  algorithm; that copy had drifted, and it is why a test named after the mask bug passed
  while the bug was still in the code.

Depends on #999, which has to be merged first. Until then this branch also carries its
four commits; it will be rebased on main once #999 lands.